### PR TITLE
Modifications to compile on OSX; ccViewer runs; qCC crashes on launch

### DIFF
--- a/CC/triangle/triangle.cpp
+++ b/CC/triangle/triangle.cpp
@@ -329,7 +329,7 @@
 #include <float.h>
 #endif /* CPU86 */
 #ifdef LINUX
-#include <fpu_control.h>
+//#include <fpu_control.h>
 #endif /* LINUX */
 #ifdef TRILIBRARY
 #include "triangle.h"
@@ -4684,7 +4684,7 @@ void exactinit()
   /*  cword = 4735; */
   cword = 4722;                 /* set FPU control word for double precision */
 #endif /* not SINGLE */
-  _FPU_SETCW(cword);
+  //  _FPU_SETCW(cword);
 #endif /* LINUX */
 
   every_other = 1;

--- a/libs/CCFbo/include/ccGlew.h
+++ b/libs/CCFbo/include/ccGlew.h
@@ -27,7 +27,7 @@
 
 //GLEW (must be included first)
 #include <GL/glew.h>
-#include <GL/gl.h>
-#include <GL/glu.h>
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
 
 #endif

--- a/libs/qCC_db/ccIncludeGL.h
+++ b/libs/qCC_db/ccIncludeGL.h
@@ -34,8 +34,8 @@
 #include <QGLWidget>
 #include <QGLFormat>
 
-#include <GL/gl.h>
-#include <GL/glu.h>
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
 
 #ifndef GL_INVALID_TEXTURE_ID
 #define GL_INVALID_TEXTURE_ID 0xffffffff


### PR DESCRIPTION
These changes allow CC to compile on OS X.
ccViewer works just fine.
qCC compiles, but crashes on launch.
