### PR TITLE
nProgress is checked for NULL, so make sure it's initialized

### DIFF
--- a/qCC/plugins/qPCV/PCV/PCV.cpp
+++ b/qCC/plugins/qPCV/PCV/PCV.cpp
@@ -93,7 +93,7 @@ bool PCV::Launch(std::vector<CCVector3>& rays,
 
 	/*** Main illumination loop ***/
 
-	CCLib::NormalizedProgress* nProgress;
+	CCLib::NormalizedProgress* nProgress = NULL;
 	if (progressCb)
 	{
 		nProgress = new CCLib::NormalizedProgress(progressCb,numberOfRays);


### PR DESCRIPTION
If no callback is passed in, nProgress is never initialized...
