### PR TITLE
Use nanosleep as waiter in PoissonRecon process

### DIFF
--- a/qCC/plugins/qPoissonRecon/qPoissonRecon.cpp
+++ b/qCC/plugins/qPoissonRecon/qPoissonRecon.cpp
@@ -35,7 +35,10 @@
 #include <algorithm>
 #if defined(_WIN32) || defined(WIN32)
 #include "Windows.h"
+#else
+#include <time.h>
 #endif
+
 
 qPoissonRecon::qPoissonRecon(QObject* parent/*=0*/)
 	: QObject(parent)
@@ -185,10 +188,11 @@ void qPoissonRecon::doAction()
 		unsigned progress = 0;
 		while (!future.isFinished())
 		{
-		    #if defined(_WIN32) || defined(WIN32)
+			#if defined(_WIN32) || defined(WIN32)
 			::Sleep(500);
 			#else
-			sleep(500);
+			struct timespec waiter = {0, 500000000L};
+			nanosleep(&waiter, NULL);
 			#endif
 
 			progressCb.update(++progress);

--- a/qCC/plugins/qPoissonRecon/qPoissonRecon.h
+++ b/qCC/plugins/qPoissonRecon/qPoissonRecon.h
@@ -23,7 +23,7 @@
 
 #include "../ccStdPluginInterface.h"
 
-//! Wrapper to the "Poisson Surface Reconstruction (Version 2)" algorithm
+//! Wrapper to the "Poisson Surface Reconstruction (Version 3)" algorithm
 /** "Poisson Surface Reconstruction", M. Kazhdan, M. Bolitho, and H. Hoppe
 	Symposium on Geometry Processing (June 2006), pages 61--70
 	http://www.cs.jhu.edu/~misha/Code/PoissonRecon/


### PR DESCRIPTION
This pull request intends to fix same issue than cloudcompare/trunk@f686522a0da7a2bc431ce4b49d4162e2d5a16bb8 but for Poisson Reconstruction plugin. it seems that sleep and usleep are deprecated in favor of nanosleep. See http://man7.org/linux/man-pages/man3/usleep.3.html for further information.
