### PR TITLE
gcc4.7 compatibility, Name lookups in C++ templates add this-> for template method call

### DIFF
--- a/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/Candidate.cpp
+++ b/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/Candidate.cpp
@@ -1,4 +1,5 @@
 #include "Candidate.h"
+#include "unistd.h"
 
 Candidate::Candidate()
 : m_subset(0)

--- a/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/Cone.h
+++ b/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/Cone.h
@@ -10,6 +10,7 @@
 #include <ostream>
 #include <istream>
 #include <stdio.h>
+#include <unistd.h>
 #include <MiscLib/NoShrinkVector.h>
 #include "LevMarLSWeight.h"
 #include "LevMarFitting.h"

--- a/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/AACubeTree.h
+++ b/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/AACubeTree.h
@@ -312,7 +312,7 @@ namespace GfxTL
 			// copying.
 			stack.back().first = BaseType::Root();
 			InitRootBuildInformation(bcube, &stack.back().second);
-			InitRoot(stack.back().second, BaseType::Root());
+			this->InitRoot(stack.back().second, BaseType::Root());
 			BaseType::InitGlobalBuildInformation(*BaseType::Root(), stack.back().second);
 			while(stack.size())
 			{
@@ -323,16 +323,16 @@ namespace GfxTL
 					stack.pop_back();
 					continue;
 				}
-				if(IsLeaf(*p.first))
+				if(this->IsLeaf(*p.first))
 				{
-					if(!ShouldSubdivide(*p.first, p.second))
+					if(!this->ShouldSubdivide(*p.first, p.second))
 					{
 						BaseType::InitLeaf(p.first, p.second);
 						stack.pop_back();
 						continue;
 					}
 					Subdivide(p.second, p.first);
-					if(IsLeaf(*p.first)) // couldn't subdivide?
+					if(this->IsLeaf(*p.first)) // couldn't subdivide?
 					{
 						BaseType::InitLeaf(p.first, p.second);
 						stack.pop_back();
@@ -343,7 +343,7 @@ namespace GfxTL
 				else
 					BaseType::LeaveGlobalBuildInformation(*p.first, p.second);
 				while(p.second.CreateChild() < (1 << DimT) &&
-					!ExistChild(*p.first, p.second.CreateChild()))
+					!this->ExistChild(*p.first, p.second.CreateChild()))
 					++p.second.CreateChild();
 				if(p.second.CreateChild() == (1 << DimT))
 				{
@@ -355,14 +355,14 @@ namespace GfxTL
 				stack.back().first = &(*p.first)[p.second.CreateChild()];
 				InitBuildInformation(*p.first, p.second,
 					p.second.CreateChild(), &stack.back().second);
-				InitCell(*p.first, p.second, p.second.CreateChild(),
+				this->InitCell(*p.first, p.second, p.second.CreateChild(),
 					stack.back().second, &(*p.first)[p.second.CreateChild()]);
 				do
 				{
 					++p.second.CreateChild();
 				}
 				while(p.second.CreateChild() < (1 << DimT) &&
-					!ExistChild(*p.first, p.second.CreateChild()));
+					!this->ExistChild(*p.first, p.second.CreateChild()));
 			}
 		}
 
@@ -417,7 +417,7 @@ namespace GfxTL
 						((1 << BaseType::m_dim) / 8) + (((1 << BaseType::m_dim) % 8)? 1 : 0);
 					char b[byteCount];
 					for(unsigned int i = 0; i < (1 << DimT); ++i)
-						if(ExistChild(*p.first, i))
+						if(this->ExistChild(*p.first, i))
 							b[i >> 3] |= 1 << (i - ((i >> 3) << 3));
 						else
 							b[i >> 3] &= ~(1 << (i - ((i >> 3) << 3)));
@@ -427,7 +427,7 @@ namespace GfxTL
 				else
 					LeaveGlobalBuildInformation(*p.first, p.second);
 				while(p.second.CreateChild() < (1 << DimT) &&
-					!ExistChild(*p.first, p.second.CreateChild()))
+					!this->ExistChild(*p.first, p.second.CreateChild()))
 					++p.second.CreateChild();
 				if(p.second.CreateChild() == (1 << DimT))
 					continue;
@@ -441,7 +441,7 @@ namespace GfxTL
 					++p.second.CreateChild();
 				}
 				while(p.second.CreateChild() < (1 << DimT) &&
-					!ExistChild(*p.first, p.second.CreateChild()));
+					!this->ExistChild(*p.first, p.second.CreateChild()));
 			}
 		}
 
@@ -472,7 +472,7 @@ namespace GfxTL
 						((1 << BaseType::m_dim) / 8) + (((1 << BaseType::m_dim) % 8)? 1 : 0);
 					char b[byteCount];
 					for(unsigned int i = 0; i < (1 << DimT); ++i)
-						if(ExistChild(*p.first, i))
+						if(this->ExistChild(*p.first, i))
 							b[i >> 3] |= 1 << (i - ((i >> 3) << 3));
 						else
 							b[i >> 3] &= ~(1 << (i - ((i >> 3) << 3)));
@@ -480,7 +480,7 @@ namespace GfxTL
 					p.second.Written(true);
 				}
 				while(p.second.CreateChild() < (1 << DimT) &&
-					!ExistChild(*p.first, p.second.CreateChild()))
+					!this->ExistChild(*p.first, p.second.CreateChild()))
 					++p.second.CreateChild();
 				if(p.second.CreateChild() == (1 << DimT))
 					continue;
@@ -493,7 +493,7 @@ namespace GfxTL
 					++p.second.CreateChild();
 				}
 				while(p.second.CreateChild() < (1 << DimT) &&
-					!ExistChild(*p.first, p.second.CreateChild()));
+					!this->ExistChild(*p.first, p.second.CreateChild()));
 			}
 		}
 
@@ -556,7 +556,7 @@ namespace GfxTL
 				else
 					LeaveGlobalBuildInformation(*p.first, p.second);
 				while(p.second.CreateChild() < (1 << DimT) &&
-					!ExistChild(*p.first, p.second.CreateChild()))
+					!this->ExistsChild(*p.first, p.second.CreateChild()))
 					++p.second.CreateChild();
 				if(p.second.CreateChild() == (1 << DimT))
 					continue;
@@ -572,7 +572,7 @@ namespace GfxTL
 					++p.second.CreateChild();
 				}
 				while(p.second.CreateChild() < (1 << DimT) &&
-					!ExistChild(*p.first, p.second.CreateChild()));
+					!this->ExistsChild(*p.first, p.second.CreateChild()));
 			}
 		}
 
@@ -632,7 +632,7 @@ namespace GfxTL
 					}
 				}
 				while(p.second.CreateChild() < (1 << DimT) &&
-					!ExistChild(*p.first, p.second.CreateChild()))
+					!this->ExistChild(*p.first, p.second.CreateChild()))
 					++p.second.CreateChild();
 				if(p.second.CreateChild() == (1 << DimT))
 					continue;
@@ -647,7 +647,7 @@ namespace GfxTL
 					++p.second.CreateChild();
 				}
 				while(p.second.CreateChild() < (1 << DimT) &&
-					!ExistChild(*p.first, p.second.CreateChild()));
+					!this->ExistChild(*p.first, p.second.CreateChild()));
 			}
 		}
 
@@ -772,7 +772,7 @@ namespace GfxTL
 			char b[byteCount];
 			// create missing cells
 			for(unsigned int i = 0; i < (1 << DimT); ++i)
-				if(!ExistChild(*cell, i))
+				if(!this->ExistChild(*cell, i))
 				{
 					cell->Child(i, new CellType);
 					b[i >> 3] |= 1 << (i - ((i >> 3) << 3));
@@ -808,14 +808,14 @@ namespace GfxTL
 			size_t maxLevel, size_t minSize, const CellType &cell,
 			const TraversalInformationT &ti, CellRange *range) const
 		{
-			if(IsLeaf(cell))
+			if(this->IsLeaf(cell))
 			{
-				GetCellRange(cell, ti, range);
+				this->GetCellRange(cell, ti, range);
 				return &cell;
 			}
-			if(CellLevel(cell, ti) == maxLevel)
+			if(this->CellLevel(cell, ti) == maxLevel)
 			{
-				GetCellRange(cell, ti, range);
+				this->GetCellRange(cell, ti, range);
 				return &cell;
 			}
 			// find the child containing the point
@@ -827,7 +827,7 @@ namespace GfxTL
 				if(point[i] > cell.Center()[i])//center[i])
 					childIdx |= 1 << (DimT - i - 1);
 			}
-			if(ExistChild(cell, childIdx)
+			if(this->ExistChild(cell, childIdx)
 				&& cell[childIdx].Size() >= minSize)
 			{
 				TraversalInformationT cti;
@@ -835,7 +835,7 @@ namespace GfxTL
 				return NodeContainingPoint(point, maxLevel, minSize,
 					cell[childIdx], cti, range);
 			}
-			GetCellRange(cell, ti, range);
+			this->GetCellRange(cell, ti, range);
 			return &cell;
 		}
 	};

--- a/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/BBoxBuildInformationTreeStrategy.h
+++ b/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/BBoxBuildInformationTreeStrategy.h
@@ -67,10 +67,10 @@ namespace GfxTL
 					new typename ScalarTypeDeferer< value_type >::ScalarType[BaseType::m_dim];
 				// init the values (box of zero volume)
 				typename BaseType::HandleType i = bi->Range().first;
-				BaseType::AssignAsAABoxMin(at(Dereference(i)), &bi->m_bbox[0]);
-				BaseType::AssignAsAABoxMax(at(Dereference(i)), &bi->m_bbox[1]);
+				BaseType::AssignAsAABoxMin(this->at(this->Dereference(i)), &bi->m_bbox[0]);
+				BaseType::AssignAsAABoxMax(this->at(this->Dereference(i)), &bi->m_bbox[1]);
 				for(++i; i != bi->Range().second; ++i)
-					BaseType::IncludeInAABox(at(Dereference(i)), bi->BBox());
+					BaseType::IncludeInAABox(this->at(this->Dereference(i)), bi->BBox());
 			}
 
 			template< class BuildInformationT >
@@ -95,10 +95,10 @@ namespace GfxTL
 					return;
 				}
 				typename BaseType::HandleType i = bi->Range().first;
-				BaseType::AssignAsAABoxMin(at(Dereference(i)), &bi->m_bbox[0]);
-				BaseType::AssignAsAABoxMax(at(Dereference(i)), &bi->m_bbox[1]);
+				BaseType::AssignAsAABoxMin(this->at(this->Dereference(i)), &bi->m_bbox[0]);
+				BaseType::AssignAsAABoxMax(this->at(this->Dereference(i)), &bi->m_bbox[1]);
 				for(++i; i != bi->Range().second; ++i)
-					BaseType::IncludeInAABox(at(Dereference(i)), bi->BBox());
+					BaseType::IncludeInAABox(this->at(this->Dereference(i)), bi->BBox());
 			}
 		};		
 	};

--- a/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/CellBBoxBuildInformationKdTreeStrategy.h
+++ b/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/CellBBoxBuildInformationKdTreeStrategy.h
@@ -72,10 +72,10 @@ namespace GfxTL
 				m_bbox[1] = new ScalarType[BaseType::m_dim];
 				// init the values (box of zero volume)
 				typename BaseType::HandleType i = bi->Range().first;
-				AssignAsAABoxMin(at(Dereference(i)), &m_bbox[0]);
-				AssignAsAABoxMax(at(Dereference(i)), &m_bbox[1]);
+				this->AssignAsAABoxMin(this->at(this->Dereference(i)), &m_bbox[0]);
+				this->AssignAsAABoxMax(this->at(this->Dereference(i)), &m_bbox[1]);
 				for(++i; i != bi->Range().second; ++i)
-					IncludeInAABox(at(Dereference(i)), m_bbox);
+					this->IncludeInAABox(this->at(this->Dereference(i)), m_bbox);
 				bi->CellBBox(m_bbox);
 			}
 

--- a/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/CellRangeDataTreeStrategy.h
+++ b/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/CellRangeDataTreeStrategy.h
@@ -194,13 +194,13 @@ namespace GfxTL
 				HandleType k = range.second - 1;
 				while(1)
 				{
-					while(j <= k && split(at(Dereference(j))))
+					while(j <= k && split(this->at(this->Dereference(j))))
 						++j;
-					while(j < k && !split(at(Dereference(k))))
+					while(j < k && !split(this->at(this->Dereference(k))))
 						--k;
 					if(j < k)
 					{
-						SwapHandles(k, j);
+						this->SwapHandles(k, j);
 						++j;
 						--k;
 					}

--- a/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/Jacobi.h
+++ b/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/Jacobi.h
@@ -5,6 +5,7 @@
 #include <GfxTL/MathHelper.h>
 #include <GfxTL/Array.h>
 #include <memory>
+#include <unistd.h>
 
 namespace GfxTL
 {

--- a/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/KdTree.h
+++ b/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/KdTree.h
@@ -260,7 +260,7 @@ namespace GfxTL
 					else
 						BaseType::LeaveGlobalBuildInformation(*p.first, p.second);
 					while(p.second.CreateChild() < CellType::NChildren &&
-						!ExistChild(*p.first, p.second.CreateChild()))
+						!this->ExistChild(*p.first, p.second.CreateChild()))
 						++p.second.CreateChild();
 					if(p.second.CreateChild() == CellType::NChildren)
 					{

--- a/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/MaxIntervalSplittingKdTreeStrategy.h
+++ b/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/MaxIntervalSplittingKdTreeStrategy.h
@@ -32,7 +32,7 @@ namespace GfxTL
 			void ComputeSplit(const BuildInformationT &bi, CellType *cell)
 			{ 
 				DiffScalarType *diff = new DiffScalarType[BaseType::m_dim];
-				Sub(bi.BBox()[1], bi.BBox()[0], &diff);
+				this->Sub(bi.BBox()[1], bi.BBox()[0], &diff);
 				unsigned int axis = 0;
 				DiffScalarType length = diff[0];
 				for(unsigned int j = 1; j < BaseType::m_dim; ++j)

--- a/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/LowStretchSphereParametrization.cpp
+++ b/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/LowStretchSphereParametrization.cpp
@@ -1,5 +1,6 @@
 #include "LowStretchSphereParametrization.h"
 #include "Bitmap.h"
+#include <unistd.h>
 
 LowStretchSphereParametrization::LowStretchSphereParametrization(
 	const Sphere &sphere)

--- a/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/LowStretchTorusParametrization.cpp
+++ b/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/LowStretchTorusParametrization.cpp
@@ -1,5 +1,6 @@
 #include "LowStretchTorusParametrization.h"
 #include "Bitmap.h"
+#include "unistd.h"
 
 LowStretchTorusParametrization::LowStretchTorusParametrization(
 	const Torus &torus)

--- a/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/RebuildAACubeTreeStrategy.h
+++ b/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/RebuildAACubeTreeStrategy.h
@@ -36,12 +36,12 @@ struct RebuildAACubeTreeStrategy
 			{
 				for(unsigned int i = 0; i < CellType::NChildren; ++i)
 				{
-					if(ExistChild(*BaseType::Root(), i))
+					if(this->ExistChild(*BaseType::Root(), i))
 						delete &((*BaseType::Root())[i]);
 					BaseType::Root()->Child(i, NULL);
 				}
 			}
-			if(IsLeaf(*BaseType::Root()))
+			if(this->IsLeaf(*BaseType::Root()))
 				return 0;
 			typename BaseType::HandleType cur = BaseType::BeginHandle();
 			size_t maxDepth = 0;
@@ -53,7 +53,7 @@ struct RebuildAACubeTreeStrategy
 			}
 			for(unsigned int i = 0; i < CellType::NChildren; ++i)
 			{
-				if(!ExistChild(*BaseType::Root(), i))
+				if(!this->ExistChild(*BaseType::Root(), i))
 					continue;
 				PointType cmin, cmax;
 				for(unsigned int j = 0; j < BaseType::m_dim; ++j)
@@ -83,7 +83,7 @@ struct RebuildAACubeTreeStrategy
 			const PointType &max, typename BaseType::HandleType *cur)
 		{
 			CellType &cell = parent[childIdx];
-			if(IsLeaf(cell))
+			if(this->IsLeaf(cell))
 			{
 				typename BaseType::HandleType h = *cur;
 				if(h >= BaseType::EndHandle())
@@ -94,7 +94,7 @@ struct RebuildAACubeTreeStrategy
 				size_t s = cell.Size();
 				for(size_t i = 0; i < s && h < BaseType::EndHandle(); ++i, ++h)
 				{
-					size_t dref = Dereference(h);
+					size_t dref = this->Dereference(h);
 					bool inside = true;
 					for(unsigned int j = 0; j < BaseType::m_dim; ++j)
 					{
@@ -119,7 +119,7 @@ struct RebuildAACubeTreeStrategy
 				size_t maxDepth = 0;
 				for(unsigned int i = 0; i < CellType::NChildren; ++i)
 				{
-					if(!ExistChild(cell, i))
+					if(!this->ExistChild(cell, i))
 						continue;
 					PointType cmin, cmax;
 					for(unsigned int j = 0; j < BaseType::m_dim; ++j)
@@ -157,7 +157,7 @@ struct RebuildAACubeTreeStrategy
 					// make cell a leaf
 					for(unsigned int i = 0; i < CellType::NChildren; ++i)
 					{
-						if(!ExistChild(cell, i))
+						if(!this->ExistChild(cell, i))
 							continue;
 						delete &(cell[i]);
 						cell.Child(i, NULL);

--- a/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/ScoreAACubeTreeStrategy.h
+++ b/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/ScoreAACubeTreeStrategy.h
@@ -47,7 +47,7 @@ struct ScoreAACubeTreeStrategy
 			typedef	typename BaseType::template 
 				CellCenterTraversalInformation< tibT > TraversalInformation;
 			TraversalInformation ti;
-			InitRootTraversalInformation(*BaseType::Root(), &ti);
+			this->InitRootTraversalInformation(*BaseType::Root(), &ti);
 			Score(*BaseType::Root(), ti, shape, /*maxCellSize,*/ score);
 		}
 
@@ -72,7 +72,7 @@ struct ScoreAACubeTreeStrategy
 		void Score(const CellType &cell, const TraversalInformationT &ti,
 			const ShapeT &shape, /*size_t maxCellSize,*/ ScoreT *score) const
 		{
-			if(/*cell.Size() <= maxCellSize ||*/ IsLeaf(cell))
+			if(/*cell.Size() <= maxCellSize ||*/ this->IsLeaf(cell))
 			{
 				//score->UpperBound() += cell.GlobalSize();
 				//score->SampledPoints() += cell.Size();
@@ -87,16 +87,16 @@ struct ScoreAACubeTreeStrategy
 				//{
 					for(typename BaseType::HandleType h = cell.Range().first;
 						h != cell.Range().second; ++h)
-						(*score)(shape, *this, Dereference(h));
+						(*score)(shape, *this, this->Dereference(h));
 				//}
 				return;
 			}
 			for(unsigned int i = 0; i < CellType::NChildren; ++i)
 			{
-				if(!ExistChild(cell, i))
+				if(!this->ExistChild(cell, i))
 					continue;
 				TraversalInformationT cti;
-				InitTraversalInformation(cell, ti, i, &cti);
+				this->InitTraversalInformation(cell, ti, i, &cti);
 				//typename BaseType::CellCenterType center;
 				//CellCenter(cell[i], cti, &center);
 				ScalarType dist = shape.Distance(*((const Vec3f *)&cell[i].Center()/*center*/));


### PR DESCRIPTION
Hi
I'm compiling CloudCompare under a Debian Testing (wheezy). Default c/C++ compilator are now gcc/g++ 4.7. This last introduce some change on name lookups in C++ template. So when I enable Ransac plugins I have a lot of error looking like :  

```
/CloudCompare_trunk/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/RansacShapeDetector.cpp:518:26:   required from here
/CloudCompare_trunk/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/AACubeTree.h:315:4: error: ‘InitRoot’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
/CloudCompare_trunk/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/AACubeTree.h:315:4: note: declarations in dependent base   

... some template stuff ...

’ are not found by unqualified lookup
CloudCompare_trunk/qCC/plugins/qRANSAC_SD/RANSAC_SD_orig/GfxTL/AACubeTree.h:315:4: note: use ‘this->InitRoot’ instead
```

So I basically do all the change as suggest by gcc 4.7 and after some compilation/code change iterations everything is compiling. 
You could see [stackoverflow](http://stackoverflow.com/questions/10639053/name-lookups-in-c-templates) for related technical details.
