### PR TITLE
Fixes for compiler warnings

### DIFF
--- a/CC/include/GenericProgressCallback.h
+++ b/CC/include/GenericProgressCallback.h
@@ -99,8 +99,8 @@ public:
 	**/
 	NormalizedProgress(GenericProgressCallback* callback, unsigned totalSteps, unsigned totalPercentage=100)
 		: percent(0.0f)
-		, percentAdd(1.0f)
 		, step(1)
+      , percentAdd(1.0f)
 		, counter(0)
 		, progressCallback(callback)
 	{

--- a/CC/include/StatisticalTestingTools.h
+++ b/CC/include/StatisticalTestingTools.h
@@ -31,9 +31,6 @@ class GenericIndexedCloudPersist;
 class GenericDistribution;
 class GenericProgressCallback;
 
-//! Max computable Chi2 distance
-static double CHI2_MAX = 1e7;
-
 //! Statistical testing algorithms (Chi2 distance computation, statistic filtering, etc.)
 #ifdef CC_USE_AS_DLL
 #include "CloudCompareDll.h"

--- a/CC/src/FastMarchingForPropagation.cpp
+++ b/CC/src/FastMarchingForPropagation.cpp
@@ -31,9 +31,9 @@ using namespace CCLib;
 
 FastMarchingForPropagation::FastMarchingForPropagation()
 	: FastMarching()
-	, lastT(0.0f)						//derniere valeur d'arrivee
-	, detectionThreshold(Cell::T_INF())	//saut relatif de la valeur d'arrivee qui arrête la propagation (ici, "desactive")
 	, jumpCoef(0.0f)					//resistance a l'avancement du front, en fonction de Cell->f (ici, pas de resistance)
+	, detectionThreshold(Cell::T_INF())	//saut relatif de la valeur d'arrivee qui arrete la propagation (ici, "desactive")
+	, lastT(0.0f)						//derniere valeur d'arrivee
 {
 }
 

--- a/CC/src/StatisticalTestingTools.cpp
+++ b/CC/src/StatisticalTestingTools.cpp
@@ -35,6 +35,9 @@
 
 using namespace CCLib;
 
+//! Max computable Chi2 distance
+static double CHI2_MAX = 1e7;
+
 //! An element of a double-chained-list structure (used by computeAdaptativeChi2Dist)
 struct Chi2Class
 {

--- a/libs/CCFbo/src/ccBilateralFilter.cpp
+++ b/libs/CCFbo/src/ccBilateralFilter.cpp
@@ -30,8 +30,8 @@ ccBilateralFilter::ccBilateralFilter()
 	: ccGlFilter("Bilateral smooth")
 	, m_width(0)
 	, m_height(0)
-	, m_shader(0)
 	, m_fbo(0)
+	, m_shader(0)
 	, m_useCurrentViewport(false)
 {
 	memset(m_dampingPixelDist, 0, KERNEL_MAX_SIZE*KERNEL_MAX_SIZE); //will be updated right away by 'setParameters'

--- a/libs/qCC_db/ccColorScale.cpp
+++ b/libs/qCC_db/ccColorScale.cpp
@@ -32,8 +32,8 @@ ccColorScale::ccColorScale(QString name, QString uuid/*=QString()*/, bool relati
 	: m_name(name)
 	, m_uuid(uuid)
 	, m_updated(false)
-	, m_locked(false)
 	, m_relative(relative)
+	, m_locked(false)
 	, m_minValue(0.0)
 	, m_range(1.0)
 {

--- a/libs/qCC_db/ccHObject.h
+++ b/libs/qCC_db/ccHObject.h
@@ -296,7 +296,7 @@ protected:
 /*** Helpers ***/
 
 //! standard ccHObject container (for children, etc.)
-static void RemoveSiblings(const ccHObject::Container& origin, ccHObject::Container& dest)
+inline void RemoveSiblings(const ccHObject::Container& origin, ccHObject::Container& dest)
 {
 	size_t count = origin.size();
 	for (size_t i=0;i<count;++i)

--- a/libs/qCC_db/ccObject.cpp
+++ b/libs/qCC_db/ccObject.cpp
@@ -25,6 +25,20 @@
 #include <assert.h>
 #include <stdint.h>
 
+/** Versions:
+   V1.0 = prior to 05/04/2012 = old version
+   V2.0 - 05/04/2012 - upgrade to serialized version with version tracking
+   V2.1 - 07/02/2012 - points & 2D labels upgraded
+   V2.2 - 11/26/2012 - object name is now a QString
+   V2.3 - 02/07/2013 - attribute 'm_selectionBehavior' added to ccHObject class
+   v2.4 - 02/22/2013 - per-cloud point size + whether name is displayed in 3D or not
+   v2.5 - 03/16/2013 - ccViewportParameters structure modified
+   v2.6 - 04/03/2013 - strictly positive scalar field removed and 'hidden' values marker is now NaN
+   v2.7 - 04/12/2013 - Customizable color scales
+**/
+const unsigned s_currentDBVersion = 27; //2.7
+
+
 void ccObject::ResetUniqueIDCounter()
 {
     QSettings settings;

--- a/libs/qCC_db/ccObject.h
+++ b/libs/qCC_db/ccObject.h
@@ -100,18 +100,7 @@ enum CC_CLASS_ENUM {
 };
 
 //! Current database version
-/** Versions:
-	V1.0 = prior to 05/04/2012 = old version
-	V2.0 - 05/04/2012 - upgrade to serialized version with version tracking
-	V2.1 - 07/02/2012 - points & 2D labels upgraded
-	V2.2 - 11/26/2012 - object name is now a QString
-	V2.3 - 02/07/2013 - attribute 'm_selectionBehavior' added to ccHObject class
-	v2.4 - 02/22/2013 - per-cloud point size + whether name is displayed in 3D or not
-	v2.5 - 03/16/2013 - ccViewportParameters structure modified
-	v2.6 - 04/03/2013 - strictly positive scalar field removed and 'hidden' values marker is now NaN
-	v2.7 - 04/12/2013 - Customizable color scales
-**/
-static unsigned s_currentDBVersion = 27; //2.7
+extern const unsigned s_currentDBVersion;
 
 //! Generic "CloudCompare Object" template
 #ifdef QCC_DB_USE_AS_DLL

--- a/libs/qCC_db/ccScalarField.cpp
+++ b/libs/qCC_db/ccScalarField.cpp
@@ -309,7 +309,6 @@ bool ccScalarField::fromFile(QFile& in, short dataVersion)
 	if (dataVersion < 26)
 	{
 		const ScalarType FORMER_BIG_VALUE = (ScalarType)(sqrt(3.4e38f)-1.0f);
-		const ScalarType FORMER_HIDDEN_VALUE = (ScalarType)-1.0;
 
 		for (unsigned i=0;i<m_maxCount;++i)
 		{

--- a/libs/qCC_db/ccTorus.cpp
+++ b/libs/qCC_db/ccTorus.cpp
@@ -32,9 +32,9 @@ ccTorus::ccTorus(PointCoordinateType insideRadius,
 	: ccGenericPrimitive(name,transMat)
 	, m_insideRadius(abs(insideRadius))
 	, m_outsideRadius(abs(outsideRadius))
-	, m_angle_rad(abs(angle_rad))
 	, m_rectSection(rectangularSection)
 	, m_rectSectionHeight(abs(rectSectionHeight))
+	, m_angle_rad(abs(angle_rad))
 {
 	setDrawingPrecision(std::max<unsigned>(precision,4)); //automatically calls buildUp + 	applyTransformationToVertices
 }

--- a/qCC/ccConsole.cpp
+++ b/qCC/ccConsole.cpp
@@ -42,9 +42,6 @@
  *** Globals ***
  ***************/
 
-//buffer for formated string generation
-static char s_buffer[4096];
-
 //unique console instance
 static ccConsole* s_console = 0;
 

--- a/qCC/db_tree/ccPropertiesTreeDelegate.cpp
+++ b/qCC/db_tree/ccPropertiesTreeDelegate.cpp
@@ -97,9 +97,9 @@ ccPropertiesTreeDelegate::ccPropertiesTreeDelegate(QStandardItemModel* model,
 												   QAbstractItemView* view,
 												   QObject *parent)
 		: QStyledItemDelegate(parent)
+		, m_currentObject(0)
 		, m_model(model)
 		, m_view(view)
-		, m_currentObject(0)
 {
 	assert(m_model && m_view);
 }
@@ -1297,7 +1297,7 @@ void ccPropertiesTreeDelegate::setEditorData(QWidget *editor, const QModelIndex 
             return;
 
         ccGLWindow* win = static_cast<ccGLWindow*>(m_currentObject->getDisplay());
-        int pos = (win ? pos = comboBox->findText(win->windowTitle()) : 0);
+        int pos = (win ? comboBox->findText(win->windowTitle()) : 0);
 
         comboBox->setCurrentIndex(std::max(pos,0)); //0 = "NONE"
         break;

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -567,7 +567,9 @@ void MainWindow::on3DMouseKeyUp(int)
 	//nothing right now
 }
 
+#ifdef CC_3DXWARE_SUPPORT
 static bool s_3dMouseContextMenuAlreadyShown = false; //DGM: to prevent multiple instances at once
+#endif
 void MainWindow::on3DMouseKeyDown(int key)
 {
 	if (!m_3dMouseInput)


### PR DESCRIPTION
- unused vars
  - init ordering in constructors
  - static vars and functions in header files
