### PR TITLE
fix CMake error on Linux

### DIFF
--- a/qCC/plugins/CMakeLists.txt
+++ b/qCC/plugins/CMakeLists.txt
@@ -8,8 +8,10 @@ file(GLOB subdirectories *)
 foreach(dir ${subdirectories})
     if(IS_DIRECTORY ${dir})
 		if (NOT ${dir} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/.svn ) #ignore svn subdir!
-			message( STATUS "Auto-add plugin subdir:" ${dir})
-			add_subdirectory (${dir})
+			if (NOT ${dir} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/CMakeFiles ) #ignore CMakeFiles subdir
+				message( STATUS "Auto-add plugin subdir:" ${dir})
+				add_subdirectory (${dir})
+			endif()
 		endif()
 	endif()
 endforeach()


### PR DESCRIPTION
Otherwise fails with:

-- Found Qt4: /usr/bin/qmake-qt4 (found version "4.8.4")
-- Found Qt4: /usr/bin/qmake-qt4 (found version "4.8.4")
-- Auto-add plugin subdir:/home/thomas/cloudcompare/qCC/plugins/qKinect
-- Auto-add plugin subdir:/home/thomas/cloudcompare/qCC/plugins/qDummyPlugin
-- Auto-add plugin subdir:/home/thomas/cloudcompare/qCC/plugins/qHPR
-- Auto-add plugin subdir:/home/thomas/cloudcompare/qCC/plugins/qRANSAC_SD
-- Auto-add plugin subdir:/home/thomas/cloudcompare/qCC/plugins/qPCV
-- Auto-add plugin subdir:/home/thomas/cloudcompare/qCC/plugins/qBlur
-- Auto-add plugin subdir:/home/thomas/cloudcompare/qCC/plugins/qSSAO
-- Auto-add plugin subdir:/home/thomas/cloudcompare/qCC/plugins/qEDL
-- Auto-add plugin subdir:/home/thomas/cloudcompare/qCC/plugins/qPoissonRecon
-- Auto-add plugin subdir:/home/thomas/cloudcompare/qCC/plugins/qPCL
-- Auto-add plugin subdir:/home/thomas/cloudcompare/qCC/plugins/CMakeFiles
CMake Error at qCC/plugins/CMakeLists.txt:12 (add_subdirectory):
  The source directory

```
/home/thomas/cloudcompare/qCC/plugins/CMakeFiles
```

  does not contain a CMakeLists.txt file.

-- Configuring incomplete, errors occurred!

(cmake version 2.8.10.2)
