### PR TITLE
fixig sleep on linux. using usleep in microseconds

### DIFF
--- a/qCC/fileIO/BinFilter.cpp
+++ b/qCC/fileIO/BinFilter.cpp
@@ -132,7 +132,7 @@ CC_FILE_ERROR BinFilter::saveToFile(ccHObject* root, const char* filename)
 #if defined(CC_WINDOWS)
 		::Sleep(500);
 #else
-		sleep(500);
+        usleep(500 * 1000);
 #endif
 		pDlg.setValue(pDlg.value()+1);
 		QApplication::processEvents();
@@ -292,7 +292,7 @@ CC_FILE_ERROR BinFilter::loadFile(const char* filename, ccHObject& container, bo
 #if defined(CC_WINDOWS)
 			::Sleep(500);
 #else
-			sleep(500);
+            usleep(500 * 1000);
 #endif
 			if (alwaysDisplayLoadDialog)
 			{

--- a/qCC/plugins/qPCL/PclUtils/filters/BaseFilter.cpp
+++ b/qCC/plugins/qPCL/PclUtils/filters/BaseFilter.cpp
@@ -194,7 +194,7 @@ int BaseFilter::start()
 #if defined(CC_WINDOWS)
             ::Sleep(500);
 #else
-            sleep(500);
+            usleep(500 * 1000);
 #endif
             progressCb->update(++progress);
         }
@@ -224,7 +224,7 @@ int BaseFilter::start()
 #if defined(CC_WINDOWS)
             ::Sleep(500);
 #else
-            sleep(500);
+            usleep(500 * 1000);
 #endif
         }
         int is_ok = s_computeStatus;

--- a/qCC/plugins/qPoissonRecon/qPoissonRecon.cpp
+++ b/qCC/plugins/qPoissonRecon/qPoissonRecon.cpp
@@ -190,7 +190,7 @@ void qPoissonRecon::doAction()
 			#if defined(CC_WINDOWS)
 			::Sleep(500);
 			#else
-			sleep(500);
+            usleep(500 * 1000);
 			#endif
 
 			pDlg.setValue(pDlg.value()+1);


### PR DESCRIPTION
sleep on linux is expressed in seconds, so calling sleep(500) require the thread to pause for too much time. Replaced with usleep - so it should be clearer it is in microseconds...
