### PR TITLE
export from the build tree a CCPConfig.cmake file for developing plugins...

### DIFF
--- a/CCPConfig.cmake.in
+++ b/CCPConfig.cmake.in
@@ -1,0 +1,53 @@
+# - Config file for the ClouCompareProjects package
+# It defines the following variables
+#  CCP_INCLUDE_DIRS         - include directories for CloudCompareProjects
+#  CCP_LIBRARIES            - libraries to link against
+#  CCP_PLUGIN_INSTALL_DIR   - the dir where plugins will be installed in the system
+#  CCP_CXX_FLAGS            - the flags that were used for compilig cloudcompare projects
+
+# Note this was made for exporting from th build tree. exporting from the install tree may require some
+# changes to this file before to be ok
+
+# current path of the cmakeconfig file
+# it will simply be the build dir for build-exported tree
+get_filename_component(CCP_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+# where plugins are placed in the system
+set(CCP_PLUGIN_INSTALL_DIR @CMAKE_INSTALL_PREFIX@/CloudCompare/plugins)
+set(CCP_CXX_FLAGS @CMAKE_CXX_FLAGS@)
+
+# import targets of the CloudCompareProject that may be useful for third-part plugin developers
+if(NOT TARGET CloudCompareProjects) # if it is not defined yet
+    include("${CCP_CMAKE_DIR}/CCPTargets.cmake")
+endif()
+ 
+# A broad range of includes to be used from your plugins
+set(CCP_INCLUDE_DIRS    "@PROJECT_SOURCE_DIR@/libs/qCC_db;
+                        @PROJECT_SOURCE_DIR@/libs/qCC_io;
+                        @PROJECT_SOURCE_DIR@/CC/include;
+                        @PROJECT_SOURCE_DIR@/qCC/db_tree;
+                        @PROJECT_SOURCE_DIR@/qCC;
+                        @PROJECT_SOURCE_DIR@/qCC/dialogs;
+                        @PROJECT_BINARY_DIR@/qCC;
+                        @PROJECT_SOURCE_DIR@/plugins;
+                        @PROJECT_BINARY_DIR@/plugins"}
+)
+
+
+# These are the shared libraries installed in the system by CCP by default
+set(CCP_LIBRARIES CC_CORE_LIB QCC_DB_LIB)
+
+# For now only QPCL plugin is handled
+if(TARGET QPCL_PLUGIN)
+        set(CCP_LIBRARIES "${CCP_LIBRARIES}" QPCL_PLUGIN_UTILS_LIB)
+endif()
+
+# Qt is mandatory for working with CC code - finding it for you
+find_package(Qt4 REQUIRED)
+set(QT_USE_QTOPENGL TRUE)
+include(${QT_USE_FILE})
+add_definitions(${QT_DEFINITIONS})
+include_directories(${QT_QTOPENGL_INCLUDE_DIR})
+
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,3 +74,38 @@ add_subdirectory( qCC )
 if( ${OPTION_BUILD_CCVIEWER} )
 	add_subdirectory( ccViewer )
 endif()
+
+
+# Experimental targets exporting from the build tree
+# Note: target exporting from the install tree still need to be implemented
+OPTION( OPTION_EXPORT_TARGETS "Check to export a CCPConfig.cmake and related targets from the build tree" ON )
+if( ${OPTION_EXPORT_TARGETS} )
+    # NOTES
+    # once CloudCompareProjects (CCP) will be exported from the build tree other people that whant to
+    # use cloudcompare code - or e.g. write plugins they will be able to find the package in this way
+    # from within their cmakelists:
+        #-> find_package(CCP REQUIRED) # CloudCompareProjects
+        #-> include_directories(${CCP_INCLUDE_DIRS})
+    # and then they just need to link their plugins against ${CCP_LIBRARIES}
+
+    set(TARGETS_TO_EXPORT CC_CORE_LIB CC_FBO_LIB GLEW_LIB QCC_DB_LIB QCC_GL_LIB QCC_IO_LIB triangle)
+
+    if(${INSTALL_QPCL_PLUGIN})
+        # we also export the shared lib produced by that
+        set(TARGETS_TO_EXPORT ${TARGETS_TO_EXPORT} QPCL_PLUGIN QPCL_PLUGIN_UTILS_LIB)
+    endif()
+
+    if( ${OPTION_BUILD_CCVIEWER} )
+        # we also export the shared lib produced by that
+        set(TARGETS_TO_EXPORT ${TARGETS_TO_EXPORT} ccViewer)
+    endif()
+
+    export(PACKAGE CCP) # this will make CCP build-tree locable from anywhere on the system for the user
+                        # how? read here: http://www.cmake.org/Wiki/CMake/Tutorials/Package_Registry
+
+    # this exports targets from the build tree. See install(EXPORT) command to export targets from an installation tree.
+    export(TARGETS ${TARGETS_TO_EXPORT} FILE "${PROJECT_BINARY_DIR}/CCPTargets.cmake")
+
+    # configure the cmake.in file and place in the build tree so external apps may find it
+    configure_file(CCPConfig.cmake.in "${PROJECT_BINARY_DIR}/CCPConfig.cmake" @ONLY)
+endif()


### PR DESCRIPTION
... from outside the CC codebase

It seems to work fine on linux. It should also work on windows. it does not modify other code at all, and can be eventually disabled if required. Should be ok to be merged with trunk.... cmake files are highly commented...
