### PR TITLE
Change source files to UTF-8 encoding

### DIFF
--- a/CC/include/MeshSamplingTools.h
+++ b/CC/include/MeshSamplingTools.h
@@ -60,7 +60,7 @@ public:
 		b=1-b. Let ABC be the triangle, then the new point P will be as
 		AP = a.AB+b.AC (AP,AB and AC are vectors here). The number of
 		points sampled on each triangle depends on the triangle's area.
-		Let s be this area, and µ the sampling density, then N = s*µ is
+		Let s be this area, and Âµ the sampling density, then N = s*Âµ is
 		the theoric (floating) number of points to sample. The floating
 		part of N (let's call it Nf, and let Ni be the integer part) is
 		handled by generating another random number between 0 and 1.

--- a/CC/src/Neighbourhood.cpp
+++ b/CC/src/Neighbourhood.cpp
@@ -232,7 +232,7 @@ bool Neighbourhood::computeLeastSquareBestFittingPlane()
 	CCVector3 G(0,0,0);
 	if (pointCount > 3)
 	{
-		//we determine plane normal by computing the smallest eigen value of M = 1/n * S[(p-µ)*(p-µ)']
+		//we determine plane normal by computing the smallest eigen value of M = 1/n * S[(p-Âµ)*(p-Âµ)']
 		CCLib::SquareMatrixd eig = computeCovarianceMatrix().computeJacobianEigenValuesAndVectors();
 
 		//invalid matrix?
@@ -732,7 +732,7 @@ ScalarType Neighbourhood::computeCurvature(unsigned neighbourIndex, CC_CURVATURE
 	const PointCoordinateType& e = H[4];
 	const PointCoordinateType& f = H[5];
 
-    //See "CURVATURE OF CURVES AND SURFACES – A PARABOLIC APPROACH" by ZVI HAR’EL
+    //See "CURVATURE OF CURVES AND SURFACES â€“ A PARABOLIC APPROACH" by ZVI HARâ€™EL
 	const PointCoordinateType  fx	= b + (d*2) * Q.u[X] + (e  ) * Q.u[Y];	// b+2d*X+eY
 	const PointCoordinateType  fy	= c + (e  ) * Q.u[X] + (f*2) * Q.u[Y];	// c+2f*Y+eX
 	const PointCoordinateType  fxx	= d*2;									// 2d

--- a/CC/src/RegistrationTools.cpp
+++ b/CC/src/RegistrationTools.cpp
@@ -790,7 +790,7 @@ bool FPCSRegistrationTools::FindBase(GenericIndexedCloud* cloud,
         x = ((p1->y-p0->y)*(p2->z-p0->z))-((p1->z-p0->z)*(p2->y-p0->y));
         y = ((p1->z-p0->z)*(p2->x-p0->x))-((p1->x-p0->x)*(p2->z-p0->z));
         z = ((p1->x-p0->x)*(p2->y-p0->y))-((p1->y-p0->y)*(p2->x-p0->x));
-        //don't need to compute the true area : f=(area²)*2 is sufficient for comparison
+        //don't need to compute the true area : f=(areaÂ²)*2 is sufficient for comparison
         f = x*x + y*y + z*z;
         if (f > best)
         {
@@ -1074,7 +1074,7 @@ bool FPCSRegistrationTools::LinesIntersections(
     //Find lambda and mu such that :
     //A = p0+lambda(p1-p0)
     //B = p2+mu(p3-p2)
-    //(lambda, mu) = argmin(||A-B||²)
+    //(lambda, mu) = argmin(||A-B||Â²)
     p02 = p0-p2;
     p32 = p3-p2;
     p10 = p1-p0;

--- a/libs/qCC_db/ccNormalVectors.cpp
+++ b/libs/qCC_db/ccNormalVectors.cpp
@@ -713,7 +713,7 @@ QString ccNormalVectors::ConvertStrikeAndDipToString(double& strike_deg, double&
 	int iStrike = static_cast<int>(strike_deg);
 	int iDip = static_cast<int>(dip_deg);
 
-	return QString("N%1°E - %2°").arg(iStrike,3,10,QChar('0')).arg(iDip,3,10,QChar('0'));
+	return QString("N%1Â°E - %2Â°").arg(iStrike,3,10,QChar('0')).arg(iDip,3,10,QChar('0'));
 }
 
 QString ccNormalVectors::ConvertDipAndDipDirToString(PointCoordinateType dip_deg, PointCoordinateType dipDir_deg)
@@ -721,7 +721,7 @@ QString ccNormalVectors::ConvertDipAndDipDirToString(PointCoordinateType dip_deg
 	int iDipDir = static_cast<int>(dipDir_deg);
 	int iDip = static_cast<int>(dip_deg);
 
-	return QString("Dip direction: %1° - Dip angle: %2°").arg(iDipDir,3,10,QChar('0')).arg(iDip,3,10,QChar('0'));
+	return QString("Dip direction: %1Â° - Dip angle: %2Â°").arg(iDipDir,3,10,QChar('0')).arg(iDip,3,10,QChar('0'));
 }
 
 void ccNormalVectors::ConvertNormalToStrikeAndDip(const CCVector3& N, double& strike_deg, double& dip_deg)

--- a/libs/qCC_db/ccNormalVectors.h
+++ b/libs/qCC_db/ccNormalVectors.h
@@ -105,7 +105,7 @@ public:
 											NormsIndexesTableType& theNormsCodes,
 											int preferedOrientation);
 
-	//! Converts a normal vector to geological 'strike & dip' parameters (N[dip]°E - [strike]°)
+	//! Converts a normal vector to geological 'strike & dip' parameters (N[dip]Â°E - [strike]Â°)
 	/** \param[in] N normal (should be normalized!)
 		\param[out] strike_deg strike value (in degrees)
 		\param[out] dip_deg dip value (in degrees)
@@ -122,17 +122,17 @@ public:
 	**/
 	static void ConvertNormalToDipAndDipDir(const CCVector3& N, PointCoordinateType& dip_deg, PointCoordinateType& dipDir_deg);
 
-	//! Converts geological 'strike & dip' parameters (N[dip]°E - [strike]°) to a string
+	//! Converts geological 'strike & dip' parameters (N[dip]Â°E - [strike]Â°) to a string
 	/** \param[in] strike_deg strike value (in degrees)
 		\param[in] dip_deg dip  value (in degrees)
-		\return formatted string "N[strike]°E - [dip]°"
+		\return formatted string "N[strike]Â°E - [dip]Â°"
 	**/
 	static QString ConvertStrikeAndDipToString(double& strike_deg, double& dip_deg);
 
 	//! Converts geological 'dip direction & dip' parameters to a string
 	/** \param[in] dip_deg dip angle value (in degrees)
 		\param[in] dipDir_deg dip direction value (in degrees)
-		\return formatted string "Dip direction: [dipDir]° - Dip angle: [dip]°"
+		\return formatted string "Dip direction: [dipDir]Â° - Dip angle: [dip]Â°"
 	**/
 	static QString ConvertDipAndDipDirToString(PointCoordinateType dip_deg, PointCoordinateType dipDir_deg);
 

--- a/qCC/ccComparisonDlg.cpp
+++ b/qCC/ccComparisonDlg.cpp
@@ -438,7 +438,7 @@ int ccComparisonDlg::determineBestOctreeLevel(double maxSearchDist)
 	double timings[CCLib::DgmOctree::MAX_OCTREE_LEVEL];
 	memset(timings,0,sizeof(double)*CCLib::DgmOctree::MAX_OCTREE_LEVEL);
 
-	//Pour le cas où la reference est un maillage
+	//Pour le cas oÃ¹ la reference est un maillage
 	double meanTriangleSurface = 1.0;
 	CCLib::GenericIndexedMesh* mesh = 0;
 	if (!m_refOctree)

--- a/qCC/db_tree/ccPropertiesTreeDelegate.cpp
+++ b/qCC/db_tree/ccPropertiesTreeDelegate.cpp
@@ -672,7 +672,7 @@ void ccPropertiesTreeDelegate::fillWithCalibratedImage(ccCalibratedImage* _obj)
 	appendRow( ITEM("Orientation"), ITEM(QString("(%0,%1,%2)").arg(axis3D.x).arg(axis3D.y).arg(axis3D.z)) );
 
     //camera orientation angle
-	appendRow( ITEM("Angle (degrees)"), ITEM(QString("%0°").arg(angle_rad*CC_RAD_TO_DEG)) );
+	appendRow( ITEM("Angle (degrees)"), ITEM(QString("%0Â°").arg(angle_rad*CC_RAD_TO_DEG)) );
 }
 
 void ccPropertiesTreeDelegate::fillWithLabel(cc2DLabel* _obj)


### PR DESCRIPTION
For non-english operation systems, people may affect by the file encoding of the source codes. On my Windows 8 with CP936 codepage, the commited files cannot be correctly displayed due to some non-unicode characters used, such as Greek letters and degree symbols. This would cause some compilation error due to errorously missing the character after the non-unicode symbol.  Note that in the diff webpage of Github, due to both encoding are used, the modified version may be not correctly display by Github. If viewing the modified version solely, it'll display correctly.
