### PR TITLE
add algorithm header for std::min, std::max

### DIFF
--- a/CC/include/GenericChunkedArray.h
+++ b/CC/include/GenericChunkedArray.h
@@ -34,6 +34,7 @@ static const unsigned ELEMENT_INDEX_BIT_MASK = MAX_NUMBER_OF_ELEMENTS_PER_CHUNK-
 //system
 #include <stdlib.h>
 #include <string.h>
+#include <algorithm>
 #include <vector>
 
 //! A generic array structure split in several small chunks to avoid the 'biggest contigous memory chunk' limit

--- a/CC/src/ReferenceCloud.cpp
+++ b/CC/src/ReferenceCloud.cpp
@@ -20,6 +20,7 @@
 //system
 #include <string.h>
 #include <assert.h>
+#include <algorithm>
 
 using namespace CCLib;
 


### PR DESCRIPTION
In my VS2013, `std::min` and `std::max` are undefined, only if

```
#include <algorithm>
```

is added. Please help me to check and confirm this commit won't do side effects to other compilers.
