### PR TITLE
The virtual function Polyline::clear() had a different signature than...

### DIFF
--- a/CC/include/Polyline.h
+++ b/CC/include/Polyline.h
@@ -48,7 +48,7 @@ class Polyline : public ReferenceCloud
 		inline void setClosed(bool state) { m_isClosed = state; }
 
 		//inherited from ReferenceCloud
-		virtual void clear();
+		virtual void clear(bool unusedParam = true);
 
 	protected:
 

--- a/CC/src/Polyline.cpp
+++ b/CC/src/Polyline.cpp
@@ -25,7 +25,7 @@ Polyline::Polyline(GenericIndexedCloudPersist* associatedCloud)
 {
 }
 
-void Polyline::clear()
+void Polyline::clear(bool /*unusedParam*/)
 {
 	ReferenceCloud::clear(true);
 	m_isClosed=false;


### PR DESCRIPTION
...the ReferenceCloud base class
