### PR TITLE
Added method void AsciiOpenDlg::resizeWidthToFitTableColumn()

### DIFF
--- a/libs/qCC_io/AsciiOpenDlg.cpp
+++ b/libs/qCC_io/AsciiOpenDlg.cpp
@@ -400,6 +400,8 @@ void AsciiOpenDlg::updateTable(const QString &separator)
 
 	//check for invalid columns
 	checkSelectedColumnsValidity(); //will eventually enable of disable the "OK" button
+    // expand dialog width to display all table columns
+    resizeWidthToFitTableColumns();
 }
 
 void AsciiOpenDlg::checkSelectedColumnsValidity()
@@ -594,4 +596,38 @@ void AsciiOpenDlg::shortcutButtonPressed()
 unsigned AsciiOpenDlg::getMaxCloudSize() const
 {
 	return static_cast<unsigned>(floor(m_ui->maxCloudSizeDoubleSpinBox->value() * 1.0e6));
+}
+
+void AsciiOpenDlg::resizeWidthToFitTableColumns()
+{
+/*!
+ * Increases dialog width if table widget contains many columns.
+ * Increases table column widths to fill dialog if only a few
+ * columns are present.
+*/
+    // First make sure all columns are wide enought to fit data
+    // Then get combined width of all columns.
+    m_ui->tableWidget->resizeColumnsToContents();
+    int totalColumnsWidth = m_ui->tableWidget->horizontalHeader()->length();
+
+    // To display whole table widget without h. scrollbars, need to add
+    // table and layout margin pixel values to get a total required dialog width
+    int leftTable, rightTable, leftLayout, rightLayout, top, bottom;
+    m_ui->tableWidget->getContentsMargins(&leftTable, &top, &rightTable, &bottom);
+    m_ui->verticalLayout->getContentsMargins(&leftLayout, &top, &rightLayout, &bottom);
+    int totalMarginsWidth = leftTable + rightTable + leftLayout + rightLayout;
+    int minDialogWidth = totalColumnsWidth + totalMarginsWidth;
+
+    // If table requires more space, resize dialog
+    if (minDialogWidth > this->width())
+        this->resize(minDialogWidth, this->height());
+
+    // Make columns stretchy and auto-resize
+    // This is done differently in Qt5 vs. Qt4
+#if QT_VERSION >= 0x050000
+    m_ui->tableWidget->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+#else
+    m_ui->tableWidget->horizontalHeader()->setResizeMode(QHeaderView::Stretch);
+#endif
+
 }

--- a/libs/qCC_io/AsciiOpenDlg.h
+++ b/libs/qCC_io/AsciiOpenDlg.h
@@ -149,6 +149,8 @@ protected:
 	//QComboBox* m_columnsType;
 	unsigned m_columnsCount;
 
+    // Resizes dialog width to fit all displayed table columns
+    void resizeWidthToFitTableColumns();
 };
 
 #endif //CC_ASCII_OPEN_DIALOG_HEADER

--- a/libs/qCC_io/ui_templates/openAsciiFileDlg.ui
+++ b/libs/qCC_io/ui_templates/openAsciiFileDlg.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>600</width>
+    <width>704</width>
     <height>600</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -274,6 +274,7 @@
    </item>
   </layout>
  </widget>
+ <resources/>
  <connections>
   <connection>
    <sender>buttonBox</sender>


### PR DESCRIPTION
This expands the width of the dialog window in order to make all
the data columns visible without having to manually resize the dialog.
In case the opened file only contains a few columns of data, the
table columns are expanded instead to fill the whole available width
without affecting the dialog size.
