### PR TITLE
Fixes compiler errors and warnings on Mac OS X compile

### DIFF
--- a/CC/src/GeometricalAnalysisTools.cpp
+++ b/CC/src/GeometricalAnalysisTools.cpp
@@ -441,7 +441,6 @@ bool GeometricalAnalysisTools::computePointsDensityInACellAtLevel(	const DgmOctr
 	//for each point in the cell
 	for (unsigned i=0; i<n; ++i)
 	{
-        ScalarType d = NAN_VALUE;
 		cell.points->getPoint(i,nNSS.queryPoint);
 
 		//look for neighbors inside a sphere

--- a/libs/qCC_db/ccQuadric.cpp
+++ b/libs/qCC_db/ccQuadric.cpp
@@ -232,7 +232,7 @@ ccQuadric* ccQuadric::Fit(CCLib::GenericIndexedCloudPersist *cloud, double* rms/
 	{
 		const uchar& dX = hfdims[0];
 		const uchar& dY = hfdims[1];
-		const uchar& dZ = hfdims[2];
+//		const uchar& dZ = hfdims[2];
 
 		*rms = 0;
 

--- a/libs/qCC_db/ccScalarField.cpp
+++ b/libs/qCC_db/ccScalarField.cpp
@@ -411,7 +411,7 @@ bool ccScalarField::fromFile(QFile& in, short dataVersion, int flags)
 		{
 			ScalarType val = getValue(i);
 			//convert former 'HIDDEN_VALUE' and 'BIG_VALUE' to 'NAN_VALUE'
-			if (onlyPositiveValues && val < 0 || !onlyPositiveValues && val >= FORMER_BIG_VALUE)
+			if ((onlyPositiveValues && val < 0) || (!onlyPositiveValues && val >= FORMER_BIG_VALUE))
 				val = NAN_VALUE;
 		}
 	}

--- a/libs/qCC_glWindow/ccGLWindow.cpp
+++ b/libs/qCC_glWindow/ccGLWindow.cpp
@@ -2900,7 +2900,7 @@ void ccGLWindow::drawPivot()
 		return;
 
 	if (m_pivotVisibility == PIVOT_HIDE ||
-		m_pivotVisibility == PIVOT_SHOW_ON_MOVE && !m_pivotSymbolShown)
+		(m_pivotVisibility == PIVOT_SHOW_ON_MOVE && !m_pivotSymbolShown))
 		return;
 
 	glMatrixMode(GL_MODELVIEW);

--- a/libs/qCC_io/FileIOFilter.h
+++ b/libs/qCC_io/FileIOFilter.h
@@ -207,6 +207,7 @@ enum CC_FILE_ERROR {CC_FERR_NO_ERROR,
 class FileIOFilter
 {
 public:
+   virtual ~FileIOFilter() {}
 
 	//! Loads one or more entities from a file with known type
 	/** \param filename filename

--- a/libs/qCC_io/LASFilter.cpp
+++ b/libs/qCC_io/LASFilter.cpp
@@ -164,7 +164,7 @@ CC_FILE_ERROR LASFilter::saveToFile(ccHObject* entity, QString filename)
 
 	//open binary file for writing
 	std::ofstream ofs;
-	ofs.open(filename.toStdString(), std::ios::out | std::ios::binary);
+	ofs.open(filename.toStdString().c_str(), std::ios::out | std::ios::binary);
 
 	if (ofs.fail())
 		return CC_FERR_WRITING;
@@ -344,7 +344,7 @@ CC_FILE_ERROR LASFilter::loadFile(QString filename, ccHObject& container, bool a
 {
 	//opening file
 	std::ifstream ifs;
-	ifs.open(filename.toStdString(), std::ios::in | std::ios::binary);
+	ifs.open(filename.toStdString().c_str(), std::ios::in | std::ios::binary);
 
 	if (ifs.fail())
 		return CC_FERR_READING;

--- a/qCC/ccColorScaleEditorDlg.cpp
+++ b/qCC/ccColorScaleEditorDlg.cpp
@@ -92,7 +92,7 @@ ccColorScaleEditorDialog::~ccColorScaleEditorDialog()
 void ccColorScaleEditorDialog::setAssociatedScalarField(ccScalarField* sf)
 {
 	m_associatedSF = sf;
-	if (m_associatedSF && !m_colorScale || m_colorScale->isRelative()) //we only update those values if the current scale is not absolute!
+	if ((m_associatedSF && !m_colorScale) || m_colorScale->isRelative()) //we only update those values if the current scale is not absolute!
 	{
 		m_minAbsoluteVal = m_associatedSF->getMin();
 		m_maxAbsoluteVal = m_associatedSF->getMax();

--- a/qCC/ccGraphicalSegmentationTool.cpp
+++ b/qCC/ccGraphicalSegmentationTool.cpp
@@ -333,8 +333,8 @@ bool ccGraphicalSegmentationTool::addEntity(ccHObject* anObject)
 					ccGenericMesh* otherMesh = ccHObjectCaster::ToGenericMesh(*p);
 					if (otherMesh->getAssociatedCloud() == mesh->getAssociatedCloud())
 					{
-						if (otherMesh->isA(CC_TYPES::SUB_MESH) && mesh->isA(CC_TYPES::MESH)
-							|| otherMesh->isA(CC_TYPES::MESH) && mesh->isA(CC_TYPES::SUB_MESH))
+						if ((otherMesh->isA(CC_TYPES::SUB_MESH) && mesh->isA(CC_TYPES::MESH))
+							|| (otherMesh->isA(CC_TYPES::MESH) && mesh->isA(CC_TYPES::SUB_MESH)))
 						{
 							ccLog::Warning("[Graphical Segmentation Tool] Can't mix sub-meshes with their parent mesh!");
 							return false;

--- a/qCC/ccGraphicalTransformationTool.cpp
+++ b/qCC/ccGraphicalTransformationTool.cpp
@@ -344,7 +344,6 @@ void ccGraphicalTransformationTool::apply()
 		ccHObject* toTransform = m_toTransform->getChild(i);
 		toTransform->setGLTransformation(correctedFinalTrans);
 
-		ccHObject* parent = 0;
 		//DGM: warning, applyGLTransformation may delete associated octree!
 		MainWindow::ccHObjectContext objContext = MainWindow::TheInstance()->removeObjectTemporarilyFromDBTree(toTransform);
 		toTransform->applyGLTransformation_recursive();

--- a/qCC/db_tree/sfEditDlg.cpp
+++ b/qCC/db_tree/sfEditDlg.cpp
@@ -136,7 +136,7 @@ void sfEditDlg::fillDialogWith(ccScalarField* sf)
 		histoFrame->setVisible(true);
 		{
 			const ccScalarField::Histogram& histogram = m_associatedSF->getHistogram();
-			unsigned classNumber = static_cast<unsigned>(m_associatedSF->getHistogram().size());
+			unsigned classNumber = static_cast<unsigned>(histogram.size());
 			if (classNumber == 0)
 				classNumber = 128;
 			m_associatedSFHisto->fromSF(m_associatedSF,classNumber,false);

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -1628,7 +1628,6 @@ void MainWindow::doActionApplyTransformation()
 		return;
 
 	ccGLMatrixd transMat = dlg.getTransformation();
-	CCVector3d T = transMat.getTranslationAsVec3D();
 
 	//if the transformation is partly converted to global shift/scale
 	bool updateGlobalShiftAndScale = false;
@@ -1678,7 +1677,6 @@ void MainWindow::doActionApplyTransformation()
 					//existing shift information
 					CCVector3d globalShift = cloud->getGlobalShift();
 					double globalScale = cloud->getGlobalScale();
-					bool cloudAlreadyShifted = cloud->isShifted();
 			
 					//we compute the transformation matrix in the global coordinate space
 					ccGLMatrixd globalTransMat = transMat;
@@ -6055,7 +6053,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
 	//}
 	//else
 	{
-		if (m_ccRoot && m_ccRoot->getRootEntity()->getChildrenNumber() == 0
+		if ((m_ccRoot && m_ccRoot->getRootEntity()->getChildrenNumber() == 0)
 			|| QMessageBox::question(	this,
 										"Quit",
 										"Are you sure you want to quit?",
@@ -6486,7 +6484,7 @@ void MainWindow::deactivateSegmentationMode(bool state)
 								ccGenericPointCloud* cloud = ccHObjectCaster::ToGenericPointCloud(segmentationResult);
 
 								int errorCode;
-								CCLib::GenericIndexedCloud* projectedPoints = cloned_sensor->project(cloud,errorCode,true);
+								cloned_sensor->project(cloud,errorCode,true);
 
 								// we need also to do the same for the original cloud
 								sensor->project(ccHObjectCaster::ToGenericPointCloud(entity), errorCode, true);
@@ -8743,8 +8741,6 @@ void MainWindow::addToDB(const QStringList& filenames, CC_FILE_TYPES fType, ccGL
 
 	//the same for 'addToDB' (if the first one is not supported, or if the scale remains too big)
 	CCVector3d addCoordinatesShift(0,0,0);
-	bool addCoordinatesTransEnabled = false;
-	double addCoordinatesScale = 1.0;
 
 	for (int i=0; i<filenames.size(); ++i)
 	{


### PR DESCRIPTION
Mainly unused vars and logic parentheses.

Please check the logical parentheses carefully to make sure I understood the logic!
