### PR TITLE
Change the minor version number in README

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-CloudCompare V2.5
+CloudCompare V2.6
 
 Homepage: http://www.cloudcompare.org/
 


### PR DESCRIPTION
A small change in the README. Are the change needed in doxygen files too ?
actually in libs/qCC_glWindow/doc/qCC_gl_doxygen_file for example we can find :
PROJECT_NUMBER         = "version 2.5.4 (Qt) - 19 Apr 2014"
