### PR TITLE
{Mac} Adjust font size on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,7 @@ v2.8.beta - XX/XX/2016
 		- New option to update an existing viewport object (with the current camera parameters)
 		- [macOS] Now looks for the global_shift.txt file beside the .app instead of inside the application bundle
 		- [macOS] Hides the 3D mouse and Gamepad menus since they are not yet supported on macOS
+		- [macOS] Increases the default font sizes for the 3D viewer (these may be set in the Display Options)
 		- I/O plugins (Faro, DP, Riegl, etc) are now loaded even when using CC in command line mode
 
 - Bug fixes:

--- a/libs/qCC_glWindow/ccGuiParameters.cpp
+++ b/libs/qCC_glWindow/ccGuiParameters.cpp
@@ -94,8 +94,14 @@ void ccGui::ParamStruct::reset()
 	colorScaleShaderSupported	= false;
 	colorScaleRampWidth			= 50;
 
+#ifdef Q_OS_MAC
+	defaultFontSize				= 12;
+	labelFontSize				= 10;
+#else
 	defaultFontSize				= 10;
 	labelFontSize				= 8;
+#endif
+	
 	displayedNumPrecision		= 6;
 	labelOpacity				= 75;
 


### PR DESCRIPTION
Fonts are too small on macOS (regular display, not retina), so change the defaults to make them more readable