### PR TITLE
Strange behavior in sphere fitting 

### DIFF
--- a/CC/src/GeometricalAnalysisTools.cpp
+++ b/CC/src/GeometricalAnalysisTools.cpp
@@ -869,7 +869,7 @@ bool GeometricalAnalysisTools::refineSphereLS(	GenericIndexedCloudPersist* cloud
 				continue;
 
 			meanNorm += norm;
-			derivatives = Di/norm;
+			derivatives += Di/norm;
 			++realCount;
 		}
 


### PR DESCRIPTION
The refinement step is not improving the results. Derivatives are not working as an accumulative element in "GeometricalAnalysisTools::refineSphereLS" so the deviation is being applied in the direction of the vector defined by the latest point of the point cloud and the center of the sphere.