### PR TITLE
enabled ccache to speed up gcc compilations in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: required
 dist: trusty
 
+cache: ccache
+
 language:
     cpp
 


### PR DESCRIPTION
this should speed up gcc compilations on travis after the first build is triggered.
If needed one can go on travis page and reset the caches...