### PR TITLE
qSort is deprecated and will be removed in the future

### DIFF
--- a/libs/qCC_db/ccColorScale.cpp
+++ b/libs/qCC_db/ccColorScale.cpp
@@ -98,7 +98,7 @@ void ccColorScale::remove(int index, bool autoUpdate/*=true*/)
 
 void ccColorScale::sort()
 {
-	qSort(m_steps.begin(), m_steps.end(), ccColorScaleElement::IsSmaller);
+	std::sort(m_steps.begin(), m_steps.end(), ccColorScaleElement::IsSmaller);
 }
 
 void ccColorScale::update()

--- a/qCC/ccColorScaleEditorWidget.cpp
+++ b/qCC/ccColorScaleEditorWidget.cpp
@@ -91,7 +91,7 @@ void ColorScaleElementSliders::addSlider(ColorScaleElementSlider* slider)
 
 void ColorScaleElementSliders::sort()
 {
-	qSort(begin(), end(), ColorScaleElementSlider::IsSmaller);
+	std::sort(begin(), end(), ColorScaleElementSlider::IsSmaller);
 }
 
 void ColorScaleElementSliders::clear()


### PR DESCRIPTION
Replace by std::sort