### PR TITLE
Remove unnecessary copy constructors and assignment operators

### DIFF
--- a/CC/include/CCGeom.h
+++ b/CC/include/CCGeom.h
@@ -53,9 +53,6 @@ public:
 
 	//! Constructor from an array of 4 elements
 	inline explicit Tuple4Tpl(const Type p[]) : x(p[0]), y(p[1]), z(p[2]), w(p[3]) {}
-	
-	//! Copy constructor
-	inline Tuple4Tpl(const Tuple4Tpl& v) : x(v.x), y(v.y), z(v.z), w(v.w) {}
 
 	//! Inverse operator
 	inline Tuple4Tpl operator - () const { Tuple4Tpl V(-x,-y,-z, -w); return V; }
@@ -104,9 +101,6 @@ public:
 
 	//! Constructor from an array of 3 elements
 	inline explicit Tuple3Tpl(const Type p[]) : x(p[0]),y(p[1]),z(p[2]) {}
-	
-	//! Copy constructor
-	inline Tuple3Tpl(const Tuple3Tpl& v) : x(v.x),y(v.y),z(v.z) {}
 
 	//! Inverse operator
 	inline Tuple3Tpl operator - () const { Tuple3Tpl V(-x,-y,-z); return V; }
@@ -161,9 +155,6 @@ public:
 
 	//! Constructor from an array of 3 elements
 	inline explicit Vector3Tpl(const Type p[]) : Tuple3Tpl<Type>(p) {}
-	
-	//! Copy constructor
-	inline Vector3Tpl(const Vector3Tpl& v) : Tuple3Tpl<Type>(v) {}
 
 	//! Constructor from an int array
 	static inline Vector3Tpl fromArray(const int a[3]) { return Vector3Tpl(static_cast<Type>(a[0]),static_cast<Type>(a[1]),static_cast<Type>(a[2])); }
@@ -209,8 +200,6 @@ public:
 	inline Vector3Tpl operator / (Type s) const { return Vector3Tpl(x/s, y/s, z/s); }
 	//! Cross product operator
 	inline Vector3Tpl operator * (const Vector3Tpl& v) const { return cross(v); }
-	//! Copy operator
-	inline Vector3Tpl& operator = (const Vector3Tpl &v) { x=v.x; y=v.y; z=v.z; return *this; }
 	//! Dot product operator
 	inline Type operator && (const Vector3Tpl &v) const { return dot(v); }
 	//! Direct coordinate access
@@ -289,9 +278,6 @@ public:
 	**/
 	inline Vector2Tpl(Type _x, Type _y) : x(_x), y(_y) {}
 
-	//! Copy constructor
-	inline Vector2Tpl(const Vector2Tpl& v) : x(v.x),y(v.y) {}
-
 	//! Returns vector square norm
 	inline Type norm2() const { return (x*x)+(y*y); }
 	//! Returns vector norm
@@ -324,8 +310,6 @@ public:
 	inline Vector2Tpl operator * (Type s) const {return Vector2Tpl(x*s, y*s);}
 	//! Division operator
 	inline Vector2Tpl operator / (Type s) const {return Vector2Tpl(x/s, y/s);}
-	//! Copy operator
-	inline Vector2Tpl& operator = (const Vector2Tpl &v) {x=v.x; y=v.y; return *this;}
 	//! Direct coordinate access
 	inline Type& operator [] (unsigned i) {return u[i];}
 	//! Direct coordinate access (const)

--- a/CC/include/PointProjectionTools.h
+++ b/CC/include/PointProjectionTools.h
@@ -151,8 +151,6 @@ public:
 		IndexedCCVector2(PointCoordinateType x, PointCoordinateType y, unsigned i) : CCVector2(x,y), index(i) {}
 		//! Copy constructor
 		IndexedCCVector2(const CCVector2& v) : CCVector2(v), index(0) {}
-		//! Copy constructor
-		IndexedCCVector2(const IndexedCCVector2& v) : CCVector2(v), index(v.index) {}
 
 		//! Point index
 		unsigned index;

--- a/CC/src/ManualSegmentationTools.cpp
+++ b/CC/src/ManualSegmentationTools.cpp
@@ -306,7 +306,6 @@ struct InsideOutsideIndexes
 {
 	InsideOutsideIndexes() : insideIndex(0), outsideIndex(0) {}
 	InsideOutsideIndexes(unsigned inside, unsigned outside) : insideIndex(inside), outsideIndex(outside) {}
-	InsideOutsideIndexes(const InsideOutsideIndexes& pmi) : insideIndex(pmi.insideIndex), outsideIndex(pmi.outsideIndex){}
 	unsigned insideIndex;
 	unsigned outsideIndex;
 };

--- a/CC/src/RegistrationTools.cpp
+++ b/CC/src/RegistrationTools.cpp
@@ -145,7 +145,7 @@ struct ModelCloud
 struct DataCloud
 {
 	DataCloud() : cloud(0), rotatedCloud(0), weights(0), CPSetRef(0), CPSetPlain(0) {}
-	DataCloud(const DataCloud& d) : cloud(d.cloud), rotatedCloud(d.rotatedCloud), weights(d.weights), CPSetRef(d.CPSetRef), CPSetPlain(d.CPSetPlain) {}
+	
 	ReferenceCloud* cloud;
 	SimpleCloud* rotatedCloud;
 	ScalarField* weights;

--- a/libs/qCC_db/ccBBox.cpp
+++ b/libs/qCC_db/ccBBox.cpp
@@ -32,12 +32,6 @@ ccBBox::ccBBox(const CCVector3& bbMinCorner, const CCVector3& bbMaxCorner)
 	, m_valid(true)
 {}
 
-ccBBox::ccBBox(const ccBBox& aBox)
-	: m_bbMin(aBox.m_bbMin)
-	, m_bbMax(aBox.m_bbMax)
-	, m_valid(aBox.m_valid)
-{}
-
 void ccBBox::clear()
 {
 	m_bbMin = m_bbMax = CCVector3(0,0,0);

--- a/libs/qCC_db/ccBBox.h
+++ b/libs/qCC_db/ccBBox.h
@@ -34,8 +34,6 @@ public:
 
 	//! Default constructor
 	ccBBox();
-	//! Copy constructor
-	ccBBox(const ccBBox& aBBox);
 	//! Constructor from two vectors (lower min. and upper max. corners)
 	ccBBox(const CCVector3& bbMinCorner, const CCVector3& bbMaxCorner);
 

--- a/libs/qCC_db/ccColorTypes.h
+++ b/libs/qCC_db/ccColorTypes.h
@@ -57,9 +57,6 @@ namespace ccColor
 
 		//! Constructor from an array of 3 values
 		explicit inline RgbTpl(const Type col[3]) : r(col[0]), g(col[1]), b(col[2]) {}
-	
-		//! Copy constructor
-		inline RgbTpl(const RgbTpl& c) : r(c.r), g(c.g), b(c.b) {}
 
 		//! Comparison operator
 		inline bool operator != (const RgbTpl<Type>& t) const { return (r != t.r || g != t.g || b != t.b); }
@@ -100,8 +97,6 @@ namespace ccColor
 		//! RgbaTpl from an array of 3 values and a transparency value
 		explicit inline RgbaTpl(const Type col[3], Type alpha) : r(col[0]), g(col[1]), b(col[2]), a(alpha) {}
 	
-		//! Copy constructor
-		inline RgbaTpl(const RgbaTpl<Type>& c) : r(c.r), g(c.g), b(c.b), a(c.a) {}
 		//! Copy constructor
 		inline RgbaTpl(const RgbTpl<Type>& c, Type alpha) : r(c.r), g(c.g), b(c.b), a(alpha) {}
 


### PR DESCRIPTION
In all these cases, the implicit methods are sufficient.