### PR TITLE
Use lambdas for repetitive slot methods 

### DIFF
--- a/plugins/ccMainAppInterface.h
+++ b/plugins/ccMainAppInterface.h
@@ -174,15 +174,6 @@ public:
 	virtual ccPickingHub* pickingHub() { return nullptr; }
 
 	//other useful methods
-	virtual void setFrontView() = 0;
-	virtual void setBottomView() = 0;
-	virtual void setTopView() = 0;
-	virtual void setBackView() = 0;
-	virtual void setLeftView() = 0;
-	virtual void setRightView() = 0;
-	virtual void setIsoView1() = 0;
-	virtual void setIsoView2() = 0;
-
 	virtual void toggleActiveWindowCenteredPerspective() = 0;
 	virtual void toggleActiveWindowCustomLight() = 0;
 	virtual void toggleActiveWindowSunLight() = 0;

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -705,7 +705,6 @@ void MainWindow::connectActions()
 	connect(actionOpenColorScalesManager,		SIGNAL(triggered()),	this,		SLOT(doActionOpenColorScalesManager()));
 	connect(actionAddIdField,					SIGNAL(triggered()),	this,		SLOT(doActionAddIdField()));
 	connect(actionSetSFAsCoord,					SIGNAL(triggered()),	this,		SLOT(doActionSetSFAsCoord()));
-	connect(actionDeleteAllSF,					SIGNAL(triggered()),	this,		SLOT(doActionDeleteAllSF()));
 	connect(actionInterpolateSFs,				SIGNAL(triggered()),	this,		SLOT(doActionInterpolateScalarFields()));
 	connect(actionDeleteScalarField, &QAction::triggered, [=]() {
 		clearSelectedEntitiesProperty( ccEntityAction::CLEAR_PROPERTY::CURRENT_SCALAR_FIELD );

--- a/qCC/mainwindow.h
+++ b/qCC/mainwindow.h
@@ -19,6 +19,8 @@
 #define CC_MAIN_WINDOW_HEADER
 
 //Local
+#include "ccEntityAction.h"
+#include "ccGLUtils.h"
 #include "ccPickingListener.h"
 
 //qCC_plugins
@@ -241,14 +243,6 @@ protected slots:
 	virtual void disableAll() override;
 	virtual void disableAllBut(ccGLWindow* win) override;
 	virtual void updateUI() override;
-	virtual void setFrontView() override;
-	virtual void setBottomView() override;
-	virtual void setTopView() override;
-	virtual void setBackView() override;
-	virtual void setLeftView() override;
-	virtual void setRightView() override;
-	virtual void setIsoView1() override;
-	virtual void setIsoView2() override;
 	
 	virtual void toggleActiveWindowStereoVision(bool);
 	virtual void toggleActiveWindowCenteredPerspective() override;
@@ -294,14 +288,6 @@ protected slots:
 	void echoCameraPosChanged(const CCVector3d&);
 	void echoPivotPointChanged(const CCVector3d&);
 	void echoPixelSizeChanged(float);
-
-	void toggleSelectedEntitiesActivation();
-	void toggleSelectedEntitiesVisibility();
-	void toggleSelectedEntitiesNormals();
-	void toggleSelectedEntitiesColors();
-	void toggleSelectedEntitiesSF();
-	void toggleSelectedEntities3DName();
-	void toggleSelectedEntitiesMaterials();
 
 	void doActionRenderToFile();
 
@@ -369,16 +355,13 @@ protected slots:
 	void doActionEditPlane();
 
 	void doActionDeleteScanGrids();
-	void doActionDeleteScalarField();
 	void doActionSmoothMeshSF();
 	void doActionEnhanceMeshSF();
 	void doActionAddConstantSF();
 	void doActionScalarFieldArithmetic();
 	void doActionScalarFieldFromColor();
-	void doActionClearColor();
 	void doActionOrientNormalsFM();
 	void doActionOrientNormalsMST();
-	void doActionClearNormals();
 	void doActionResampleWithOctree();
 	void doActionComputeMeshAA();
 	void doActionComputeMeshLS();
@@ -391,7 +374,6 @@ protected slots:
 	void doActionSmoothMeshLaplacian();
 	void doActionSubdivideMesh();
 	void doActionComputeCPS();
-	void doActionDeleteAllSF();
 	void doActionShowWaveDialog();
 	void doActionCompressFWFData();
 	void doActionKMeans();
@@ -490,7 +472,11 @@ protected slots:
 	void doActionCreateCloudFromEntCenters();
 
 protected:
-
+	void	toggleSelectedEntitiesProperty( ccEntityAction::TOGGLE_PROPERTY property );
+	void	clearSelectedEntitiesProperty( ccEntityAction::CLEAR_PROPERTY property );
+	
+	void	setView( CC_VIEW_ORIENTATION view );
+	
 	//! Apply transformation to the selected entities
 	void applyTransformation(const ccGLMatrixd& transMat);
 


### PR DESCRIPTION
…when the only difference is one parameter

  - toggling selected item properties
  - clearing selected item properties
  - setting the camera view

Also removed unused pure virtual methods for setting each camera view in `ccMainAppInterface` - they don't seem to be used anywhere.