### PR TITLE
Use system locale to format number of points in several places

### DIFF
--- a/libs/qCC_db/ccGBLSensor.cpp
+++ b/libs/qCC_db/ccGBLSensor.cpp
@@ -682,7 +682,7 @@ bool ccGBLSensor::computeDepthBuffer(CCLib::GenericCloud* theCloud, int& errorCo
 			ccProgressDialog pdlg(true);
 			CCLib::NormalizedProgress nprogress(&pdlg,pointCount);
 			pdlg.setMethodTitle(QObject::tr("Depth buffer"));
-			pdlg.setInfo(QObject::tr("Points: %1").arg(pointCount));
+			pdlg.setInfo(QObject::tr("Points: %1").arg( QLocale::system().toString( pointCount ) ));
 			pdlg.start();
 			QCoreApplication::processEvents();
 

--- a/libs/qCC_db/ccGBLSensor.cpp
+++ b/libs/qCC_db/ccGBLSensor.cpp
@@ -682,7 +682,7 @@ bool ccGBLSensor::computeDepthBuffer(CCLib::GenericCloud* theCloud, int& errorCo
 			ccProgressDialog pdlg(true);
 			CCLib::NormalizedProgress nprogress(&pdlg,pointCount);
 			pdlg.setMethodTitle(QObject::tr("Depth buffer"));
-			pdlg.setInfo(QObject::tr("Points: %1").arg( QLocale::system().toString( pointCount ) ));
+			pdlg.setInfo(QObject::tr("Points: %L1").arg( pointCount ));
 			pdlg.start();
 			QCoreApplication::processEvents();
 

--- a/libs/qCC_db/ccPointCloud.cpp
+++ b/libs/qCC_db/ccPointCloud.cpp
@@ -5093,7 +5093,7 @@ bool ccPointCloud::computeNormalsWithGrids(	CC_LOCAL_MODEL_TYPES localModel,
 	if (pDlg)
 	{
 		pDlg->setWindowTitle(QObject::tr("Normals computation"));
-		pDlg->setLabelText(QObject::tr("Points: ") + QString::number(pointCount));
+		pDlg->setLabelText(QObject::tr("Points: %1").arg( QLocale::system().toString( pointCount ) ) );
 		pDlg->setRange(0, static_cast<int>(pointCount));
 		pDlg->show();
 		QCoreApplication::processEvents();
@@ -5300,7 +5300,7 @@ bool ccPointCloud::orientNormalsWithGrids(ccProgressDialog* pDlg/*=0*/)
 	if (pDlg)
 	{
 		pDlg->setWindowTitle(QObject::tr("Orienting normals"));
-		pDlg->setLabelText(QObject::tr("Points: ") + QString::number(pointCount));
+		pDlg->setLabelText(QObject::tr("Points: %1").arg( QLocale::system().toString( pointCount ) ) );
 		pDlg->setRange(0, static_cast<int>(pointCount));
 		pDlg->show();
 		QCoreApplication::processEvents();

--- a/libs/qCC_db/ccPointCloud.cpp
+++ b/libs/qCC_db/ccPointCloud.cpp
@@ -5093,7 +5093,7 @@ bool ccPointCloud::computeNormalsWithGrids(	CC_LOCAL_MODEL_TYPES localModel,
 	if (pDlg)
 	{
 		pDlg->setWindowTitle(QObject::tr("Normals computation"));
-		pDlg->setLabelText(QObject::tr("Points: %1").arg( QLocale::system().toString( pointCount ) ) );
+		pDlg->setLabelText(QObject::tr("Points: %L1").arg( pointCount ) );
 		pDlg->setRange(0, static_cast<int>(pointCount));
 		pDlg->show();
 		QCoreApplication::processEvents();
@@ -5300,7 +5300,7 @@ bool ccPointCloud::orientNormalsWithGrids(ccProgressDialog* pDlg/*=0*/)
 	if (pDlg)
 	{
 		pDlg->setWindowTitle(QObject::tr("Orienting normals"));
-		pDlg->setLabelText(QObject::tr("Points: %1").arg( QLocale::system().toString( pointCount ) ) );
+		pDlg->setLabelText(QObject::tr("Points: %L1").arg( pointCount ) );
 		pDlg->setRange(0, static_cast<int>(pointCount));
 		pDlg->show();
 		QCoreApplication::processEvents();

--- a/libs/qCC_db/ccRasterGrid.cpp
+++ b/libs/qCC_db/ccRasterGrid.cpp
@@ -216,7 +216,7 @@ bool ccRasterGrid::fillWith(	ccGenericPointCloud* cloud,
 	if (progressDialog)
 	{
 		progressDialog->setMethodTitle(QObject::tr("Grid generation"));
-		progressDialog->setInfo(QObject::tr("Points: %1\nCells: %2 x %3").arg(pointCount).arg(width).arg(height));
+		progressDialog->setInfo(QObject::tr("Points: %1\nCells: %2 x %3").arg( QLocale::system().toString( pointCount ) ).arg(width).arg(height));
 		progressDialog->start();
 		progressDialog->show();
 		QCoreApplication::processEvents();

--- a/libs/qCC_db/ccRasterGrid.cpp
+++ b/libs/qCC_db/ccRasterGrid.cpp
@@ -216,7 +216,7 @@ bool ccRasterGrid::fillWith(	ccGenericPointCloud* cloud,
 	if (progressDialog)
 	{
 		progressDialog->setMethodTitle(QObject::tr("Grid generation"));
-		progressDialog->setInfo(QObject::tr("Points: %1\nCells: %2 x %3").arg( QLocale::system().toString( pointCount ) ).arg(width).arg(height));
+		progressDialog->setInfo(QObject::tr("Points: %L1\nCells: %L2 x %L3").arg( pointCount ).arg(width).arg(height));
 		progressDialog->start();
 		progressDialog->show();
 		QCoreApplication::processEvents();

--- a/libs/qCC_io/LASFilter.cpp
+++ b/libs/qCC_io/LASFilter.cpp
@@ -386,7 +386,7 @@ CC_FILE_ERROR LASFilter::saveToFile(ccHObject* entity, QString filename, SavePar
 	{
 		pDlg.reset(new ccProgressDialog(true, parameters.parentWidget)); //cancel available
 		pDlg->setMethodTitle(QObject::tr("Save LAS file"));
-		pDlg->setInfo(QObject::tr("Points: %1").arg(numberOfPoints));
+		pDlg->setInfo(QObject::tr("Points: %1").arg( QLocale::system().toString( numberOfPoints ) ));
 		pDlg->start();
 	}
 	CCLib::NormalizedProgress nProgress(pDlg.data(), numberOfPoints);
@@ -865,7 +865,7 @@ CC_FILE_ERROR LASFilter::loadFile(QString filename, ccHObject& container, LoadPa
 		{
 			pDlg.reset(new ccProgressDialog(true, parameters.parentWidget)); //cancel available
 			pDlg->setMethodTitle(QObject::tr("Open LAS file"));
-			pDlg->setInfo(QObject::tr("Points: %1").arg(nbOfPoints));
+			pDlg->setInfo(QObject::tr("Points: %1").arg( QLocale::system().toString( nbOfPoints ) ));
 			pDlg->start();
 		}
 		CCLib::NormalizedProgress nProgress(pDlg.data(), nbOfPoints);

--- a/libs/qCC_io/LASFilter.cpp
+++ b/libs/qCC_io/LASFilter.cpp
@@ -386,7 +386,7 @@ CC_FILE_ERROR LASFilter::saveToFile(ccHObject* entity, QString filename, SavePar
 	{
 		pDlg.reset(new ccProgressDialog(true, parameters.parentWidget)); //cancel available
 		pDlg->setMethodTitle(QObject::tr("Save LAS file"));
-		pDlg->setInfo(QObject::tr("Points: %1").arg( QLocale::system().toString( numberOfPoints ) ));
+		pDlg->setInfo(QObject::tr("Points: %L1").arg( numberOfPoints ));
 		pDlg->start();
 	}
 	CCLib::NormalizedProgress nProgress(pDlg.data(), numberOfPoints);
@@ -865,7 +865,7 @@ CC_FILE_ERROR LASFilter::loadFile(QString filename, ccHObject& container, LoadPa
 		{
 			pDlg.reset(new ccProgressDialog(true, parameters.parentWidget)); //cancel available
 			pDlg->setMethodTitle(QObject::tr("Open LAS file"));
-			pDlg->setInfo(QObject::tr("Points: %1").arg( QLocale::system().toString( nbOfPoints ) ));
+			pDlg->setInfo(QObject::tr("Points: %L1").arg( nbOfPoints ));
 			pDlg->start();
 		}
 		CCLib::NormalizedProgress nProgress(pDlg.data(), nbOfPoints);

--- a/libs/qCC_io/LASOpenDlg.cpp
+++ b/libs/qCC_io/LASOpenDlg.cpp
@@ -173,7 +173,7 @@ void LASOpenDlg::setInfos(	QString filename,
 	outputPathLineEdit->setText(QFileInfo(filename).absolutePath());
 
 	//number of points
-	pointCountLineEdit->setText(QLocale(QLocale::English).toString(pointCount));
+	pointCountLineEdit->setText(QLocale::system().toString(pointCount));
 
 	//bounding-box
 	bbTextEdit->setText(QString("X = [%1 ; %2]\nY = [%3 ; %4]\nZ = [%5 ; %6]")

--- a/libs/qCC_io/LASOpenDlg.cpp
+++ b/libs/qCC_io/LASOpenDlg.cpp
@@ -173,7 +173,7 @@ void LASOpenDlg::setInfos(	QString filename,
 	outputPathLineEdit->setText(QFileInfo(filename).absolutePath());
 
 	//number of points
-	pointCountLineEdit->setText(QLocale::system().toString(pointCount));
+	pointCountLineEdit->setText(QLocale().toString(pointCount));
 
 	//bounding-box
 	bbTextEdit->setText(QString("X = [%1 ; %2]\nY = [%3 ; %4]\nZ = [%5 ; %6]")

--- a/libs/qCC_io/PNFilter.cpp
+++ b/libs/qCC_io/PNFilter.cpp
@@ -86,7 +86,7 @@ CC_FILE_ERROR PNFilter::saveToFile(ccHObject* entity, QString filename, SavePara
 	{
 		pDlg.reset(new ccProgressDialog(true, parameters.parentWidget)); //cancel available
 		pDlg->setMethodTitle(QObject::tr("Save PN file"));
-		pDlg->setInfo(QObject::tr("Points: %1").arg(numberOfPoints));
+		pDlg->setInfo(QObject::tr("Points: %1").arg( QLocale::system().toString( numberOfPoints ) ));
 		pDlg->start();
 	}
 	CCLib::NormalizedProgress nprogress(pDlg.data(), numberOfPoints);
@@ -158,7 +158,7 @@ CC_FILE_ERROR PNFilter::loadFile(QString filename, ccHObject& container, LoadPar
 	{
 		pDlg.reset(new ccProgressDialog(true, parameters.parentWidget)); //cancel available
 		pDlg->setMethodTitle(QObject::tr("Open PN file"));
-		pDlg->setInfo(QObject::tr("Points: %1").arg(numberOfPoints));
+		pDlg->setInfo(QObject::tr("Points: %1").arg( QLocale::system().toString( numberOfPoints ) ));
 		pDlg->start();
 	}
 	CCLib::NormalizedProgress nprogress(pDlg.data(), numberOfPoints);

--- a/libs/qCC_io/PNFilter.cpp
+++ b/libs/qCC_io/PNFilter.cpp
@@ -86,7 +86,7 @@ CC_FILE_ERROR PNFilter::saveToFile(ccHObject* entity, QString filename, SavePara
 	{
 		pDlg.reset(new ccProgressDialog(true, parameters.parentWidget)); //cancel available
 		pDlg->setMethodTitle(QObject::tr("Save PN file"));
-		pDlg->setInfo(QObject::tr("Points: %1").arg( QLocale::system().toString( numberOfPoints ) ));
+		pDlg->setInfo(QObject::tr("Points: %L1").arg( numberOfPoints ));
 		pDlg->start();
 	}
 	CCLib::NormalizedProgress nprogress(pDlg.data(), numberOfPoints);
@@ -158,7 +158,7 @@ CC_FILE_ERROR PNFilter::loadFile(QString filename, ccHObject& container, LoadPar
 	{
 		pDlg.reset(new ccProgressDialog(true, parameters.parentWidget)); //cancel available
 		pDlg->setMethodTitle(QObject::tr("Open PN file"));
-		pDlg->setInfo(QObject::tr("Points: %1").arg( QLocale::system().toString( numberOfPoints ) ));
+		pDlg->setInfo(QObject::tr("Points: %L1").arg( numberOfPoints ));
 		pDlg->start();
 	}
 	CCLib::NormalizedProgress nprogress(pDlg.data(), numberOfPoints);

--- a/libs/qCC_io/PVFilter.cpp
+++ b/libs/qCC_io/PVFilter.cpp
@@ -91,7 +91,7 @@ CC_FILE_ERROR PVFilter::saveToFile(ccHObject* entity, QString filename, SavePara
 	{
 		pDlg.reset(new ccProgressDialog(true, parameters.parentWidget)); //cancel available
 		pDlg->setMethodTitle(QObject::tr("Save PV file"));
-		pDlg->setInfo(QObject::tr("Points: %1").arg(numberOfPoints));
+		pDlg->setInfo(QObject::tr("Points: %1").arg( QLocale::system().toString( numberOfPoints ) ));
 		pDlg->start();
 	}
 	CCLib::NormalizedProgress nprogress(pDlg.data(), numberOfPoints);
@@ -157,7 +157,7 @@ CC_FILE_ERROR PVFilter::loadFile(QString filename, ccHObject& container, LoadPar
 	{
 		pDlg.reset(new ccProgressDialog(true, parameters.parentWidget)); //cancel available
 		pDlg->setMethodTitle(QObject::tr("Open PV file"));
-		pDlg->setInfo(QObject::tr("Points: %1").arg(numberOfPoints));
+		pDlg->setInfo(QObject::tr("Points: %1").arg( QLocale::system().toString( numberOfPoints ) ));
 		pDlg->start();
 	}
 	CCLib::NormalizedProgress nprogress(pDlg.data(), numberOfPoints);

--- a/libs/qCC_io/PVFilter.cpp
+++ b/libs/qCC_io/PVFilter.cpp
@@ -91,7 +91,7 @@ CC_FILE_ERROR PVFilter::saveToFile(ccHObject* entity, QString filename, SavePara
 	{
 		pDlg.reset(new ccProgressDialog(true, parameters.parentWidget)); //cancel available
 		pDlg->setMethodTitle(QObject::tr("Save PV file"));
-		pDlg->setInfo(QObject::tr("Points: %1").arg( QLocale::system().toString( numberOfPoints ) ));
+		pDlg->setInfo(QObject::tr("Points: %L1").arg( numberOfPoints ));
 		pDlg->start();
 	}
 	CCLib::NormalizedProgress nprogress(pDlg.data(), numberOfPoints);
@@ -157,7 +157,7 @@ CC_FILE_ERROR PVFilter::loadFile(QString filename, ccHObject& container, LoadPar
 	{
 		pDlg.reset(new ccProgressDialog(true, parameters.parentWidget)); //cancel available
 		pDlg->setMethodTitle(QObject::tr("Open PV file"));
-		pDlg->setInfo(QObject::tr("Points: %1").arg( QLocale::system().toString( numberOfPoints ) ));
+		pDlg->setInfo(QObject::tr("Points: %L1").arg( numberOfPoints ));
 		pDlg->start();
 	}
 	CCLib::NormalizedProgress nprogress(pDlg.data(), numberOfPoints);

--- a/qCC/ccClippingBoxTool.cpp
+++ b/qCC/ccClippingBoxTool.cpp
@@ -613,7 +613,7 @@ bool ccClippingBoxTool::ExtractSlicesAndContours
 
 				if (progressDialog)
 				{
-					progressDialog->setWindowTitle(QObject::tr("Preparing extraction"));
+					progressDialog->setWindowTitle(tr("Preparing extraction"));
 					progressDialog->start();
 					progressDialog->show();
 					progressDialog->setAutoClose(false);
@@ -627,8 +627,8 @@ bool ccClippingBoxTool::ExtractSlicesAndContours
 					ccGenericPointCloud* cloud = clouds[ci];
 					unsigned pointCount = cloud->size();
 
-					QString infos = QObject::tr("Cloud '%1").arg(cloud->getName());
-					infos += QObject::tr("Points: %1").arg(pointCount);
+					QString infos = tr("Cloud '%1").arg(cloud->getName());
+					infos += tr("Points: %1").arg( QLocale::system().toString( pointCount ));
 					if (progressDialog)
 					{
 						progressDialog->setInfo(infos);

--- a/qCC/ccClippingBoxTool.cpp
+++ b/qCC/ccClippingBoxTool.cpp
@@ -628,7 +628,7 @@ bool ccClippingBoxTool::ExtractSlicesAndContours
 					unsigned pointCount = cloud->size();
 
 					QString infos = tr("Cloud '%1").arg(cloud->getName());
-					infos += tr("Points: %1").arg( QLocale::system().toString( pointCount ));
+					infos += tr("Points: %L1").arg( pointCount );
 					if (progressDialog)
 					{
 						progressDialog->setInfo(infos);
@@ -684,7 +684,7 @@ bool ccClippingBoxTool::ExtractSlicesAndContours
 				if (progressDialog)
 				{
 					progressDialog->setWindowTitle(QObject::tr("Section extraction"));
-					progressDialog->setInfo(QObject::tr("Section(s): %1").arg(subCloudsCount));
+					progressDialog->setInfo(QObject::tr("Section(s): %L1").arg(subCloudsCount));
 					progressDialog->setMaximum(static_cast<int>(subCloudsCount));
 					progressDialog->setValue(0);
 					QApplication::processEvents();
@@ -888,7 +888,7 @@ bool ccClippingBoxTool::ExtractSlicesAndContours
 			if (progressDialog)
 			{
 				progressDialog->setWindowTitle("Contour extraction");
-				progressDialog->setInfo(QObject::tr("Contour(s): %1").arg(cloudSliceCount));
+				progressDialog->setInfo(QObject::tr("Contour(s): %L1").arg(cloudSliceCount));
 				progressDialog->setMaximum(static_cast<int>(cloudSliceCount));
 				if (!visualDebugMode)
 				{

--- a/qCC/db_tree/ccDBRoot.cpp
+++ b/qCC/db_tree/ccDBRoot.cpp
@@ -1559,33 +1559,33 @@ void ccDBRoot::gatherRecursiveInformation()
 	//output information
 	{
 		QStringList infoStr;
-		QLocale locale(QLocale::English);
-		QString separator("--------------------------");
 
-		infoStr << QString("Point(s):\t\t%1").arg(locale.toString(info.pointCount));
-		infoStr << QString("Triangle(s):\t\t%1").arg(locale.toString(info.triangleCount));
+		const QString separator("--------------------------");
+
+		infoStr << QString("Point(s):\t\t%L1").arg(info.pointCount);
+		infoStr << QString("Triangle(s):\t\t%L1").arg(info.triangleCount);
 
 		infoStr << separator;
 		if (info.colorCount)
-			infoStr << QString("Color(s):\t\t%1").arg(locale.toString(info.colorCount));
+			infoStr << QString("Color(s):\t\t%L1").arg(info.colorCount);
 		if (info.normalCount)
-			infoStr << QString("Normal(s):\t\t%1").arg(locale.toString(info.normalCount));
+			infoStr << QString("Normal(s):\t\t%L1").arg(info.normalCount);
 		if (info.scalarFieldCount)
-			infoStr << QString("Scalar field(s):\t\t%1").arg(locale.toString(info.scalarFieldCount));
+			infoStr << QString("Scalar field(s):\t\t%L1").arg(info.scalarFieldCount);
 		if (info.materialCount)
-			infoStr << QString("Material(s):\t\t%1").arg(locale.toString(info.materialCount));
+			infoStr << QString("Material(s):\t\t%L1").arg(info.materialCount);
 
 		infoStr << separator;
-		infoStr << QString("Cloud(s):\t\t%1").arg(locale.toString(info.cloudCount));
-		infoStr << QString("Mesh(es):\t\t%1").arg(locale.toString(info.meshCount));
+		infoStr << QString("Cloud(s):\t\t%L1").arg(info.cloudCount);
+		infoStr << QString("Mesh(es):\t\t%L1").arg(info.meshCount);
 		if (info.octreeCount)
-			infoStr << QString("Octree(s):\t\t%1").arg(locale.toString(info.octreeCount));
+			infoStr << QString("Octree(s):\t\t%L1").arg(info.octreeCount);
 		if (info.imageCount)
-			infoStr << QString("Image(s):\t\t%1").arg(locale.toString(info.imageCount));
+			infoStr << QString("Image(s):\t\t%L1").arg(info.imageCount);
 		if (info.labelCount)
-			infoStr << QString("Label(s):\t\t%1").arg(locale.toString(info.labelCount));
+			infoStr << QString("Label(s):\t\t%L1").arg(info.labelCount);
 		if (info.sensorCount)
-			infoStr << QString("Sensor(s):\t\t%1").arg(locale.toString(info.sensorCount));
+			infoStr << QString("Sensor(s):\t\t%L1").arg(info.sensorCount);
 
 		//display info box
 		QMessageBox::information(MainWindow::TheInstance(),

--- a/qCC/main.cpp
+++ b/qCC/main.cpp
@@ -133,13 +133,11 @@ int main(int argc, char **argv)
 	//Locale management
 	{
 		//Force 'english' locale so as to get a consistent behavior everywhere
-		QLocale locale = QLocale(QLocale::English);
-		locale.setNumberOptions(QLocale::c().numberOptions());
-		QLocale::setDefault(locale);
+		QLocale::setDefault( QLocale( QLocale::English ) );
 
 #ifdef Q_OS_UNIX
 		//We reset the numeric locale for POSIX functions
-		//See http://qt-project.org/doc/qt-5/qcoreapplication.html#locale-settings
+		//See https://doc.qt.io/qt-5/qcoreapplication.html#locale-settings
 		setlocale(LC_NUMERIC, "C");
 #endif
 	}

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -2629,7 +2629,7 @@ void MainWindow::doActionComputePointsVisibility()
 		ccProgressDialog pdlg(true);
 		CCLib::NormalizedProgress nprogress(&pdlg,pointCloud->size());
 		pdlg.setMethodTitle(tr("Compute visibility"));
-		pdlg.setInfo(tr("Points: %1").arg( QLocale::system().toString( pointCloud->size() ) ));
+		pdlg.setInfo(tr("Points: %L1").arg( pointCloud->size() ));
 		pdlg.start();
 		QApplication::processEvents();
 

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -2629,7 +2629,7 @@ void MainWindow::doActionComputePointsVisibility()
 		ccProgressDialog pdlg(true);
 		CCLib::NormalizedProgress nprogress(&pdlg,pointCloud->size());
 		pdlg.setMethodTitle(tr("Compute visibility"));
-		pdlg.setInfo(tr("Points: %1").arg(pointCloud->size()));
+		pdlg.setInfo(tr("Points: %1").arg( QLocale::system().toString( pointCloud->size() ) ));
 		pdlg.start();
 		QApplication::processEvents();
 


### PR DESCRIPTION
I seem to recall we went back-and-forth on some QLocale problems and I see that `QLocale(QLocale::English)` is used in several paces.

I've used `QLocale::system()` - if it's a problem we can switch this to `QLocale::English`, but it would be better if we could handle it properly for everyone instead of forcing English.

Fixes #559