### PR TITLE
Fix GenericChunkedArray::reserve() under 64-bit environments.

### DIFF
--- a/CC/include/GenericChunkedArray.h
+++ b/CC/include/GenericChunkedArray.h
@@ -231,15 +231,17 @@ public:
 #ifdef CC_ENV_64
 		try
 		{
-			m_data.resize(capacity * N);
+			if (m_capacity < capacity)
+			{
+				m_data.resize(capacity * N);
+				m_capacity = capacity;
+			}
 		}
 		catch (const std::bad_alloc&)
 		{
 			//not enough memory
 			return false;
 		}
-
-		m_capacity = capacity;
 #else
 		while (m_capacity < capacity)
 		{
@@ -889,15 +891,17 @@ public:
 #ifdef CC_ENV_64
 		try
 		{
-			m_data.resize(capacity);
+			if (m_capacity < capacity)
+			{
+				m_data.resize(capacity);
+				m_capacity = capacity;
+			}
 		}
 		catch (const std::bad_alloc&)
 		{
 			//not enough memory
 			return false;
 		}
-
-		m_capacity = capacity;
 #else
 		while (m_capacity < capacity)
 		{


### PR DESCRIPTION
According to comments: "If the new number of elements is smaller than the actual one,
nothing happens." However currently under 64-bit environments reserve() will actually shrink
the array, which causes loss of data.