### PR TITLE
Calculate normals with adaptive radius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ v2.9.alpha - XX/XX/XXXX
 	* Normal computation tools:
 		- new algorithm to compute the normals based on scan grids (faster, and more robust)
 		- the 'kernel size' parameter is replaced by 'the minimum angle of triangles' used in the internal triangulation process
+		- Plane and Quadric mode increase the radius adaptively to reach minimum number of points
 
 	* Other
 		- color scales are now listed in alphabetical order

--- a/libs/qCC_db/ccNormalVectors.cpp
+++ b/libs/qCC_db/ccNormalVectors.cpp
@@ -698,6 +698,12 @@ bool ccNormalVectors::ComputeNormsAtLevelWithQuadric(	const CCLib::DgmOctree::oc
 
 		//warning: there may be more points at the end of nNSS.pointsInNeighbourhood than the actual nearest neighbors (k)!
 		unsigned k = cell.parentOctree->findNeighborsInASphereStartingFromCell(nNSS, radius, false);
+		float cur_radius = radius;
+		while (k < NUMBER_OF_POINTS_FOR_NORM_WITH_QUADRIC && cur_radius < 16*radius)
+		{
+			cur_radius *= 1.189207115f;
+			k = cell.parentOctree->findNeighborsInASphereStartingFromCell(nNSS, cur_radius, false);
+		}
 		if (k >= NUMBER_OF_POINTS_FOR_NORM_WITH_QUADRIC)
 		{
 			CCLib::DgmOctreeReferenceCloud neighbours(&nNSS.pointsInNeighbourhood, k);
@@ -749,6 +755,12 @@ bool ccNormalVectors::ComputeNormsAtLevelWithLS(const CCLib::DgmOctree::octreeCe
 
 		//warning: there may be more points at the end of nNSS.pointsInNeighbourhood than the actual nearest neighbors (k)!
 		unsigned k = cell.parentOctree->findNeighborsInASphereStartingFromCell(nNSS, radius, false);
+		float cur_radius = radius;
+		while (k < NUMBER_OF_POINTS_FOR_NORM_WITH_LS && cur_radius < 16*radius)
+		{
+			cur_radius *= 1.189207115f;
+			k = cell.parentOctree->findNeighborsInASphereStartingFromCell(nNSS, cur_radius, false);
+		}
 		if (k >= NUMBER_OF_POINTS_FOR_NORM_WITH_LS)
 		{
 			CCLib::DgmOctreeReferenceCloud neighbours(&nNSS.pointsInNeighbourhood, k);


### PR DESCRIPTION
## Old Behavior
After normal calculation with a certain radius the points with too little neighbors within this radius don't get a normal.

## New Behavior
The search radius is increased on a point by point base to be able to compute normals also for points that are more sparse than average.
The values are now hard coded to find the minimum number of points within 16 times the given radius. (3 for plane/ls and 6 for quadric)
The maximum radius could also be turned into an option if people prefer that.