### PR TITLE
Use cmath instead of math.h

### DIFF
--- a/CC/include/CCConst.h
+++ b/CC/include/CCConst.h
@@ -23,8 +23,8 @@
 
 //system
 #include <cfloat>
+#include <cmath>
 #include <limits>
-#include <math.h>
 
 //! Pi
 #ifndef M_PI

--- a/CC/include/CCGeom.h
+++ b/CC/include/CCGeom.h
@@ -24,7 +24,7 @@
 #include "CCTypes.h"
 
 //system
-#include <math.h> //for sqrt, fabs
+#include <cmath>
 
 //! 4-Tuple structure (templated version)
 template <class Type> class Tuple4Tpl
@@ -172,11 +172,11 @@ public:
 	//! Returns vector square norm (forces double precision output)
 	inline double norm2d() const { return static_cast<double>(x)*x + static_cast<double>(y)*y + static_cast<double>(z)*z; }
 	//! Returns vector norm
-	inline Type norm() const { return static_cast<Type>(sqrt(norm2d())); }
+	inline Type norm() const { return static_cast<Type>(std::sqrt(norm2d())); }
 	//! Returns vector norm (forces double precision output)
-	inline double normd() const { return sqrt(norm2d()); }
+	inline double normd() const { return std::sqrt(norm2d()); }
 	//! Sets vector norm to unity
-	inline void normalize() { double n = norm2d(); if (n>0) *this /= static_cast<Type>(sqrt(n)); }
+	inline void normalize() { double n = norm2d(); if (n>0) *this /= static_cast<Type>(std::sqrt(n)); }
 	//! Returns a normalized vector which is orthogonal to this one
 	inline Vector3Tpl orthogonal() const { Vector3Tpl ort; vorthogonal(u, ort.u); return ort; }
 
@@ -221,19 +221,19 @@ public:
 	static inline void vsubstract(const Type p[], const Type q[], Type r[]) {r[0]=p[0]-q[0]; r[1]=p[1]-q[1]; r[2]=p[2]-q[2];}
 	static inline void vcombination(Type a, const Type p[], Type b, const Type q[], Type r[]) {r[0]=(a*p[0])+(b*q[0]); r[1]=(a*p[1])+(b*q[1]); r[2]=(a*p[2])+(b*q[2]);}
 	static inline void vcombination(const Type p[], Type b, const Type q[], Type r[]) {r[0]=p[0]+(b*q[0]); r[1]=p[1]+(b*q[1]); r[2]=p[2]+(b*q[2]);}
-	static inline void vnormalize(Type p[]) {Type n = vnorm2(p); if (n>0) vdivide(p, sqrt(n));}
+	static inline void vnormalize(Type p[]) {Type n = vnorm2(p); if (n>0) vdivide(p, std::sqrt(n));}
 	static inline Type vnorm2(const Type p[]) {return (p[0]*p[0])+(p[1]*p[1])+(p[2]*p[2]);}
 	static inline Type vdistance2(const Type p[], const Type q[]) {return ((p[0]-q[0])*(p[0]-q[0]))+((p[1]-q[1])*(p[1]-q[1]))+((p[2]-q[2])*(p[2]-q[2]));}
-	static inline Type vnorm(const Type p[]) {return sqrt(vnorm2(p));}
-	static inline Type vdistance(const Type p[], const Type q[]) {return sqrt(vdistance2(p, q));}
+	static inline Type vnorm(const Type p[]) {return std::sqrt(vnorm2(p));}
+	static inline Type vdistance(const Type p[], const Type q[]) {return std::sqrt(vdistance2(p, q));}
 
 	static inline void vorthogonal(const Type p[], Type q[])
 	{
-		if (fabs(p[0]) <= fabs(p[1]) && fabs(p[0]) <= fabs(p[2]))
+		if (std::abs(p[0]) <= std::abs(p[1]) && std::abs(p[0]) <= std::abs(p[2]))
 		{
 			q[0]=0; q[1]=p[2]; q[2]=-p[1];
 		}
-		else if (fabs(p[1]) <= fabs(p[0]) && fabs(p[1]) <= fabs(p[2]))
+		else if (std::abs(p[1]) <= std::abs(p[0]) && std::abs(p[1]) <= std::abs(p[2]))
 		{
 			q[0]=-p[2]; q[1]=0; q[2]=p[0];
 		}
@@ -281,9 +281,9 @@ public:
 	//! Returns vector square norm
 	inline Type norm2() const { return (x*x)+(y*y); }
 	//! Returns vector norm
-	inline Type norm() const { return sqrt(norm2()); }
+	inline Type norm() const { return std::sqrt(norm2()); }
 	//! Sets vector norm to unity
-	inline void normalize() { Type n = norm2(); if (n>0) *this /= sqrt(n); }
+	inline void normalize() { Type n = norm2(); if (n>0) *this /= std::sqrt(n); }
 
 	//! Dot product
 	inline Type dot(const Vector2Tpl& v) const { return (x*v.x)+(y*v.y); }

--- a/CC/src/Chi2Helper.h
+++ b/CC/src/Chi2Helper.h
@@ -20,7 +20,7 @@
 #define CHI2_HELPER_HEADER
 
 //system
-#include <math.h>
+#include <cmath>
 
 #ifndef LOG_SQRT_PI
 #define LOG_SQRT_PI 0.5723649429247000870717135 /* log(sqrt(pi)) */
@@ -58,7 +58,7 @@ public:
 		}
 		else
 		{
-			double y = 0.5 * fabs(z);
+			double y = 0.5 * std::abs(z);
 			if (y >= 3.0) /* Maximum meaningful z value (6) divided by 2 */
 			{
 				x = 1.0;
@@ -107,27 +107,27 @@ public:
 		bool even = !(df & 1); /* True if df is an even number */
 		double y = 0;
 		if (df > 1) {
-			y = exp(-a);
+			y = std::exp(-a);
 		}
-		double s = (even ? y : (2.0 * poz(-sqrt(x))));
+		double s = (even ? y : (2.0 * poz(-std::sqrt(x))));
 		if (df > 2) {
 			x = 0.5 * (df - 1.0);
 			double z = (even ? 1.0 : 0.5);
 			if (a > EXP_MAX_A_VALUE())
 			{
 				double e = (even ? 0.0 : LOG_SQRT_PI);
-				double c = log(a);
+				double c = std::log(a);
 				while (z <= x)
 				{
-					e = log(z)+e;
-					s += exp(c*z-a-e);
+					e = std::log(z)+e;
+					s += std::exp(c*z-a-e);
 					z += 1.0;
 				}
 				return s;
 			}
 			else
 			{
-				double e = (even ? 1.0 : (I_SQRT_PI / sqrt(a)));
+				double e = (even ? 1.0 : (I_SQRT_PI / std::sqrt(a)));
 				double c = 0.0;
 				while (z <= x)
 				{
@@ -158,7 +158,7 @@ public:
 		else if (p >= 1.0)
 			return 0.0;
 
-		chisqval = df / sqrt(p);    /* fair first value */
+		chisqval = df / std::sqrt(p);    /* fair first value */
 		while ((maxchisq - minchisq) > CHI_EPSILON)
 		{
 			if (pochisq(chisqval, df) < p)

--- a/libs/CCFbo/src/ccBilateralFilter.cpp
+++ b/libs/CCFbo/src/ccBilateralFilter.cpp
@@ -18,9 +18,9 @@
 #include "ccBilateralFilter.h"
 
 //system
-#include <math.h>
-#include <assert.h>
 #include <algorithm>
+#include <assert.h>
+#include <cmath>
 
 //! Max kernel size
 /** Can't add this as a static const definition (in the header file)
@@ -230,7 +230,7 @@ void ccBilateralFilter::updateDampingTable()
 		for (unsigned d = 0; d <= m_halfSpatialSize; d++)
 		{
 			//pixel distance based damping
-			m_dampingPixelDist[c*(m_halfSpatialSize + 1) + d] = exp((c*c + d*d) / (-q));
+			m_dampingPixelDist[c*(m_halfSpatialSize + 1) + d] = std::exp((c*c + d*d) / (-q));
 		}
 	}
 }

--- a/libs/qCC_db/ccColorTypes.h
+++ b/libs/qCC_db/ccColorTypes.h
@@ -219,9 +219,9 @@ namespace ccColor
 			float hi = 0;
 			float f = std::modf(H / 60.0f, &hi);
 
-			float l = static_cast<float>(V*(1.0 - S));
-			float m = static_cast<float>(V*(1.0 - f*S));
-			float n = static_cast<float>(V*(1.0 - (1.0 - f)*S));
+			float l = V*(1.0f - S);
+			float m = V*(1.0f - f*S);
+			float n = V*(1.0f - (1.0f - f)*S);
 
 			Rgbf rgb(0, 0, 0);
 

--- a/libs/qCC_db/ccColorTypes.h
+++ b/libs/qCC_db/ccColorTypes.h
@@ -25,7 +25,7 @@
 #include <QColor>
 
 //system
-#include <math.h> //for modf
+#include <cmath>
 #include <random>
 
 //! Default color components type (R,G and B)
@@ -216,8 +216,8 @@ namespace ccColor
 		**/
 		static Rgb hsv2rgb(float H, float S, float V)
 		{
-			double hi = 0;
-			double f = modf(H / 60.0, &hi);
+			float hi = 0;
+			float f = std::modf(H / 60.0f, &hi);
 
 			float l = static_cast<float>(V*(1.0 - S));
 			float m = static_cast<float>(V*(1.0 - f*S));

--- a/libs/qCC_db/ccIncludeGL.h
+++ b/libs/qCC_db/ccIncludeGL.h
@@ -114,7 +114,7 @@ public: //GLU equivalent methods
 		{
 			double* matrix = outMatrix.data();
 
-			double ymax = znear * tanf(fovyInDegrees/2 * CC_DEG_TO_RAD);
+			double ymax = znear * std::tan(fovyInDegrees/2 * CC_DEG_TO_RAD);
 			double xmax = ymax * aspectRatio;
 
 			double dZ = zfar - znear;

--- a/libs/qCC_db/ccIndexedTransformation.cpp
+++ b/libs/qCC_db/ccIndexedTransformation.cpp
@@ -22,9 +22,8 @@
 #include <QTextStream>
 
 //System
-#include <math.h>
-#include <string.h>
 #include <assert.h>
+#include <string>
 
 ccIndexedTransformation::ccIndexedTransformation()
 	: ccGLMatrix()
@@ -154,7 +153,7 @@ ccIndexedTransformation ccIndexedTransformation::Interpolate(	double index,
 																const ccIndexedTransformation& trans2)
 {
 	double dt = trans2.getIndex() - trans1.getIndex();
-	if (dt == 0)
+	if (dt == 0.0)
 	{
 		assert(index == trans1.getIndex());
 		return trans1;

--- a/libs/qCC_glWindow/ccRenderingTools.cpp
+++ b/libs/qCC_glWindow/ccRenderingTools.cpp
@@ -187,8 +187,8 @@ void ConvertToLogScale(ScalarType& dispMin, ScalarType& dispMax)
 {
 	ScalarType absDispMin = (dispMax < 0 ? std::min(-dispMax, -dispMin) : std::max<ScalarType>(dispMin, 0)); 
 	ScalarType absDispMax = std::max(std::abs(dispMin), std::abs(dispMax));
-	dispMin = std::log10(qMax(absDispMin, FLT_EPSILON));
-	dispMax = std::log10(qMax(absDispMax, FLT_EPSILON));
+	dispMin = std::log10(std::max(absDispMin, FLT_EPSILON));
+	dispMax = std::log10(std::max(absDispMax, FLT_EPSILON));
 }
 
 void ccRenderingTools::DrawColorRamp(const CC_DRAW_CONTEXT& context)

--- a/libs/qCC_glWindow/ccRenderingTools.cpp
+++ b/libs/qCC_glWindow/ccRenderingTools.cpp
@@ -185,10 +185,10 @@ const double c_log10 = log(10.0);
 //Convert standard range to log scale
 void ConvertToLogScale(ScalarType& dispMin, ScalarType& dispMax)
 {
-	ScalarType absDispMin = (dispMax < 0 ? std::min(-dispMax, -dispMin) : std::max<ScalarType>(dispMin, 0));
-	ScalarType absDispMax = std::max(fabs(dispMin), fabs(dispMax));
-	dispMin = log10(std::max(absDispMin, static_cast<ScalarType>(ZERO_TOLERANCE)));
-	dispMax = log10(std::max(absDispMax, static_cast<ScalarType>(ZERO_TOLERANCE)));
+	ScalarType absDispMin = (dispMax < 0 ? std::min(-dispMax, -dispMin) : std::max<ScalarType>(dispMin, 0)); 
+	ScalarType absDispMax = std::max(std::abs(dispMin), std::abs(dispMax));
+	dispMin = std::log10(qMax(absDispMin, FLT_EPSILON));
+	dispMax = std::log10(qMax(absDispMax, FLT_EPSILON));
 }
 
 void ccRenderingTools::DrawColorRamp(const CC_DRAW_CONTEXT& context)

--- a/plugins/qCSF/Cloth.cpp
+++ b/plugins/qCSF/Cloth.cpp
@@ -29,17 +29,16 @@
 #include "Cloth.h"
 
 //qCC_db
-#include <ccPointCloud.h>
 #include <ccMesh.h>
+#include <ccPointCloud.h>
 
 //system
 #include <assert.h>
-#include <math.h>
 #include <cmath>
+#include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <sstream>
-#include <iomanip>
-#include <fstream>
 #include <queue>
 
 Cloth::Cloth(	const Vec3& _origin_pos,
@@ -211,7 +210,7 @@ compute the overall displacement of a particle accroding to the rigidness
 	{
 		if (particles[i].isMovable())
 		{
-			double diff = fabs(particles[i].old_pos.y - particles[i].pos.y);
+			double diff = std::abs(particles[i].old_pos.y - particles[i].pos.y);
 			if (diff > maxDiff)
 				maxDiff = diff;
 		}
@@ -391,7 +390,7 @@ void Cloth::findUnmovablePoint(	const std::vector<XY>& connected,
 			if (!ptc_x.isMovable())
 			{
 				int index_ref = y*num_particles_width + x - 1;
-				if (fabs(heightvals[index] - heightvals[index_ref]) < smoothThreshold && ptc.pos.y - heightvals[index] < heightThreshold)
+				if (std::abs(heightvals[index] - heightvals[index_ref]) < smoothThreshold && ptc.pos.y - heightvals[index] < heightThreshold)
 				{
 					Vec3 offsetVec(0, heightvals[index] - ptc.pos.y, 0);
 					particles[index].offsetPos(offsetVec);
@@ -408,7 +407,7 @@ void Cloth::findUnmovablePoint(	const std::vector<XY>& connected,
 			if (!ptc_x.isMovable())
 			{
 				int index_ref = y*num_particles_width + x + 1;
-				if (fabs(heightvals[index] - heightvals[index_ref]) < smoothThreshold && ptc.pos.y - heightvals[index] < heightThreshold)
+				if (std::abs(heightvals[index] - heightvals[index_ref]) < smoothThreshold && ptc.pos.y - heightvals[index] < heightThreshold)
 				{
 					Vec3 offsetVec(0, heightvals[index] - ptc.pos.y, 0);
 					particles[index].offsetPos(offsetVec);
@@ -425,7 +424,7 @@ void Cloth::findUnmovablePoint(	const std::vector<XY>& connected,
 			if (!ptc_y.isMovable())
 			{
 				int index_ref = (y - 1)*num_particles_width + x;
-				if (fabs(heightvals[index] - heightvals[index_ref]) < smoothThreshold && ptc.pos.y - heightvals[index] < heightThreshold)
+				if (std::abs(heightvals[index] - heightvals[index_ref]) < smoothThreshold && ptc.pos.y - heightvals[index] < heightThreshold)
 				{
 					Vec3 offsetVec(0, heightvals[index] - ptc.pos.y, 0);
 					particles[index].offsetPos(offsetVec);
@@ -443,7 +442,7 @@ void Cloth::findUnmovablePoint(	const std::vector<XY>& connected,
 			if (!ptc_y.isMovable())
 			{
 				int index_ref = (y + 1)*num_particles_width + x;
-				if (fabs(heightvals[index] - heightvals[index_ref]) < smoothThreshold && ptc.pos.y - heightvals[index] < heightThreshold)
+				if (std::abs(heightvals[index] - heightvals[index_ref]) < smoothThreshold && ptc.pos.y - heightvals[index] < heightThreshold)
 				{
 					Vec3 offsetVec(0, heightvals[index] - ptc.pos.y, 0);
 					particles[index].offsetPos(offsetVec);
@@ -480,7 +479,7 @@ void Cloth::handle_slop_connected(	const std::vector<int>& edgePoints,
 		for (size_t i = 0; i < neibors[index].size(); i++)
 		{
 			int index_neibor = connected[neibors[index][i]].y*num_particles_width + connected[neibors[index][i]].x;
-			if (fabs(heightvals[index_center] - heightvals[index_neibor]) < smoothThreshold && fabs(particles[index_neibor].pos.y - heightvals[index_neibor]) < heightThreshold)
+			if (std::abs(heightvals[index_center] - heightvals[index_neibor]) < smoothThreshold && fabs(particles[index_neibor].pos.y - heightvals[index_neibor]) < heightThreshold)
 			{
 				Vec3 offsetVec(0, heightvals[index_neibor] - particles[index_neibor].pos.y, 0);
 				particles[index_neibor].offsetPos(offsetVec);

--- a/plugins/qCompass/ccCompass.h
+++ b/plugins/qCompass/ccCompass.h
@@ -66,7 +66,6 @@
 #include "ccPinchNodeTool.h"
 
 //other
-#include <math.h>
 #include <vector>
 
 class ccCompass : public QObject, public ccStdPluginInterface, public ccPickingListener
@@ -235,9 +234,6 @@ public:
 	//digitization mode
 	static bool mapMode; //true if map mode, false if measure mode
 	static int mapTo; //see flags in ccGeoObject.h for definition of different mapping locations
-
-	 
-
 };
 
 #endif

--- a/plugins/qCompass/ccMouseCircle.cpp
+++ b/plugins/qCompass/ccMouseCircle.cpp
@@ -17,7 +17,7 @@
 
 #include "ccMouseCircle.h"
 
-#include <math.h>
+#include <cmath>
 
 ccMouseCircle::ccMouseCircle(ccGLWindow* owner, QString name) 
 	: cc2DViewportObject(name.isEmpty() ? "label" : name)
@@ -29,8 +29,8 @@ ccMouseCircle::ccMouseCircle(ccGLWindow* owner, QString name)
 	for (int n = 0; n < ccMouseCircle::RESOLUTION; n++)
 	{
 		float heading = n * (2 * M_PI / (float) ccMouseCircle::RESOLUTION); //heading in radians
-		ccMouseCircle::UNIT_CIRCLE[n][0] = cos(heading);
-		ccMouseCircle::UNIT_CIRCLE[n][1] = sin(heading);
+		ccMouseCircle::UNIT_CIRCLE[n][0] = std::cos(heading);
+		ccMouseCircle::UNIT_CIRCLE[n][1] = std::sin(heading);
 	}
 
 	//attach to owner
@@ -89,7 +89,6 @@ void ccMouseCircle::draw(CC_DRAW_CONTEXT& context)
 	if (!m_params.perspectiveView) //ortho mode
 	{
 		//Screen pan & pivot compensation
-		float totalZoom = m_params.zoom / m_params.pixelSize;
 		m_winTotalZoom = params.zoom / params.pixelSize;
 
 		//CCVector3d dC = m_params.cameraCenter - params.cameraCenter;

--- a/plugins/qEDL/ccEDLFilter.cpp
+++ b/plugins/qEDL/ccEDLFilter.cpp
@@ -28,8 +28,8 @@
 #include <QOpenGLContext>
 
 //system
-#include <math.h>
 #include <assert.h>
+#include <cmath>
 
 //For MSVC
 #ifndef M_PI
@@ -69,13 +69,13 @@ ccEDLFilter::ccEDLFilter()
 	m_bilateralFilters[2].sigma    = 2.0f;
 	m_bilateralFilters[2].sigmaZ   = 0.4f;
 
-	setLightDir(static_cast<float>(M_PI / 2), static_cast<float>(M_PI / 2));
+	setLightDir(static_cast<float>(M_PI / 2.0), static_cast<float>(M_PI / 2.0));
 
 	memset(m_neighbours, 0, sizeof(float) * 8 * 2);
 	for (unsigned c = 0; c < 8; c++)
 	{
-		m_neighbours[2 * c]     = static_cast<float>(cos(static_cast<double>(c) * M_PI / 4));
-		m_neighbours[2 * c + 1] = static_cast<float>(sin(static_cast<double>(c) * M_PI / 4));
+		m_neighbours[2 * c]     = static_cast<float>(std::cos(c * M_PI / 4.0));
+		m_neighbours[2 * c + 1] = static_cast<float>(std::sin(c * M_PI / 4.0));
 	}
 }
 
@@ -252,7 +252,7 @@ void ccEDLFilter::shade(GLuint texDepth, GLuint texColor, ViewportParameters& pa
 	//perspective mode
 	int perspectiveMode = parameters.perspectiveMode ? 1 : 0;
 	//light-balancing based on the current zoom (for ortho. mode only)
-	float lightMod = perspectiveMode ? 3.0f : static_cast<float>(sqrt(2 * std::max<double>(parameters.zoom, 0.7))); //1.41 ~ sqrt(2)
+	float lightMod = perspectiveMode ? 3.0f : static_cast<float>(std::sqrt(2.0 * std::max(parameters.zoom, 0.7))); //1.41 ~ sqrt(2)
 
 	//we must use corner-based screen coordinates
 	m_glFunc.glMatrixMode(GL_PROJECTION);
@@ -375,7 +375,7 @@ GLuint ccEDLFilter::getTexture()
 
 void ccEDLFilter::setLightDir(float theta_rad, float phi_rad)
 {
-	m_lightDir[0] = sin(phi_rad)*cos(theta_rad);
-	m_lightDir[1] = cos(phi_rad);
-	m_lightDir[2] = sin(phi_rad)*sin(theta_rad);
+	m_lightDir[0] = std::sin(phi_rad)*std::cos(theta_rad);
+	m_lightDir[1] = std::cos(phi_rad);
+	m_lightDir[2] = std::sin(phi_rad)*std::sin(theta_rad);
 }

--- a/plugins/qHoughNormals/qHoughNormalsDialog.h
+++ b/plugins/qHoughNormals/qHoughNormalsDialog.h
@@ -24,10 +24,7 @@
 #include <QDialog>
 
 //System
-#ifndef _USE_MATH_DEFINES
-#define _USE_MATH_DEFINES
-#endif
-#include <math.h>
+#include <cmath>
 
 //! Dialog for Hough Normals dialog
 class qHoughNormalsDialog : public QDialog, public Ui::HoughNormalsDialog
@@ -59,7 +56,7 @@ public:
 		tSpinBox->setValue(params.T);
 		nPhiSpinBox->setValue(params.n_phi);
 		nRotSpinBox->setValue(params.n_rot);
-		tolAngleSpinBox->setValue(params.tol_angle_rad * 180 / M_PI);
+		tolAngleSpinBox->setValue(params.tol_angle_rad * 180.0 / M_PI);
 		kDensitySpinBox->setValue(params.k_density);
 		useDensityCheckBox->setChecked(params.use_density);
 	}
@@ -70,7 +67,7 @@ public:
 		params.T = tSpinBox->value();
 		params.n_phi = nPhiSpinBox->value();
 		params.n_rot = nRotSpinBox->value();
-		params.tol_angle_rad = tolAngleSpinBox->value() * M_PI / 180;
+		params.tol_angle_rad = tolAngleSpinBox->value() * M_PI / 180.0;
 		params.k_density = kDensitySpinBox->value();
 		params.use_density = useDensityCheckBox->isChecked();
 	}

--- a/qCC/ccContourExtractor.cpp
+++ b/qCC/ccContourExtractor.cpp
@@ -21,22 +21,22 @@
 #include "ccContourExtractorDlg.h"
 
 //qCC_db
+#include <cc2DLabel.h>
 #include <ccLog.h>
 #include <ccPointCloud.h>
-#include <cc2DLabel.h>
 
 //qCC_gl
 #include <ccGLWindow.h>
 
 //CCLib
-#include <Neighbourhood.h>
 #include <DistanceComputationTools.h>
+#include <Neighbourhood.h>
 #include <PointProjectionTools.h>
 
 //System
 #include <assert.h>
+#include <cmath>
 #include <set>
-#include <math.h>
 
 //list of already used point to avoid hull's inner loops
 enum HullPointFlags {	POINT_NOT_USED	= 0,
@@ -110,7 +110,7 @@ PointCoordinateType FindNearestCandidate(	unsigned& minIndex,
 		{
 			CCVector2 PB = **itB - P;
 			PointCoordinateType dotProd = AP.x * PB.x + AP.y * PB.y;
-			PointCoordinateType minDotProd = static_cast<PointCoordinateType>(minCosAngle * sqrt(AP.norm2() * PB.norm2()));
+			PointCoordinateType minDotProd = static_cast<PointCoordinateType>(minCosAngle * std::sqrt(AP.norm2() * PB.norm2()));
 			if (dotProd < minDotProd)
 			{
 				continue;
@@ -172,7 +172,7 @@ bool ccContourExtractor::ExtractConcaveHull2D(	std::vector<Vertex2D>& points,
 		return false;
 	}
 
-	double minCosAngle = maxAngleDeg <= 0 ? -1.0 : cos(maxAngleDeg * M_PI / 180.0);
+	double minCosAngle = maxAngleDeg <= 0 ? -1.0 : std::cos(maxAngleDeg * M_PI / 180.0);
 
 	//hack: compute the theoretical 'minimal' edge length
 	PointCoordinateType minSquareEdgeLength = 0;
@@ -800,5 +800,4 @@ bool ccContourExtractor::ExtractFlatContour(CCLib::GenericIndexedCloudPersist* p
 	basePoly = 0;
 
 	return success;
-
 }

--- a/qCC/ccIsolines.h
+++ b/qCC/ccIsolines.h
@@ -40,8 +40,8 @@
 
 //system
 #include <assert.h>
+#include <cmath>
 #include <vector>
-#include <math.h>
 
 template< typename T > class Isolines
 {
@@ -782,7 +782,7 @@ protected:
 	{
 		double dx = getContourX(contour, first) - getContourX(contour, second);
 		double dy = getContourY(contour, first) - getContourY(contour, second);
-		return sqrt(dx * dx + dy * dy);
+		return std::sqrt(dx * dx + dy * dy);
 	}
 
 	// return length from i to i + 1
@@ -798,7 +798,7 @@ protected:
 		double aftx = m_contourX[v2] - m_contourX[v1];
 		double afty = m_contourY[v2] - m_contourY[v1];
 
-		return sqrt(aftx * aftx + afty * afty);
+		return std::sqrt(aftx * aftx + afty * afty);
 	}
 
 	// return the relative angle change in radians
@@ -810,10 +810,10 @@ protected:
 		double aftx = getContourX(contour, i + 1) - getContourX(contour, i + 0);
 		double afty = getContourY(contour, i + 1) - getContourY(contour, i + 0);
 
-		double befl = sqrt(befx * befx + befy * befy); 
+		double befl = std::sqrt(befx * befx + befy * befy); 
 		befx /= befl;
 		befy /= befl;
-		double aftl = sqrt(aftx * aftx + afty * afty);
+		double aftl = std::sqrt(aftx * aftx + afty * afty);
 		aftx /= aftl;
 		afty /= aftl;		
 
@@ -822,7 +822,7 @@ protected:
 			dot = 1.0;
 		else if (dot < 0)
 			dot = 0;
-		double rads = acos(dot);
+		double rads = std::acos(dot);
 		assert(rads == rads); //otherwise it means that rads is NaN!!!
 
 		if (aftx * befy - afty * befx < 0)
@@ -1073,8 +1073,8 @@ public:
 		return w * h;
 	}
 
-	inline double getBBCenterX(int k) const { return (getBBMinX(k) + getBBMaxX(k)) / 2; }
-	inline double getBBCenterY(int k) const { return (getBBMinY(k) + getBBMaxY(k)) / 2; }
+	inline double getBBCenterX(int k) const { return (getBBMinX(k) + getBBMaxX(k)) / 2.0; }
+	inline double getBBCenterY(int k) const { return (getBBMinY(k) + getBBMaxY(k)) / 2.0; }
 };
 
 #endif //ISOLINES_HEADER

--- a/qCC/ccOrthoSectionGenerationDlg.cpp
+++ b/qCC/ccOrthoSectionGenerationDlg.cpp
@@ -18,7 +18,7 @@
 #include "ccOrthoSectionGenerationDlg.h"
 
 //system
-#include <math.h>
+#include <cmath>
 
 ccOrthoSectionGenerationDlg::ccOrthoSectionGenerationDlg(QWidget* parent/*=0*/)
 	: QDialog(parent, Qt::Tool)
@@ -73,6 +73,6 @@ void ccOrthoSectionGenerationDlg::onStepChanged(double step)
 	if (step < 0)
 		return;
 
-	unsigned count = step < 1.0e-6 ? 1 : 1+static_cast<unsigned>(floor(m_pathLength / step));
+	unsigned count = step < 1.0e-6 ? 1 : 1+static_cast<unsigned>(std::floor(m_pathLength / step));
 	sectionCountLineEdit->setText(QString::number(count));
 }

--- a/qCC/ccScalarFieldArithmeticsDlg.cpp
+++ b/qCC/ccScalarFieldArithmeticsDlg.cpp
@@ -30,7 +30,7 @@
 #ifdef _MSC_VER
 #include <windows.h>
 #endif
-#include <math.h>
+#include <cmath>
 
 //number of valid operations
 static const unsigned s_opCount = 18;
@@ -130,8 +130,12 @@ ccScalarFieldArithmeticsDlg::Operation ccScalarFieldArithmeticsDlg::GetOperation
 
 	//test all known names...
 	for (unsigned i=0; i<s_opCount; ++i)
+	{
 		if (name == QString(s_opNames[i]).toUpper())
+		{
 			return static_cast<ccScalarFieldArithmeticsDlg::Operation>(i);
+		}
+	}
 
 	return INVALID;
 }
@@ -362,14 +366,14 @@ bool ccScalarFieldArithmeticsDlg::Apply(ccPointCloud* cloud,
 					else
 					{
 						const ScalarType& val2 = sf2->getValue(i);
-						if (ccScalarField::ValidValue(val2) && fabs(val2) > ZERO_TOLERANCE )
+						if (ccScalarField::ValidValue(val2) && std::abs(val2) > ZERO_TOLERANCE )
 							val = val1 / val2;
 					}
 				}
 				break;
 			case SQRT:
 				if (val1 >= 0)
-					val = sqrt(val1);
+					val = std::sqrt(val1);
 				break;
 			case POW2:
 				val = val1*val1;
@@ -378,41 +382,41 @@ bool ccScalarFieldArithmeticsDlg::Apply(ccPointCloud* cloud,
 				val = val1*val1*val1;
 				break;
 			case EXP:
-				val = exp(val1);
+				val = std::exp(val1);
 				break;
 			case LOG:
 				if (val1 >= 0)
-					val = log(val1);
+					val = std::log(val1);
 				break;
 			case LOG10:
 				if (val1 >= 0)
-					val = log10(val1);
+					val = std::log10(val1);
 				break;
 			case COS:
-				val = cos(val1);
+				val = std::cos(val1);
 				break;
 			case SIN:
-				val = sin(val1);
+				val = std::sin(val1);
 				break;
 			case TAN:
-				val = tan(val1);
+				val = std::tan(val1);
 				break;
 			case ACOS:
-				if (val1 >= -1 && val1 <= 1.0)
-					val = acos(val1);
+				if (val1 >= -1 && val1 <= 1.0f)
+					val = std::acos(val1);
 				break;
 			case ASIN:
-				if (val1 >= -1 && val1 <= 1.0)
-					val = asin(val1);
+				if (val1 >= -1 && val1 <= 1.0f)
+					val = std::asin(val1);
 				break;
 			case ATAN:
-				val = atan(val1);
+				val = std::atan(val1);
 				break;
 			case INT:
 				val = static_cast<ScalarType>(static_cast<int>(val1)); //integer part ('round' doesn't seem to be available on MSVC?!)
 				break;
 			case INVERSE:
-				val = fabs(val1) < ZERO_TOLERANCE ? NAN_VALUE : static_cast<ScalarType>(1.0/val1);
+				val = std::abs(val1) < ZERO_TOLERANCE ? NAN_VALUE : static_cast<ScalarType>(1.0f/val1);
 				break;
 			default:
 				assert(false);

--- a/qCC/ccScalarFieldArithmeticsDlg.cpp
+++ b/qCC/ccScalarFieldArithmeticsDlg.cpp
@@ -402,11 +402,11 @@ bool ccScalarFieldArithmeticsDlg::Apply(ccPointCloud* cloud,
 				val = std::tan(val1);
 				break;
 			case ACOS:
-				if (val1 >= -1 && val1 <= 1.0f)
+				if (val1 >= -1 && val1 <= 1)
 					val = std::acos(val1);
 				break;
 			case ASIN:
-				if (val1 >= -1 && val1 <= 1.0f)
+				if (val1 >= -1 && val1 <= 1)
 					val = std::asin(val1);
 				break;
 			case ATAN:
@@ -416,7 +416,7 @@ bool ccScalarFieldArithmeticsDlg::Apply(ccPointCloud* cloud,
 				val = static_cast<ScalarType>(static_cast<int>(val1)); //integer part ('round' doesn't seem to be available on MSVC?!)
 				break;
 			case INVERSE:
-				val = std::abs(val1) < ZERO_TOLERANCE ? NAN_VALUE : static_cast<ScalarType>(1.0f/val1);
+				val = std::abs(val1) < ZERO_TOLERANCE ? NAN_VALUE : static_cast<ScalarType>(1.0/val1);
 				break;
 			default:
 				assert(false);

--- a/qCC/ccSectionExtractionTool.cpp
+++ b/qCC/ccSectionExtractionTool.cpp
@@ -46,7 +46,7 @@
 
 //System
 #include <assert.h>
-#include <math.h>
+#include <cmath>
 
 //default parameters
 static const ccColor::Rgba& s_defaultPolylineColor = ccColor::magenta;
@@ -1515,7 +1515,7 @@ void ccSectionExtractionTool::unfoldPoints()
 	static double s_defaultThickness = -1.0;
 	if (s_defaultThickness <= 0)
 	{
-		s_defaultThickness = box.getMaxBoxDim() / 10;
+		s_defaultThickness = box.getMaxBoxDim() / 10.0;
 	}
 
 	bool ok;
@@ -1626,8 +1626,8 @@ void ccSectionExtractionTool::unfoldPoints()
 				//longitudinal 'distance'
 				PointCoordinateType dotprod = s.u.dot(AP2D);
 
-				PointCoordinateType squareDist = 0;
-				if (dotprod < 0)
+				PointCoordinateType squareDist = 0.0f;
+				if (dotprod < 0.0f)
 				{
 					//dist to nearest vertex
 					squareDist = AP2D.norm2();
@@ -1815,7 +1815,7 @@ void ccSectionExtractionTool::extractPoints()
 	int yDim = (xDim < 2 ? xDim + 1 : 0);
 
 	//we consider half of the total thickness as points can be on both sides!
-	double sectionThicknessSq = pow(s_defaultSectionThickness / 2, 2.0);
+	double sectionThicknessSq = std::pow(s_defaultSectionThickness / 2, 2.0);
 	bool error = false;
 
 	unsigned generatedContours = 0;
@@ -1873,7 +1873,7 @@ void ccSectionExtractionTool::extractPoints()
 						}
 
 						//now test each point and see if it's close to the current polyline (in 2D)
-						PointCoordinateType s = 0;
+						PointCoordinateType s = 0.0f;
 						for (unsigned j = 0; j < polyMaxCount; ++j)
 						{
 							//current polyline segment

--- a/qCC/ccSectionExtractionTool.cpp
+++ b/qCC/ccSectionExtractionTool.cpp
@@ -1626,7 +1626,7 @@ void ccSectionExtractionTool::unfoldPoints()
 				//longitudinal 'distance'
 				PointCoordinateType dotprod = s.u.dot(AP2D);
 
-				PointCoordinateType squareDist = 0.0f;
+				PointCoordinateType squareDist = 0;
 				if (dotprod < 0.0f)
 				{
 					//dist to nearest vertex
@@ -1815,7 +1815,7 @@ void ccSectionExtractionTool::extractPoints()
 	int yDim = (xDim < 2 ? xDim + 1 : 0);
 
 	//we consider half of the total thickness as points can be on both sides!
-	double sectionThicknessSq = std::pow(s_defaultSectionThickness / 2, 2.0);
+	double sectionThicknessSq = std::pow(s_defaultSectionThickness / 2.0, 2.0);
 	bool error = false;
 
 	unsigned generatedContours = 0;
@@ -1873,7 +1873,7 @@ void ccSectionExtractionTool::extractPoints()
 						}
 
 						//now test each point and see if it's close to the current polyline (in 2D)
-						PointCoordinateType s = 0.0f;
+						PointCoordinateType s = 0;
 						for (unsigned j = 0; j < polyMaxCount; ++j)
 						{
 							//current polyline segment

--- a/qCC/db_tree/sfEditDlg.cpp
+++ b/qCC/db_tree/sfEditDlg.cpp
@@ -27,8 +27,8 @@
 #include <CCConst.h>
 
 //system
-#include <math.h>
 #include <assert.h>
+#include <cmath>
 
 //! Default number of steps for spin-boxes
 const int SPIN_BOX_STEPS = 1000;


### PR DESCRIPTION
- use "std" namespace math functions (instead of f* versions) to make sure we get the correct overload
- add "std::" namespace to some math functions to ensure we get the correct overload (only did the obvious ones in the files I was changing the includes - needs to be done throughout the code base)
- use proper types for some initializations
- remove math.h completely on cases where it is unnecessary
- remove `_USE_MATH_DEFINES` check in qHoughNormalsDialog.h (if this is still necessary for MSVC, I'd suggest adding `-D_USE_MATH_DEFINES` globally in CMAkeSetCompilerOptions.cmake)