### PR TITLE
The new line width was not clamped like the point size is.

### DIFF
--- a/libs/qCC_glWindow/ccGLWindow.cpp
+++ b/libs/qCC_glWindow/ccGLWindow.cpp
@@ -65,7 +65,7 @@ static OculusHMD s_oculus;
 const float ccGLWindow::MIN_POINT_SIZE_F = 1.0f;
 const float ccGLWindow::MAX_POINT_SIZE_F = 16.0f;
 const float ccGLWindow::MIN_LINE_WIDTH_F = 1.0f;
-const float ccGLWindow::MAX_LINE_WIDTH_F = 10.0f;
+const float ccGLWindow::MAX_LINE_WIDTH_F = 16.0f;
 
 //Min and max zoom ratio (relative)
 static const float CC_GL_MAX_ZOOM_RATIO = 1.0e6f;

--- a/libs/qCC_glWindow/ccGLWindow.cpp
+++ b/libs/qCC_glWindow/ccGLWindow.cpp
@@ -64,6 +64,8 @@ static OculusHMD s_oculus;
 
 const float ccGLWindow::MIN_POINT_SIZE_F = 1.0f;
 const float ccGLWindow::MAX_POINT_SIZE_F = 16.0f;
+const float ccGLWindow::MIN_LINE_WIDTH_F = 1.0f;
+const float ccGLWindow::MAX_LINE_WIDTH_F = 10.0f;
 
 //Min and max zoom ratio (relative)
 static const float CC_GL_MAX_ZOOM_RATIO = 1.0e6f;
@@ -4977,9 +4979,11 @@ void ccGLWindow::setPointSize(float size, bool silent/*=false*/)
 
 void ccGLWindow::setLineWidth(float width)
 {
-	if (m_viewportParams.defaultLineWidth != width)
+	float newWidth = std::max(std::min(width, MAX_LINE_WIDTH_F), MIN_LINE_WIDTH_F);
+	
+	if (m_viewportParams.defaultLineWidth != newWidth)
 	{
-		m_viewportParams.defaultLineWidth = width;
+		m_viewportParams.defaultLineWidth = newWidth;
 		deprecate3DLayer();
 	}
 }

--- a/libs/qCC_glWindow/ccGLWindow.h
+++ b/libs/qCC_glWindow/ccGLWindow.h
@@ -381,9 +381,14 @@ public:
 	/** \param size point size (between MIN_POINT_SIZE_F and MAX_POINT_SIZE_F)
 	**/
 	virtual void setPointSize(float size, bool silent = false);
+	
+	//! Minimum line width
+	static const float MIN_LINE_WIDTH_F;
+	//! Maximum line width
+	static const float MAX_LINE_WIDTH_F;
 
 	//! Sets line width
-	/** \param width lines width (typically between 1 and 10)
+	/** \param width lines width (between MIN_LINE_WIDTH_F and MAX_LINE_WIDTH_F)
 	**/
 	virtual void setLineWidth(float width);
 

--- a/qCC/db_tree/ccPropertiesTreeDelegate.cpp
+++ b/qCC/db_tree/ccPropertiesTreeDelegate.cpp
@@ -1309,7 +1309,7 @@ QWidget* ccPropertiesTreeDelegate::createEditor(QWidget *parent,
 		QComboBox *comboBox = new QComboBox(parent);
 
 		comboBox->addItem(c_defaultPolyWidthSizeString); //size = 0
-		for (int i = static_cast<int>(ccGLWindow::MIN_POINT_SIZE_F); i <= static_cast<int>(ccGLWindow::MAX_POINT_SIZE_F); ++i)
+		for (int i = static_cast<int>(ccGLWindow::MIN_LINE_WIDTH_F); i <= static_cast<int>(ccGLWindow::MAX_LINE_WIDTH_F); ++i)
 			comboBox->addItem(QString::number(i));
 
 		connect(comboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(polyineWidthChanged(int)));


### PR DESCRIPTION
Mimic the way the line width is clamped to prevent negative (or zero) line widths.