### PR TITLE
Fix some grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ v2.9 - 10/22/2017
 		- 3 algorithms are available: average, median and weighted average
 
 	* New sub-menu 'Tools > Batch export'
-		- 'Export cloud(s) info' (formerly in the 'Sand-box' sub-menu)
+		- 'Export cloud info' (formerly in the 'Sand-box' sub-menu)
 			* exports various pieces of information about selected clouds in a CSV file
 			* Name, point count, barycenter
 			+ for each scalar field: name, mean value, std. dev. and sum
@@ -1357,7 +1357,7 @@ v2.5.4 04/19/2014
 		- for each point, the best fit plane is computed on all the neighbors except the point itself
 			(this gives a less biased measure). The roughness value is then computed as the distance
 			between the point and this plane.
-	* New 'sand box' method: "Export cloud(s) info"
+	* New 'sand box' method: "Export cloud info"
 		- exports various pieces of information for all selected clouds in a CSV file (cloud name, size,
 			mean, std.dev. and sum of all scalar fields, etc.)
 	* 'Camera link' feature enhanced:

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -778,8 +778,8 @@ void MainWindow::connectActions()
 	connect(m_UI->actionFitFacet,					&QAction::triggered, this, &MainWindow::doActionFitFacet);
 	connect(m_UI->actionFitQuadric,					&QAction::triggered, this, &MainWindow::doActionFitQuadric);
 	//"Tools > Batch export" menu
-	connect(m_UI->actionExportCloudsInfo,			&QAction::triggered, this, &MainWindow::doActionExportCloudsInfo);
-	connect(m_UI->actionExportPlanesInfo,			&QAction::triggered, this, &MainWindow::doActionExportPlanesInfo);
+	connect(m_UI->actionExportCloudInfo,			&QAction::triggered, this, &MainWindow::doActionExportCloudInfo);
+	connect(m_UI->actionExportPlaneInfo,			&QAction::triggered, this, &MainWindow::doActionExportPlaneInfo);
 	//"Tools > Other" menu
 	connect(m_UI->actionComputeDensity,				&QAction::triggered, this, &MainWindow::doComputeDensity);
 	connect(m_UI->actionCurvature,					&QAction::triggered, this, &MainWindow::doComputeCurvature);
@@ -8342,7 +8342,7 @@ void MainWindow::doActionComputeBestICPRmsMatrix()
 	}
 }
 
-void MainWindow::doActionExportPlanesInfo()
+void MainWindow::doActionExportPlaneInfo()
 {
 	ccHObject::Container planes;
 
@@ -8438,7 +8438,7 @@ void MainWindow::doActionExportPlanesInfo()
 	csvFile.close();
 }
 
-void MainWindow::doActionExportCloudsInfo()
+void MainWindow::doActionExportCloudInfo()
 {
 	//look for clouds
 	ccHObject::Container clouds;
@@ -9935,8 +9935,8 @@ void MainWindow::enableUIItems(dbTreeSelectionInfo& selInfo)
 	m_UI->actionSubsample->setEnabled(atLeastOneCloud);
 
 	m_UI->actionSNETest->setEnabled(atLeastOneCloud);
-	m_UI->actionExportCloudsInfo->setEnabled(atLeastOneEntity);
-	m_UI->actionExportPlanesInfo->setEnabled(atLeastOneEntity);
+	m_UI->actionExportCloudInfo->setEnabled(atLeastOneEntity);
+	m_UI->actionExportPlaneInfo->setEnabled(atLeastOneEntity);
 
 	m_UI->actionFilterByValue->setEnabled(atLeastOneSF);
 	m_UI->actionConvertToRGB->setEnabled(atLeastOneSF);

--- a/qCC/mainwindow.h
+++ b/qCC/mainwindow.h
@@ -451,10 +451,10 @@ private slots:
 	//! Removes all entities currently loaded in the DB tree
 	void closeAll();
 
-	//! Batch export some pieces of info from a set of selected clouds
-	void doActionExportCloudsInfo();
-	//! Batch export some pieces of info from a set of selected planes
-	void doActionExportPlanesInfo();
+	//! Batch export some info from a set of selected clouds
+	void doActionExportCloudInfo();
+	//! Batch export some info from a set of selected planes
+	void doActionExportPlaneInfo();
 
 	//! Generates a matrix with the best (registration) RMS for all possible couple among the selected entities
 	void doActionComputeBestICPRmsMatrix();

--- a/qCC/ui_templates/mainWindow.ui
+++ b/qCC/ui_templates/mainWindow.ui
@@ -477,8 +477,8 @@
      <property name="title">
       <string>Batch export</string>
      </property>
-     <addaction name="actionExportCloudsInfo"/>
-     <addaction name="actionExportPlanesInfo"/>
+     <addaction name="actionExportCloudInfo"/>
+     <addaction name="actionExportPlaneInfo"/>
     </widget>
     <addaction name="menuClean"/>
     <addaction name="menuProjection"/>
@@ -2598,12 +2598,12 @@ QTreeView::branch:open:has-children:has-siblings  {
     <string>Dip/Dip direction SFs</string>
    </property>
   </action>
-  <action name="actionExportCloudsInfo">
+  <action name="actionExportCloudInfo">
    <property name="text">
-    <string>Export cloud(s) info</string>
+    <string>Export cloud info</string>
    </property>
    <property name="toolTip">
-    <string>Export cloud(s) info to a CSV file (name, size, barycenter, scalar fields info, etc.)</string>
+    <string>Export cloud info to a CSV file (name, size, barycenter, scalar fields info, etc.)</string>
    </property>
   </action>
   <action name="actionInterpolateColors">
@@ -3045,12 +3045,12 @@ QTreeView::branch:open:has-children:has-siblings  {
     <string>Interpolate scalar-field(s) from another cloud or mesh</string>
    </property>
   </action>
-  <action name="actionExportPlanesInfo">
+  <action name="actionExportPlaneInfo">
    <property name="text">
-    <string>Export plane(s) info</string>
+    <string>Export plane info</string>
    </property>
    <property name="toolTip">
-    <string>Export plane(s) info to a CSV file (name, width, height, center, normal, dip and dip direction, etc.)</string>
+    <string>Export plane info to a CSV file (name, width, height, center, normal, dip and dip direction, etc.)</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
One would not say "Export clouds info" even for multiple clouds - it's "Export cloud info" for both singular and plural. (Same thing for planes.)