### PR TITLE
MainWindow::addToDBAuto() should take (const QStringList &) like addToDB()

### DIFF
--- a/ccViewer/ccviewer.cpp
+++ b/ccViewer/ccviewer.cpp
@@ -113,7 +113,7 @@ ccViewer::ccViewer(QWidget *parent, Qt::WindowFlags flags)
 #endif
 
 	//Signals & slots connection
-	connect(m_glWindow,								SIGNAL(filesDropped(QStringList)),			this,		SLOT(addToDB(QStringList)));
+	connect(m_glWindow,								SIGNAL(filesDropped(const QStringList&)),			this,		SLOT(addToDB(const QStringList&)), Qt::QueuedConnection);
 	connect(m_glWindow,								SIGNAL(entitySelectionChanged(ccHObject*)),	this,		SLOT(selectEntity(ccHObject*)));
 	connect(m_glWindow,								SIGNAL(exclusiveFullScreenToggled(bool)),	this,		SLOT(onExclusiveFullScreenToggled(bool)));
 	//connect(m_glWindow,							SIGNAL(entitiesSelectionChanged(std::unordered_set<int>)),	this,		SLOT(selectEntities(std::unordered_set<int>))); //not supported!
@@ -493,7 +493,7 @@ void ccViewer::updateGLFrameGradient()
 	ui.GLframe->setStyleSheet(styleSheet);
 }
 
-void ccViewer::addToDB(QStringList filenames)
+void ccViewer::addToDB(const QStringList& filenames)
 {
 	ccHObject* currentRoot = m_glWindow->getSceneDB();
 	if (currentRoot)

--- a/ccViewer/ccviewer.h
+++ b/ccViewer/ccviewer.h
@@ -60,7 +60,7 @@ public slots:
 	//! Tries to load (and then adds to main db) a list of entity (files)
 	/** \param filenames filenames to load
 	**/
-	void addToDB(QStringList filenames);
+	void addToDB(const QStringList& filenames);
 
 protected slots:
 

--- a/libs/qCC_glWindow/ccGLWindow.h
+++ b/libs/qCC_glWindow/ccGLWindow.h
@@ -757,7 +757,7 @@ signals:
 	void drawing3D();
 
 	//! Signal emitted when files are dropped on the window
-	void filesDropped(QStringList files);
+	void filesDropped(const QStringList& filenames);
 
 	//! Signal emitted when a new label is created
 	void newLabel(ccHObject* obj);

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -9121,7 +9121,7 @@ void MainWindow::onExclusiveFullScreenToggled(bool state)
 	}
 }
 
-void MainWindow::addToDBAuto(QStringList filenames)
+void MainWindow::addToDBAuto(const QStringList& filenames)
 {
 	ccGLWindow* win = qobject_cast<ccGLWindow*>(QObject::sender());
 

--- a/qCC/mainwindow.h
+++ b/qCC/mainwindow.h
@@ -269,7 +269,7 @@ private slots:
 	void updateMenus();
 	void on3DViewActivated(QMdiSubWindow*);
 	void updateUIWithSelection();
-	void addToDBAuto(QStringList);
+	void addToDBAuto(const QStringList& filenames);
 
 	void echoMouseWheelRotate(float);
 	void echoCameraDisplaced(float ddx, float ddy);


### PR DESCRIPTION
This cascaded to other changes:

- ccGLWindow::filesDropped() also takes a const ref
- ccViewer::addToDB() then has to take a const ref
- ccviewer's connection should presumably be a Qt::QueuedConnection like the one in MainWindow