### PR TITLE
Make SF gradient command-line actually use the active SF

### DIFF
--- a/qCC/ccCommandLineCommands.h
+++ b/qCC/ccCommandLineCommands.h
@@ -1163,8 +1163,11 @@ struct CommandSFGradient : public ccCommandLineInterface::Command
 				if (sfCount > 1)
 					cmd.warning(QString("cmd.warning: cloud '%1' has several scalar fields (the active one will be used by default, or the first one if none is active)").arg(cmd.clouds()[i].pc->getName()));
 
-				if (!cmd.clouds()[i].pc->getCurrentDisplayedScalarField())
-					cmd.clouds()[i].pc->setCurrentDisplayedScalarField(0);
+				int activeSFIndex = cmd.clouds()[i].pc->getCurrentOutScalarFieldIndex();
+				if (activeSFIndex < 0)
+					activeSFIndex = 0;
+
+				cmd.clouds()[i].pc->setCurrentDisplayedScalarField(activeSFIndex);
 
 				entities.push_back(cmd.clouds()[i].pc);
 			}


### PR DESCRIPTION
'-SF_GRAD' didn't work with '-SET_ACTIVE_SF'. In the warning message it says "the active one will be used by default", but this was not actually the case and the displayed scalar field on save would be used since the method `getCurrentDisplayedScalarField` was used.