### PR TITLE
Fix invalid include path specification resulting from deprecated ROS sub-directory removal in PCL 

### DIFF
--- a/plugins/qPCL/PclUtils/utils/my_point_types.h
+++ b/plugins/qPCL/PclUtils/utils/my_point_types.h
@@ -19,7 +19,7 @@
 #define Q_PCL_PLUGIN_MY_POINT_TYPES_H
 
 //PCL
-#include <pcl/ros/register_point_struct.h>
+#include <pcl/register_point_struct.h>
 #include <pcl/point_types.h>
 
 //! PCL custom point type used for reading RGB data


### PR DESCRIPTION
This change should be merged if deemed harmless, else, tracked for changing when CloudCompare bumps up its official supported PCL version.

Deprecated ROS headers are removed from PCL in PointCloudLibrary/pcl@c50d8ada7e6556c4db6c81f6b8541c826fefda25.

The inclusion of these causes a compile error on Ubuntu16.04 (and indeed should for any other platform). 
The proposed change fixes only the compile error. Unfortunately, I do not know enough about cloud compare / PCL to note what, if anything, fails at run-time at the moment.