### PR TITLE
(LAS) Read and save extra dimensions

### DIFF
--- a/libs/qCC_io/LASFields.cpp
+++ b/libs/qCC_io/LASFields.cpp
@@ -86,12 +86,6 @@ bool LasField::GetLASFields(ccPointCloud* cloud, std::vector<LasField>& fieldsTo
 					break;
 				}
 			}
-
-			//no correspondance was found?
-			if (!outBounds && (fieldsToSave.empty() || fieldsToSave.back().sf != sf))
-			{
-				ccLog::Warning(QString("[LAS] Found a '%1' scalar field, but it doesn't match with any of the official LAS fields... we will ignore it!").arg(sf->getName()));
-			}
 		}
 	}
 	catch (const std::bad_alloc&)

--- a/libs/qCC_io/ui_templates/saveLASFileDlg.ui
+++ b/libs/qCC_io/ui_templates/saveLASFileDlg.ui
@@ -219,6 +219,28 @@
      </property>
     </widget>
    </item>
+    <item>
+      <widget class="QGroupBox" name="extraFieldGroupBox">
+        <property name="title">
+          <string>Save additional field(s)</string>
+        </property>
+        <property name="checkable">
+          <bool>true</bool>
+        </property>
+        <property name="checked">
+          <bool>false</bool>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+            <widget class="QListWidget" name="evlrListWidget">
+              <property name="selectionMode">
+                <enum>QAbstractItemView::MultiSelection</enum>
+              </property>
+            </widget>
+          </item>
+        </layout>
+      </widget>
+    </item>
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">


### PR DESCRIPTION
Here is some explanation of the process:

The VLR record describing the extra bytes after each point is mandatory only in the Las format 1.4. Most software write it anyway in versions <= 1.3. the 1.4 specification says:

> This VLR has been added to LAS 1.4 to formalize a process that has been used in prior versions of LAS.

So PDAL doesn't read this VLR if the version is before 1.4. The user has to manually specify the names and datatypes of the extra bytes to read.

In this PR, I read the VLR manually, make a string of the names and data type, and pass that back to the PDAL reader.