### PR TITLE
Fix when opening files from argv containing non ASCII

### DIFF
--- a/qCC/main.cpp
+++ b/qCC/main.cpp
@@ -350,7 +350,7 @@ int main(int argc, char **argv)
 				}
 				else
 				{
-					filenames << arg;
+					filenames << QString::fromLocal8Bit(argv[i]);
 				}
 			}
 


### PR DESCRIPTION
Otherwise CloudCompare complains "file doesn't exist"