### PR TITLE
Plugin manager

### DIFF
--- a/qCC/CMakeLists.txt
+++ b/qCC/CMakeLists.txt
@@ -26,6 +26,7 @@ file( GLOB qrc_list *.qrc )
 file( GLOB txt_list TODO.txt ${CloudCompareProjects_SOURCE_DIR}/CHANGELOG.md )
 
 add_subdirectory( db_tree )
+add_subdirectory( pluginManager )
 
 # 3DX support (3dConnexion devices)
 if ( ${OPTION_SUPPORT_3DCONNEXION_DEVICES} )

--- a/qCC/main.cpp
+++ b/qCC/main.cpp
@@ -299,7 +299,7 @@ int main(int argc, char **argv)
 			QMessageBox::critical(0, "Error", "Failed to initialize the main application window?!");
 			return EXIT_FAILURE;
 		}
-		mainWindow->setupPluginDispatch(plugins, pluginPaths);
+		mainWindow->initPlugins(plugins, pluginPaths);
 		mainWindow->show();
 		QApplication::processEvents();
 

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -667,7 +667,7 @@ void MainWindow::connectActions()
 
 	//"About" menu entry
 	connect(m_UI->actionHelp,						&QAction::triggered, this, &MainWindow::doActionShowHelpDialog);
-	connect(m_UI->actionAboutPlugins,				&QAction::triggered, m_pluginManager, &ccPluginManager::showAboutPluginsDialog);
+	connect(m_UI->actionAboutPlugins,				&QAction::triggered, m_pluginManager, &ccPluginManager::showAboutDialog);
 	connect(m_UI->actionEnableQtWarnings,			&QAction::toggled, this, &MainWindow::doEnableQtWarnings);
 
 	connect(m_UI->actionAbout,	&QAction::triggered, this, [this] () {

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -64,9 +64,6 @@
 #include "ccInnerRect2DFinder.h"
 #include "ccHistogramWindow.h"
 
-//shaders & Filters
-#include <ccShader.h>
-
 //dialogs
 #include "ccAboutDialog.h"
 #include "ccAdjustZoomDlg.h"
@@ -92,7 +89,6 @@
 #include "ccPickingHub.h"
 #include "ccPickOneElementDlg.h"
 #include "ccPlaneEditDlg.h"
-#include "ccPluginDlg.h"
 #include "ccPointListPickingDlg.h"
 #include "ccPointPairRegistrationDlg.h"
 #include "ccPointPropertiesDlg.h" //Aurelien BEY
@@ -119,6 +115,7 @@
 #include "ccRecentFiles.h"
 #include "ccRegistrationTools.h"
 #include "ccUtils.h"
+#include "pluginManager/ccPluginManager.h"
 
 //3D mouse handler
 #ifdef CC_3DXWARE_SUPPORT
@@ -180,11 +177,12 @@ MainWindow::MainWindow()
 	, m_plpDlg(nullptr)
 	, m_pprDlg(nullptr)
 	, m_pfDlg(nullptr)
-	, m_glFilterActions(this)
 {
 	m_UI->setupUi( this );
 
-	m_glFilterActions.setExclusive( true );
+	setWindowTitle(QStringLiteral("CloudCompare v") + ccCommon::GetCCVersion(false));
+	
+	m_pluginManager = new ccPluginManager( this, this );
 	
 #ifdef Q_OS_MAC
 	m_UI->actionAbout->setMenuRole( QAction::AboutRole );
@@ -194,13 +192,12 @@ MainWindow::MainWindow()
 	m_UI->actionFullScreen->setShortcut( QKeySequence( Qt::CTRL + Qt::META + Qt::Key_F ) );
 #endif
 
+	// Set up dynamic menus
 	m_UI->menuFile->insertMenu(m_UI->actionSave, m_recentFiles->menu());
-
+	
 	//Console
 	ccConsole::Init(m_UI->consoleWidget, this, this);
 	m_UI->actionEnableQtWarnings->setChecked(ccConsole::QtMessagesEnabled());
-
-	setWindowTitle(QString("CloudCompare v") + ccCommon::GetCCVersion(false));
 
 	//advanced widgets not handled by QDesigner
 	{
@@ -327,207 +324,30 @@ MainWindow::~MainWindow()
 	ccConsole::ReleaseInstance();
 }
 
-void MainWindow::setupPluginDispatch(const tPluginInfoList& plugins, const QStringList& pluginPaths)
+void MainWindow::initPlugins(const tPluginInfoList& plugins, const QStringList& pluginPaths)
 {
-	m_UI->menuPlugins->setEnabled(false);
-	m_UI->menuShadersAndFilters->setEnabled(false);
-	m_UI->toolBarPluginTools->setVisible(false);
-	m_UI->toolBarGLFilters->setVisible(false);
-
-	m_pluginInfoList = plugins;
-	m_pluginPaths = pluginPaths;
-
-	for ( const tPluginInfo &plugin : plugins )
+	m_pluginManager->init( plugins, pluginPaths );
+	
+	// Set up dynamic tool bars
+	addToolBar( Qt::RightToolBarArea, m_pluginManager->glFiltersToolbar() );
+	addToolBar( Qt::RightToolBarArea, m_pluginManager->mainPluginToolbar() );
+	
+	for ( QToolBar *toolbar : m_pluginManager->additionalPluginToolbars() )
 	{
-		if (!plugin.object)
-		{
-			assert(false);
-			continue;
-		}
-
-		QString pluginName = plugin.object->getName();
-		if (pluginName.isEmpty())
-		{
-			ccLog::Warning(QString("[Plugin] Plugin '%1' has an invalid (empty) name!").arg(plugin.filename));
-			continue;
-		}
-
-		CC_PLUGIN_TYPE type = plugin.object->getType();
-		switch (type)
-		{
-
-		case CC_STD_PLUGIN: //standard plugin
-		{
-			plugin.qObject->setParent(this);
-			ccStdPluginInterface* stdPlugin = static_cast<ccStdPluginInterface*>(plugin.object);
-			stdPlugin->setMainAppInterface(this);
-
-			QMenu* destMenu = nullptr;
-			QToolBar* destToolBar = nullptr;
-
-			QActionGroup actions(this);
-			stdPlugin->getActions(actions);
-			if (actions.actions().size() > 1) //more than one action? We create it's own menu and toolbar
-			{
-				destMenu = (m_UI->menuPlugins ? m_UI->menuPlugins->addMenu(pluginName) : 0);
-				if (destMenu)
-					destMenu->setIcon(stdPlugin->getIcon());
-				destToolBar = addToolBar(pluginName + QString(" toolbar"));
-
-				if (destToolBar)
-				{
-					m_stdPluginsToolbars.push_back(destToolBar);
-					//not sure why but it seems that we must specifically set the object name.
-					//if not the QSettings thing will complain about an unset name
-					//when saving settings of qCC mainwindow
-					destToolBar->setObjectName(pluginName);
-				}
-			}
-			else //default destination
-			{
-				destMenu = m_UI->menuPlugins;
-				destToolBar = m_UI->toolBarPluginTools;
-			}
-
-			//add actions
-			const QList<QAction *>	actionList = actions.actions();
-			
-			for (QAction* action : actionList)
-			{
-				//add to menu (if any)
-				if (destMenu)
-				{
-					destMenu->addAction(action);
-					destMenu->setEnabled(true);
-				}
-				//add to toolbar
-				if (destToolBar)
-				{
-					destToolBar->addAction(action);
-					destToolBar->setVisible(true);
-					destToolBar->setEnabled(true);
-				}
-			}
-
-			//add to std. plugins list
-			m_stdPlugins.push_back(stdPlugin);
-
-			//last but not least: update the current plugin state
-			stdPlugin->onNewSelection(m_selectedEntities);
-		}
-		break;
-
-		case CC_GL_FILTER_PLUGIN: //GL filter
-		{
-			//(auto)create action
-			plugin.qObject->setParent(this);
-			
-			QAction* action = new QAction(pluginName, plugin.qObject);
-			action->setToolTip(plugin.object->getDescription());
-			action->setIcon(plugin.object->getIcon());
-			action->setCheckable( true );
-			
-			connect(action, &QAction::triggered, this, &MainWindow::doEnableGLFilter);
-
-			m_UI->menuShadersAndFilters->addAction(action);
-			m_UI->menuShadersAndFilters->setEnabled(true);
-			m_UI->toolBarGLFilters->addAction(action);
-			m_UI->toolBarGLFilters->setVisible(true);
-			m_UI->toolBarGLFilters->setEnabled(true);
-
-			//add to GL filter (actions) list
-			m_glFilterActions.addAction(action);
-		}
-		break;
-
-		case CC_IO_FILTER_PLUGIN: //I/O filter
-		{
-			//not handled by the MainWindow instance
-		}
-		break;
-
-		default:
-			assert(false);
-			continue;
-		}
+		addToolBar( Qt::TopToolBarArea, toolbar );
 	}
+	
+	// Set up dynamic menus
+	m_UI->menubar->insertMenu( m_UI->menu3DViews->menuAction(), m_pluginManager->pluginMenu() );
+	m_UI->menuDisplay->insertMenu( m_UI->menuActiveScalarField->menuAction(), m_pluginManager->shaderAndFilterMenu() );
 
-	if (m_UI->menuPlugins)
-	{
-		m_UI->menuPlugins->setEnabled(!m_stdPlugins.empty());
-	}
-
-	if (m_UI->toolBarPluginTools->isEnabled())
-	{
-		m_UI->actionDisplayPluginTools->setEnabled(true);
-		m_UI->actionDisplayPluginTools->setChecked(true);
-	}
-	else
-	{
-		//DGM: doesn't work :(
-		//actionDisplayPluginTools->setChecked(false);
-	}
-
-	if (m_UI->toolBarGLFilters->isEnabled())
-	{
-		m_UI->actionDisplayGLFiltersTools->setEnabled(true);
-		m_UI->actionDisplayGLFiltersTools->setChecked(true);
-	}
-	else
-	{
-		//DGM: doesn't work :(
-		//actionDisplayGLFiltersTools->setChecked(false);
-	}
-}
-
-void MainWindow::doActionShowAboutPluginsDialog()
-{
-	ccPluginDlg ccpDlg(m_pluginPaths, m_pluginInfoList, this);
-	ccpDlg.exec();
+	m_UI->menuToolbars->addAction( m_pluginManager->actionShowMainPluginToolbar() );
+	m_UI->menuToolbars->addAction( m_pluginManager->actionShowGLFilterToolbar() );
 }
 
 void MainWindow::doEnableQtWarnings(bool state)
 {
 	ccConsole::EnableQtMessages(state);
-}
-
-void MainWindow::doEnableGLFilter()
-{
-	ccGLWindow* win = getActiveGLWindow();
-	if (!win)
-	{
-		ccLog::Warning("[GL filter] No active 3D view!");
-		return;
-	}
-
-	QAction *action = qobject_cast<QAction*>(sender());
-	ccPluginInterface* ccPlugin = ccPlugins::ToValidPlugin(action ? action->parent() : 0);
-	if (!ccPlugin)
-		return;
-
-	if (ccPlugin->getType() != CC_GL_FILTER_PLUGIN)
-		return;
-
-	if (win->areGLFiltersEnabled())
-	{
-		ccGlFilter* filter = static_cast<ccGLFilterPluginInterface*>(ccPlugin)->getFilter();
-		if (filter)
-		{
-			win->setGlFilter(filter);
-			
-			m_UI->actionNoFilter->setEnabled( true );
-			
-			ccConsole::Print("Note: go to << Display > Shaders & Filters > No filter >> to disable GL filter");
-		}
-		else
-		{
-			ccConsole::Error("Can't load GL filter (an error occurred)!");
-		}
-	}
-	else
-	{
-		ccConsole::Error("GL filters not supported!");
-	}
 }
 
 void MainWindow::increasePointSize()
@@ -824,7 +644,6 @@ void MainWindow::connectActions()
 	//"Display > Shaders & filters" menu
 	connect(m_UI->actionLoadShader,					&QAction::triggered, this, &MainWindow::doActionLoadShader);
 	connect(m_UI->actionDeleteShader,				&QAction::triggered, this, &MainWindow::doActionDeleteShader);
-	connect(m_UI->actionNoFilter,					&QAction::triggered, this, &MainWindow::doDisableGLFilter);
 
 	//"Display > Active SF" menu
 	connect(m_UI->actionToggleActiveSFColorScale,	&QAction::triggered, this, &MainWindow::doActionToggleActiveSFColorScale);
@@ -848,7 +667,7 @@ void MainWindow::connectActions()
 
 	//"About" menu entry
 	connect(m_UI->actionHelp,						&QAction::triggered, this, &MainWindow::doActionShowHelpDialog);
-	connect(m_UI->actionAboutPlugins,				&QAction::triggered, this, &MainWindow::doActionShowAboutPluginsDialog);
+	connect(m_UI->actionAboutPlugins,				&QAction::triggered, m_pluginManager, &ccPluginManager::showAboutPluginsDialog);
 	connect(m_UI->actionEnableQtWarnings,			&QAction::toggled, this, &MainWindow::doEnableQtWarnings);
 
 	connect(m_UI->actionAbout,	&QAction::triggered, this, [this] () {
@@ -5998,16 +5817,13 @@ void MainWindow::freezeUI(bool state)
 	//freeze standard plugins
 	m_UI->toolBarMainTools->setDisabled(state);
 	m_UI->toolBarSFTools->setDisabled(state);
-	m_UI->toolBarPluginTools->setDisabled(state);
-	//toolBarGLFilters->setDisabled(state);
-	//toolBarView->setDisabled(state);
+	
+	m_pluginManager->mainPluginToolbar()->setDisabled(state);
 
 	//freeze plugin toolbars
+	for ( QToolBar *toolbar : m_pluginManager->additionalPluginToolbars() )
 	{
-		for ( QToolBar *toolbar : m_stdPluginsToolbars )
-		{
-			toolbar->setDisabled(state);
-		}
+		toolbar->setDisabled(state);
 	}
 
 	m_UI->DockableDBTree->setDisabled(state);
@@ -8998,20 +8814,6 @@ void MainWindow::doActionDeleteShader()
 		win->setShader(0);
 }
 
-void MainWindow::doDisableGLFilter()
-{
-	ccGLWindow* win = getActiveGLWindow();
-	if (win)
-	{
-		win->setGlFilter(nullptr);
-		win->redraw(false);
-		
-		m_UI->actionNoFilter->setEnabled( false );
-		
-		m_glFilterActions.checkedAction()->setChecked( false );
-	}
-}
-
 void MainWindow::removeFromDB(ccHObject* obj, bool autoDelete/*=true*/)
 {
 	if (!obj)
@@ -9792,11 +9594,7 @@ void MainWindow::updateMenus()
 	m_UI->actionToggleViewerBasedPerspective->setEnabled(hasMdiChild);
 
 	//plugins
-	const QList<QAction*> actionList = m_glFilterActions.actions();
-	for (QAction* action : actionList)
-	{
-		action->setEnabled(hasMdiChild);
-	}
+	m_pluginManager->updateMenus();
 }
 
 void MainWindow::update3DViewsMenu()
@@ -10098,10 +9896,7 @@ void MainWindow::enableUIItems(dbTreeSelectionInfo& selInfo)
 	m_UI->actionMatchScales->setEnabled(atLeastTwoEntities);
 
 	//standard plugins
-	for (ccStdPluginInterface* plugin : m_stdPlugins)
-	{
-		plugin->onNewSelection(m_selectedEntities);
-	}
+	m_pluginManager->handleSelectionChanged();
 }
 
 void MainWindow::echoMouseWheelRotate(float wheelDelta_deg)

--- a/qCC/mainwindow.h
+++ b/qCC/mainwindow.h
@@ -51,7 +51,7 @@ class ccGraphicalSegmentationTool;
 class ccGraphicalTransformationTool;
 class ccHObject;
 class ccOverlayDialog;
-class ccPluginInterface;
+class ccPluginManager;
 class ccPointListPickingDlg;
 class ccPointPairRegistrationDlg;
 class ccPointPropertiesDlg;
@@ -166,8 +166,8 @@ public:
 	**/
 	void  addEditPlaneAction( QMenu &menu ) const;
 	
-	//! Dispatches the (loaded) plugins in the UI
-	void setupPluginDispatch(const tPluginInfoList& plugins, const QStringList& pluginPaths);
+	//! Sets up the UI (menus and toolbars) based on loaded plugins
+	void initPlugins(const tPluginInfoList& plugins, const QStringList& pluginPaths);
 
 	//! Updates the 'Properties' view
 	void updatePropertiesView();
@@ -184,8 +184,6 @@ private slots:
 
 	//! Displays 'help' dialog
 	void doActionShowHelpDialog();
-	//! Displays 'about plugins' dialog
-	void doActionShowAboutPluginsDialog();
 	//! Displays file open dialog
 	void doActionLoadFile();
 	//! Displays file save dialog
@@ -380,8 +378,6 @@ private slots:
 	//Shaders & plugins
 	void doActionLoadShader();
 	void doActionDeleteShader();
-	void doEnableGLFilter();
-	void doDisableGLFilter();
 
 	void doActionFindBiggestInnerRectangle();
 
@@ -602,11 +598,8 @@ private:
 	ccPrimitiveFactoryDlg* m_pfDlg;
 
 	/*** plugins ***/
-	QStringList m_pluginPaths;
-	tPluginInfoList m_pluginInfoList;
-	QList<ccStdPluginInterface*> m_stdPlugins;
-	QList<QToolBar*> m_stdPluginsToolbars;
-	QActionGroup m_glFilterActions;
+	//! Manages plugins - menus, toolbars, and the about dialog
+	ccPluginManager	*m_pluginManager;
 };
 
 #endif

--- a/qCC/pluginManager/CMakeLists.txt
+++ b/qCC/pluginManager/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(header_list
+   ${header_list}
+   ${CMAKE_CURRENT_SOURCE_DIR}/ccPluginManager.h
+   PARENT_SCOPE
+)
+
+set(source_list
+   ${source_list}
+   ${CMAKE_CURRENT_SOURCE_DIR}/ccPluginManager.cpp
+   PARENT_SCOPE
+)

--- a/qCC/pluginManager/ccPluginManager.cpp
+++ b/qCC/pluginManager/ccPluginManager.cpp
@@ -273,13 +273,13 @@ void ccPluginManager::setupMenus()
 
 void ccPluginManager::setupToolbars()
 {
-	m_mainPluginToolbar = new QToolBar( m_parentWidget );
+	m_mainPluginToolbar = new QToolBar( tr( "Plugins" ), m_parentWidget );
 	
 	m_mainPluginToolbar->setObjectName( QStringLiteral( "Main Plugin Toolbar" ) );
 	
 	connect( m_showPluginToolbar, &QAction::toggled, m_mainPluginToolbar, &QToolBar::setVisible );
 	
-	m_glFiltersToolbar = new QToolBar( m_parentWidget );
+	m_glFiltersToolbar = new QToolBar( tr( "GL Filters" ), m_parentWidget );
 	
 	m_glFiltersToolbar->setObjectName( QStringLiteral( "GL Plugin Toolbar" ) );
 	m_glFiltersToolbar->addAction( m_actionRemoveFilter );	

--- a/qCC/pluginManager/ccPluginManager.cpp
+++ b/qCC/pluginManager/ccPluginManager.cpp
@@ -237,7 +237,7 @@ void ccPluginManager::handleSelectionChanged()
 	}
 }
 
-void ccPluginManager::showAboutPluginsDialog() const
+void ccPluginManager::showAboutDialog() const
 {
 	ccPluginDlg ccpDlg( m_pluginPaths, m_pluginInfoList );
 	

--- a/qCC/pluginManager/ccPluginManager.cpp
+++ b/qCC/pluginManager/ccPluginManager.cpp
@@ -1,0 +1,345 @@
+//##########################################################################
+//#                                                                        #
+//#                              CLOUDCOMPARE                              #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 or later of the License.      #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#          COPYRIGHT: CloudCompare project                               #
+//#                                                                        #
+//##########################################################################
+
+#include <QAction>
+#include <QMenu>
+#include <QToolBar>
+#include <QWidget>
+
+#include "ccConsole.h"
+#include "ccGLWindow.h"
+#include "ccPluginManager.h"
+#include "ccMainAppInterface.h"
+#include "ccPluginDlg.h"
+
+
+ccPluginManager::ccPluginManager( ccMainAppInterface *appInterface, QWidget *parent )
+	: QObject( parent )
+	, m_parentWidget( parent )
+	, m_appInterface( appInterface )
+	, m_pluginMenu( nullptr )
+	, m_glFilterMenu( nullptr )
+	, m_actionRemoveFilter( nullptr )
+	, m_glFilterActions( this )
+	, m_mainPluginToolbar( nullptr )
+	, m_showPluginToolbar( nullptr )
+	, m_glFiltersToolbar( nullptr )
+	, m_showGLFilterToolbar( nullptr )
+{
+	setupActions();
+	setupMenus();
+	setupToolbars();
+}
+
+ccPluginManager::~ccPluginManager()
+{
+}
+
+void ccPluginManager::init( const tPluginInfoList &plugins, const QStringList &pluginPaths )
+{
+	m_pluginPaths = pluginPaths;	
+	m_pluginInfoList = plugins;
+	
+	m_pluginMenu->setEnabled( false );
+	m_glFilterMenu->setEnabled( false );
+	
+	m_mainPluginToolbar->setVisible( false );
+	
+	for ( const tPluginInfo &plugin : plugins )
+	{
+		if ( plugin.object == nullptr )
+		{
+			Q_ASSERT( false );
+			continue;
+		}
+		
+		QString pluginName = plugin.object->getName();
+		
+		if ( pluginName.isEmpty() )
+		{
+			ccLog::Warning( QStringLiteral( "[Plugin] Plugin '%1' has an invalid (empty) name!" ).arg( plugin.filename ) );
+			continue;
+		}
+		
+		switch ( plugin.object->getType() )
+		{
+			case CC_STD_PLUGIN: //standard plugin
+			{
+				plugin.qObject->setParent( this );
+				
+				ccStdPluginInterface *stdPlugin = static_cast<ccStdPluginInterface*>( plugin.object );
+				
+				stdPlugin->setMainAppInterface( m_appInterface );
+				
+				QMenu *menu = m_pluginMenu;
+				QToolBar *toolBar = m_mainPluginToolbar;
+				
+				QActionGroup actions( this );
+				stdPlugin->getActions( actions );
+				
+				if ( actions.actions().size() > 1 ) //more than one action? We create it's own menu and toolbar
+				{
+					menu = m_pluginMenu->addMenu( pluginName );
+					
+					if ( menu != nullptr )
+					{
+						menu->setIcon( stdPlugin->getIcon() );
+					}
+					
+					toolBar = new QToolBar( pluginName + QStringLiteral( " toolbar" ), m_parentWidget );
+					
+					if ( toolBar != nullptr )
+					{
+						m_additionalPluginToolbars.push_back( toolBar );
+
+						toolBar->setObjectName( pluginName );
+					}
+				}
+				
+				Q_ASSERT( menu != nullptr );
+				
+				// add actions to menu and toolbar
+				const QList<QAction *>	actionList = actions.actions();
+				
+				for ( QAction* action : actionList )
+				{
+					menu->addAction( action );
+					menu->setEnabled( true );
+					
+					toolBar->addAction( action );
+					toolBar->setEnabled( true );
+				}
+				
+				m_plugins.push_back( stdPlugin );
+				
+				stdPlugin->onNewSelection( m_appInterface->getSelectedEntities() );
+				
+				break;
+			}
+				
+			case CC_GL_FILTER_PLUGIN: //GL filter
+			{
+				//(auto)create action
+				plugin.qObject->setParent( this );
+				
+				QAction* action = new QAction( pluginName, plugin.qObject );
+				action->setToolTip( plugin.object->getDescription() );
+				action->setIcon( plugin.object->getIcon() );
+				action->setCheckable( true );
+				
+				connect( action, &QAction::triggered, this, &ccPluginManager::enableGLFilter );
+
+				m_glFilterActions.addAction( action );
+				
+				m_glFilterMenu->addAction( action );
+				m_glFilterMenu->setEnabled( true );
+				
+				m_glFiltersToolbar->addAction( action );				
+				m_glFiltersToolbar->setEnabled( true );				
+				break;
+			}
+				
+			case CC_IO_FILTER_PLUGIN:
+			{
+				// there are no menus or toolbars for I/O plugins
+				break;
+			}
+				
+		}
+	}
+	
+	m_pluginMenu->setEnabled( !m_plugins.empty() );
+	
+	if ( m_mainPluginToolbar->isEnabled() )
+	{
+		m_showPluginToolbar->setEnabled( true );
+	}
+	
+	m_showPluginToolbar->setChecked( m_mainPluginToolbar->isEnabled() );
+	
+	if ( m_glFiltersToolbar->isEnabled() )
+	{
+		m_showGLFilterToolbar->setEnabled( true );
+	}
+	
+	m_showGLFilterToolbar->setChecked( m_glFiltersToolbar->isEnabled() );
+}
+
+QMenu *ccPluginManager::pluginMenu() const
+{
+	return m_pluginMenu;
+}
+
+QMenu *ccPluginManager::shaderAndFilterMenu() const
+{
+	return m_glFilterMenu;
+}
+
+QToolBar *ccPluginManager::mainPluginToolbar()
+{
+	return m_mainPluginToolbar;
+}
+
+QList<QToolBar *> &ccPluginManager::additionalPluginToolbars()
+{
+	return m_additionalPluginToolbars;
+}
+
+QAction *ccPluginManager::actionShowMainPluginToolbar()
+{
+	return m_showPluginToolbar;
+}
+
+QToolBar *ccPluginManager::glFiltersToolbar()
+{
+	return m_glFiltersToolbar;
+}
+
+QAction *ccPluginManager::actionShowGLFilterToolbar()
+{
+	return m_showGLFilterToolbar;
+}
+
+void ccPluginManager::updateMenus()
+{
+	ccGLWindow *active3DView = m_appInterface->getActiveGLWindow();
+	const bool hasActiveView = (active3DView != nullptr);
+
+	const QList<QAction*> actionList = m_glFilterActions.actions();
+	
+	for ( QAction* action : actionList )
+	{
+		action->setEnabled( hasActiveView );
+	}
+}
+
+void ccPluginManager::handleSelectionChanged()
+{
+	const ccHObject::Container &selectedEntities = m_appInterface->getSelectedEntities();
+	
+	for ( ccStdPluginInterface* plugin : m_plugins )
+	{
+		plugin->onNewSelection( selectedEntities );
+	}
+}
+
+void ccPluginManager::showAboutPluginsDialog() const
+{
+	ccPluginDlg ccpDlg( m_pluginPaths, m_pluginInfoList );
+	
+	ccpDlg.exec();
+}
+
+void ccPluginManager::setupActions()
+{
+	m_actionRemoveFilter = new QAction( QIcon( ":/CC/images/noFilter.png" ), tr( "Remove Filter" ), this );
+	m_actionRemoveFilter->setEnabled( false );
+	
+	connect( m_actionRemoveFilter, &QAction::triggered, this, &ccPluginManager::disableGLFilter );
+	
+	m_showPluginToolbar = new QAction( tr( "Plugins" ), this );
+	m_showPluginToolbar->setCheckable( true );
+	m_showPluginToolbar->setEnabled( false );
+	
+	m_showGLFilterToolbar = new QAction( tr( "GL Filters" ), this );
+	m_showGLFilterToolbar->setCheckable( true );
+	m_showGLFilterToolbar->setEnabled( false );
+}
+
+void ccPluginManager::setupMenus()
+{	
+	m_pluginMenu = new QMenu( tr( "Plugins" ), m_parentWidget );
+	
+	m_glFilterMenu = new QMenu( tr( "Shaders && Filters NEW" ), m_parentWidget );
+	
+	m_glFilterMenu->addAction( m_actionRemoveFilter );
+	
+	m_glFilterActions.setExclusive( true );		
+}
+
+void ccPluginManager::setupToolbars()
+{
+	m_mainPluginToolbar = new QToolBar( m_parentWidget );
+	
+	m_mainPluginToolbar->setObjectName( QStringLiteral( "Main Plugin Toolbar" ) );
+	
+	connect( m_showPluginToolbar, &QAction::toggled, m_mainPluginToolbar, &QToolBar::setVisible );
+	
+	m_glFiltersToolbar = new QToolBar( m_parentWidget );
+	
+	m_glFiltersToolbar->setObjectName( QStringLiteral( "GL Plugin Toolbar" ) );
+	m_glFiltersToolbar->addAction( m_actionRemoveFilter );	
+
+	connect( m_showGLFilterToolbar, &QAction::toggled, m_glFiltersToolbar, &QToolBar::setVisible );
+}
+
+void ccPluginManager::enableGLFilter()
+{
+	ccGLWindow *win = m_appInterface->getActiveGLWindow();
+	
+	if ( win == nullptr )
+	{
+		ccLog::Warning( "[GL filter] No active 3D view" );
+		return;
+	}
+	
+	QAction *action = qobject_cast<QAction*>(sender());
+	
+	ccPluginInterface *ccPlugin = ccPlugins::ToValidPlugin( action ? action->parent() : nullptr );
+	
+	if ( (ccPlugin == nullptr) || (ccPlugin->getType() != CC_GL_FILTER_PLUGIN) )
+	{
+		return;
+	}
+	
+	if ( win->areGLFiltersEnabled() )
+	{
+		ccGlFilter *filter = static_cast<ccGLFilterPluginInterface*>(ccPlugin)->getFilter();
+		
+		if ( filter != nullptr )
+		{
+			win->setGlFilter(filter);
+			
+			m_actionRemoveFilter->setEnabled( true );
+			
+			ccConsole::Print( "Note: go to << Display > Shaders & Filters > No filter >> to disable GL filter" );
+		}
+		else
+		{
+			ccConsole::Error( "Can't load GL filter (an error occurred)!" );
+		}
+	}
+	else
+	{
+		ccConsole::Error( "GL filters not supported!" );
+	}
+}
+
+void ccPluginManager::disableGLFilter()
+{
+	ccGLWindow *win = m_appInterface->getActiveGLWindow();
+	
+	if ( win != nullptr )
+	{
+		win->setGlFilter( nullptr );
+		win->redraw( false );
+		
+		m_actionRemoveFilter->setEnabled( false );
+		
+		m_glFilterActions.checkedAction()->setChecked( false );
+	}	
+}

--- a/qCC/pluginManager/ccPluginManager.h
+++ b/qCC/pluginManager/ccPluginManager.h
@@ -57,7 +57,7 @@ public:
 	void	updateMenus();
 	void	handleSelectionChanged();
 
-	void	showAboutPluginsDialog() const;
+	void	showAboutDialog() const;
 	
 private:
 	void	setupActions();

--- a/qCC/pluginManager/ccPluginManager.h
+++ b/qCC/pluginManager/ccPluginManager.h
@@ -1,0 +1,94 @@
+#ifndef CCPLUGINMANAGER_H
+#define CCPLUGINMANAGER_H
+
+//##########################################################################
+//#                                                                        #
+//#                              CLOUDCOMPARE                              #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 or later of the License.      #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#          COPYRIGHT: CloudCompare project                               #
+//#                                                                        #
+//##########################################################################
+
+#include <QList>
+#include <QObject>
+
+#include "ccPluginInfo.h"
+
+class QAction;
+class QActionGroup;
+class QMenu;
+class QString;
+class QToolBar;
+class QWidget;
+
+class ccMainAppInterface;
+class ccStdPluginInterface;
+
+//! Plugin manager
+class ccPluginManager : public QObject
+{
+	Q_OBJECT
+	
+public:
+	ccPluginManager( ccMainAppInterface *appInterface, QWidget *parent );
+	~ccPluginManager();
+	
+	void	init( const tPluginInfoList &plugins, const QStringList &pluginPaths );
+	
+	QMenu	*pluginMenu() const;
+	QMenu	*shaderAndFilterMenu() const;
+	
+	QToolBar *mainPluginToolbar();
+	QList<QToolBar *> &additionalPluginToolbars();
+	QAction *actionShowMainPluginToolbar();
+
+	QToolBar *glFiltersToolbar();
+	QAction *actionShowGLFilterToolbar();
+		
+	void	updateMenus();
+	void	handleSelectionChanged();
+
+	void	showAboutPluginsDialog() const;
+	
+private:
+	void	setupActions();
+	void	setupMenus();
+	void	setupToolbars();
+	
+	void	enableGLFilter();
+	void	disableGLFilter();
+	
+	QWidget	*m_parentWidget;	// unfortunately we need this when creating new menus & toolbars
+	
+	ccMainAppInterface *m_appInterface;
+
+	// these are used to create our toolbars and menus as well as provide info for the about dialog
+	QStringList m_pluginPaths;
+	tPluginInfoList m_pluginInfoList;
+	
+	QMenu	*m_pluginMenu;
+	QMenu	*m_glFilterMenu;
+	
+	QAction *m_actionRemoveFilter;	
+	QActionGroup m_glFilterActions;
+	
+	QList<ccStdPluginInterface *> m_plugins;	
+	
+	QToolBar *m_mainPluginToolbar;	// if a plugin only has one action it goes here
+	QList<QToolBar *> m_additionalPluginToolbars;	// if a plugin has multiple actions it gets its own toolbar
+	QAction	*m_showPluginToolbar;
+	
+	QToolBar *m_glFiltersToolbar;
+	QAction	*m_showGLFilterToolbar;
+};
+
+#endif

--- a/qCC/ui_templates/mainWindow.ui
+++ b/qCC/ui_templates/mainWindow.ui
@@ -2992,7 +2992,6 @@ QTreeView::branch:open:has-children:has-siblings  {
  </customwidgets>
  <resources>
   <include location="../icones.qrc"/>
-  <include location="../icones.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/qCC/ui_templates/mainWindow.ui
+++ b/qCC/ui_templates/mainWindow.ui
@@ -67,8 +67,6 @@
      <addaction name="actionDisplayMainTools"/>
      <addaction name="actionDisplayScalarFieldsTools"/>
      <addaction name="actionDisplayViewTools"/>
-     <addaction name="actionDisplayPluginTools"/>
-     <addaction name="actionDisplayGLFiltersTools"/>
     </widget>
     <widget class="QMenu" name="menuLights">
      <property name="title">
@@ -88,7 +86,6 @@
      <addaction name="actionLoadShader"/>
      <addaction name="actionDeleteShader"/>
      <addaction name="separator"/>
-     <addaction name="actionNoFilter"/>
     </widget>
     <widget class="QMenu" name="menuActiveScalarField">
      <property name="title">
@@ -361,14 +358,6 @@
     <addaction name="actionNext3DView"/>
     <addaction name="actionPrevious3DView"/>
    </widget>
-   <widget class="QMenu" name="menuPlugins">
-    <property name="enabled">
-     <bool>false</bool>
-    </property>
-    <property name="title">
-     <string>Plugins</string>
-    </property>
-   </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
      <string>Tools</string>
@@ -503,7 +492,6 @@
    <addaction name="menuEdit"/>
    <addaction name="menuTools"/>
    <addaction name="menuDisplay"/>
-   <addaction name="menuPlugins"/>
    <addaction name="menu3DViews"/>
    <addaction name="menuHelp"/>
   </widget>
@@ -781,41 +769,6 @@ QTreeView::branch:open:has-children:has-siblings  {
      </item>
     </layout>
    </widget>
-  </widget>
-  <widget class="QToolBar" name="toolBarGLFilters">
-   <property name="enabled">
-    <bool>true</bool>
-   </property>
-   <property name="windowTitle">
-    <string>GL filters</string>
-   </property>
-   <property name="toolTip">
-    <string>GL filters</string>
-   </property>
-   <attribute name="toolBarArea">
-    <enum>RightToolBarArea</enum>
-   </attribute>
-   <attribute name="toolBarBreak">
-    <bool>false</bool>
-   </attribute>
-   <addaction name="actionNoFilter"/>
-  </widget>
-  <widget class="QToolBar" name="toolBarPluginTools">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
-   <property name="windowTitle">
-    <string>Plugins</string>
-   </property>
-   <property name="toolTip">
-    <string>Plugins</string>
-   </property>
-   <attribute name="toolBarArea">
-    <enum>RightToolBarArea</enum>
-   </attribute>
-   <attribute name="toolBarBreak">
-    <bool>false</bool>
-   </attribute>
   </widget>
   <action name="actionOpen">
    <property name="icon">
@@ -1905,18 +1858,6 @@ QTreeView::branch:open:has-children:has-siblings  {
     <string>Load shader</string>
    </property>
   </action>
-  <action name="actionNoFilter">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
-   <property name="icon">
-    <iconset resource="../icones.qrc">
-     <normaloff>:/CC/images/noFilter.png</normaloff>:/CC/images/noFilter.png</iconset>
-   </property>
-   <property name="text">
-    <string>Remove Filter</string>
-   </property>
-  </action>
   <action name="actionDeleteShader">
    <property name="enabled">
     <bool>false</bool>
@@ -1938,17 +1879,6 @@ QTreeView::branch:open:has-children:has-siblings  {
    </property>
    <property name="statusTip">
     <string>Point picking (point information, distance between 2 points, angles between 3 points, etc.)</string>
-   </property>
-  </action>
-  <action name="actionDisplayPluginTools">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Plugins</string>
    </property>
   </action>
   <action name="actionComputeBestFitBB">
@@ -2619,17 +2549,6 @@ QTreeView::branch:open:has-children:has-siblings  {
     <string>Distance map to best-fit 3D quadric</string>
    </property>
   </action>
-  <action name="actionDisplayGLFiltersTools">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>GL filters</string>
-   </property>
-  </action>
   <action name="actionChangeColorLevels">
    <property name="text">
     <string>Levels</string>
@@ -3073,6 +2992,7 @@ QTreeView::branch:open:has-children:has-siblings  {
  </customwidgets>
  <resources>
   <include location="../icones.qrc"/>
+  <include location="../icones.qrc"/>
  </resources>
  <connections>
   <connection>
@@ -3152,38 +3072,6 @@ QTreeView::branch:open:has-children:has-siblings  {
     <hint type="destinationlabel">
      <x>36</x>
      <y>95</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>actionDisplayPluginTools</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>toolBarPluginTools</receiver>
-   <slot>setVisible(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>-1</x>
-     <y>-1</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>963</x>
-     <y>57</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>actionDisplayGLFiltersTools</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>toolBarGLFilters</receiver>
-   <slot>setVisible(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>-1</x>
-     <y>-1</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>957</x>
-     <y>37</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
Pull the plugin UI management out of the main window into its own class (ccPluginManager).

It should be functionally equivalent to the current UI.

I put this in its own directory because I intend to rewrite the "About plugins" dialog and it will live here as well.

There are likely other cleanups with plugin handling that could move into here. I need to look at how CC and ccViewer are using and passing plugin info.