### PR TITLE
{plugins} Removes the tPluginInfo struct as it's now unnecessary

### DIFF
--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -59,7 +59,7 @@ bool ccCommandLineParser::error(const QString& message) const
 	return false;
 }
 
-int ccCommandLineParser::Parse(int nargs, char** args, tPluginInfoList* plugins/*=0*/)
+int ccCommandLineParser::Parse(int nargs, char** args, ccPluginInterfaceList& plugins)
 {
 	if (!args || nargs < 2)
 	{
@@ -97,18 +97,15 @@ int ccCommandLineParser::Parse(int nargs, char** args, tPluginInfoList* plugins/
 	}
 
 	//load the plugins commands
-	if (plugins)
+	for ( ccPluginInterface *plugin : plugins )
 	{
-		for (tPluginInfo &pluginInfo : *plugins)
+		if (!plugin)
 		{
-			if (!pluginInfo.interface)
-			{
-				assert(false);
-				continue;
-			}
-			ccPluginInterface* plugin = static_cast<ccPluginInterface*>(pluginInfo.interface);
-			plugin->registerCommands(parser.data());
+			assert(false);
+			continue;
 		}
+
+		plugin->registerCommands(parser.data());
 	}
 
 	//parse input

--- a/qCC/ccCommandLineParser.h
+++ b/qCC/ccCommandLineParser.h
@@ -16,7 +16,7 @@ class ccCommandLineParser : public ccCommandLineInterface
 public:
 
 	//! Parses the input command
-	static int Parse(int nargs, char** args, tPluginInfoList* plugins = 0);
+	static int Parse(int nargs, char** args, ccPluginInterfaceList& plugins);
 
 	//! Destructor
 	virtual ~ccCommandLineParser();

--- a/qCC/main.cpp
+++ b/qCC/main.cpp
@@ -224,7 +224,7 @@ int main(int argc, char **argv)
 	ccColorScalesManager::GetUniqueInstance(); //force pre-computed color tables initialization
 
 	//load the plugins
-	tPluginInfoList	plugins = ccPlugins::LoadPlugins();
+	ccPluginInterfaceList	plugins = ccPlugins::LoadPlugins();
 	
 	int result = 0;
 
@@ -232,7 +232,7 @@ int main(int argc, char **argv)
 	if (commandLine)
 	{
 		//command line processing (no GUI)
-		result = ccCommandLineParser::Parse(argc, argv, &plugins);
+		result = ccCommandLineParser::Parse(argc, argv, plugins);
 	}
 	else
 	{
@@ -273,15 +273,15 @@ int main(int argc, char **argv)
 					QString pluginNameUpper = pluginName.toUpper();
 					//look for this plugin
 					bool found = false;
-					for (const tPluginInfo &plugin : plugins)
+					for ( ccPluginInterface *plugin : plugins )
 					{
-						if (plugin.interface->getName().replace(' ', '_').toUpper() == pluginNameUpper)
+						if (plugin->getName().replace(' ', '_').toUpper() == pluginNameUpper)
 						{
 							found = true;
-							bool success = plugin.interface->start();
+							bool success = plugin->start();
 							if (!success)
 							{
-								ccLog::Error(QString("Failed to start the plugin '%1'").arg(plugin.interface->getName()));
+								ccLog::Error(QString("Failed to start the plugin '%1'").arg(plugin->getName()));
 							}
 							break;
 						}
@@ -322,15 +322,9 @@ int main(int argc, char **argv)
 		}
 
 		//release the plugins
-		for (tPluginInfo &plugin : plugins)
+		for ( ccPluginInterface *plugin : plugins )
 		{
-			plugin.interface->stop(); //just in case
-			if (!plugin.qObject->parent())
-			{
-				delete plugin.interface;
-				plugin.interface = nullptr;
-				plugin.qObject = nullptr;
-			}
+			plugin->stop(); //just in case
 		}
 	}
 

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -324,7 +324,7 @@ MainWindow::~MainWindow()
 	ccConsole::ReleaseInstance();
 }
 
-void MainWindow::initPlugins( const tPluginInfoList& plugins )
+void MainWindow::initPlugins( const ccPluginInterfaceList& plugins )
 {
 	m_pluginManager->init( plugins );
 	

--- a/qCC/mainwindow.h
+++ b/qCC/mainwindow.h
@@ -167,7 +167,7 @@ public:
 	void  addEditPlaneAction( QMenu &menu ) const;
 	
 	//! Sets up the UI (menus and toolbars) based on loaded plugins
-	void initPlugins(const tPluginInfoList& plugins);
+	void initPlugins(const ccPluginInterfaceList& plugins);
 
 	//! Updates the 'Properties' view
 	void updatePropertiesView();

--- a/qCC/pluginManager/ccPluginManager.cpp
+++ b/qCC/pluginManager/ccPluginManager.cpp
@@ -49,7 +49,7 @@ ccPluginManager::~ccPluginManager()
 {
 }
 
-void ccPluginManager::init( const tPluginInfoList &plugins )
+void ccPluginManager::init( const ccPluginInterfaceList &plugins )
 {	
 	m_pluginMenu->setEnabled( false );
 	m_glFilterMenu->setEnabled( false );
@@ -58,15 +58,15 @@ void ccPluginManager::init( const tPluginInfoList &plugins )
 	
 	bool haveStdPlugin = false;
 	
-	for ( const tPluginInfo &plugin : plugins )
+	for ( ccPluginInterface *plugin : plugins )
 	{
-		if ( plugin.interface == nullptr )
+		if ( plugin == nullptr )
 		{
 			Q_ASSERT( false );
 			continue;
 		}
 		
-		QString pluginName = plugin.interface->getName();
+		const QString pluginName = plugin->getName();
 		
 		Q_ASSERT( !pluginName.isEmpty() );
 		
@@ -76,15 +76,13 @@ void ccPluginManager::init( const tPluginInfoList &plugins )
 			continue;
 		}
 		
-		switch ( plugin.interface->getType() )
+		switch ( plugin->getType() )
 		{
 			case CC_STD_PLUGIN: //standard plugin
 			{
 				haveStdPlugin = true;
-				
-				plugin.qObject->setParent( this );
-				
-				ccStdPluginInterface *stdPlugin = static_cast<ccStdPluginInterface*>( plugin.interface );
+								
+				ccStdPluginInterface *stdPlugin = static_cast<ccStdPluginInterface*>( plugin );
 				
 				stdPlugin->setMainAppInterface( m_appInterface );
 				
@@ -136,17 +134,15 @@ void ccPluginManager::init( const tPluginInfoList &plugins )
 				
 			case CC_GL_FILTER_PLUGIN: //GL filter
 			{
-				ccGLFilterPluginInterface *glPlugin = static_cast<ccGLFilterPluginInterface*>( plugin.interface );
-				
-				plugin.qObject->setParent( this );
-				
-				QAction* action = new QAction( pluginName, plugin.qObject );
+				ccGLFilterPluginInterface *glPlugin = static_cast<ccGLFilterPluginInterface*>( plugin );
+								
+				QAction* action = new QAction( pluginName, this );
 				
 				action->setToolTip( glPlugin->getDescription() );
 				action->setIcon( glPlugin->getIcon() );
 				action->setCheckable( true );
 				
-				// store the plugin's pointer in the QAction data so we can access it in enableGLFilter()
+				// store the plugin's interface pointer in the QAction data so we can access it in enableGLFilter()
 				QVariant v;
 		  
 				v.setValue( glPlugin );
@@ -169,7 +165,7 @@ void ccPluginManager::init( const tPluginInfoList &plugins )
 				
 			case CC_IO_FILTER_PLUGIN:
 			{
-				ccIOFilterPluginInterface *ioPlugin = static_cast<ccIOFilterPluginInterface*>( plugin.interface );
+				ccIOFilterPluginInterface *ioPlugin = static_cast<ccIOFilterPluginInterface*>( plugin );
 
 				// there are no menus or toolbars for I/O plugins
 				

--- a/qCC/pluginManager/ccPluginManager.h
+++ b/qCC/pluginManager/ccPluginManager.h
@@ -42,7 +42,7 @@ public:
 	ccPluginManager( ccMainAppInterface *appInterface, QWidget *parent );
 	~ccPluginManager();
 	
-	void	init( const tPluginInfoList &plugins );
+	void	init( const ccPluginInterfaceList &plugins );
 	
 	QMenu	*pluginMenu() const;
 	QMenu	*shaderAndFilterMenu() const;


### PR DESCRIPTION
- change ccViewer's GL plugin handling to pass the plugin interface to doEnableGLFilter() in the data
- change tPluginInfoList into a vector of <ccPluginInterface *> and renamed ccPluginInterfaceList
- pass a reference to the plugin list to ccCommandLineParser::Parse() instead of a pointer