### PR TITLE
(LAS) Validate srs before loading it in metadata

### DIFF
--- a/libs/qCC_io/LASFilter.cpp
+++ b/libs/qCC_io/LASFilter.cpp
@@ -1158,11 +1158,14 @@ CC_FILE_ERROR LASFilter::loadFile(QString filename, ccHObject& container, LoadPa
 
 				//save the Spatial reference as meta-data
 				SpatialReference srs = lasHeader.srs();
-				if (!srs.empty())
+				if (srs.valid())
 				{
 					QString proj4 = QString::fromStdString(srs.getProj4());
 					ccLog::Print("[LAS] Spatial reference: " + proj4);
 					pointChunk.loadedCloud->setMetaData(s_LAS_SRS_Key, proj4);
+				}
+				else {
+					ccLog::Print("[LAS] Spatial reference: None");
 				}
 
 				pointChunk.createFieldsToLoad(extraDimensionsIds, extraNamesToLoad);


### PR DESCRIPTION
When the VLR describing the spatial reference is there, but contains no valid info, the function `srs.empty()` return false and an empty string is recorded for the `s_LAS_SRS_Key` metadata. An error occurs when the user tries to save this cloud with an empty string as the `a_srs` parameter in PDAL.

Using the `.valid()` function ensures the reference system is valid before recording it.