### PR TITLE
Change E57 plugin to use libE57Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,12 @@ v2.10.alpha - XX/XX/201X
 	* LAS I/O:
 		- CloudCompare can now read and save extra dimensions (for any file version) - see https://github.com/CloudCompare/CloudCompare/pull/666
 
-	* Plugins:
+	* E57:
+		- the E57 plugin now uses [libE57Format](https://github.com/asmaloney/libE57Format) which is a fork of the old E57RefImpl 
+		- if you compile CloudCompare with the E57 plugin, you will need to use this new lib and change some CMake options to point at it - specifically **OPTION_USE_LIBE57FORMAT** and **LIBE57FORMAT_INSTALL_DIR**
+		- the E57 plugin is now available on macOS
+
+	* Plugins (General):
 		- The "About Plugins" dialog was rewritten to provide more information about installed plugins and to include I/O and GL plugins.
 		- Added several fields to the plugin interface: authors, maintainers, and reference links.
 		- I/O plugins now have the option to return a list of filters using a new method *getFilters()* (so one plugin can handle multiple file extensions)
@@ -83,8 +88,8 @@ v2.10.alpha - XX/XX/201X
 			- Salome Hydro polylines (*.poly)
 			- SinusX curve (*.sx)
 			- Mensi Soisic cloud (*.soi)
-		
-- Bug fix:
+
+- bug fixes:
 
 	* Subsampling with a radius dependent on the active scalar field could make CC stall when dealing with negative values
 	* Point picking was performed on each click, even when double-clicking. This could actually prevent the double-click from

--- a/contrib/AllSupport.cmake
+++ b/contrib/AllSupport.cmake
@@ -34,7 +34,7 @@ function( target_link_contrib ) # 2 arguments: ARGV0 = project name / ARGV1 = sh
 	#GDAL support
 	target_link_GDAL( ${ARGV0} ${ARGV1} )
 	#E57 support
-	target_link_LIBE57( ${ARGV0} )
+	target_link_LIBE57FORMAT( ${ARGV0} )
 	#DXF support
 	target_link_DXFLIB( ${ARGV0} )
 	#FBX support

--- a/contrib/E57Support.cmake
+++ b/contrib/E57Support.cmake
@@ -1,21 +1,18 @@
 # ------------------------------------------------------------------------------
-# libE57+CMake support for CloudCompare
+# libE57Format+CMake support for CloudCompare
 # ------------------------------------------------------------------------------
 
-OPTION( OPTION_USE_LIBE57 "Build with libE57 (ASTM E2807-11 E57 file format support)" OFF )
-if( ${OPTION_USE_LIBE57} )
+OPTION( OPTION_USE_LIBE57FORMAT "Build with libE57Format (ASTM E2807-11 E57 file format support)" OFF )
 
-	# DGM: does not work on my machine!
-	#find_package( E57RefImpl )
+if( ${OPTION_USE_LIBE57FORMAT} )
 
-	# LibE57
-	set( LIBE57_INSTALL_DIR "" CACHE PATH "libE57 install directory (CMake INSTALL output)" )
+	# libE57Format
+	set( LIBE57FORMAT_INSTALL_DIR "" CACHE PATH "libE57Format install directory (CMake INSTALL output)" )
 
-	if( NOT LIBE57_INSTALL_DIR )
-		message( SEND_ERROR "No LibE57 install dir specified (LIBE57_INSTALL_DIR)" )
+	if( NOT LIBE57FORMAT_INSTALL_DIR )
+		message( SEND_ERROR "No libE57Format install dir specified (LIBE57FORMAT_INSTALL_DIR)" )
 	else()
-		include_directories( ${LIBE57_INSTALL_DIR}/include )
-		include_directories( ${LIBE57_INSTALL_DIR}/include/e57 )
+		include_directories( ${LIBE57FORMAT_INSTALL_DIR}/include/E57Format )
 	endif()
 
 	# Find Boost
@@ -64,51 +61,45 @@ if( ${OPTION_USE_LIBE57} )
 
 endif()
 
-# link project with LIBE57 libraries
-function( target_link_LIBE57 ) # 1 argument: ARGV0 = project name
-
-if( ${OPTION_USE_LIBE57} )
-	# manual version
-	if( LIBE57_INSTALL_DIR )
-
-	#libE57
-		if (WIN32 AND NOT MINGW)
-			set(LIBE57_LIB_DEBUG "E57RefImpl-d.lib")
-			set(LIBE57_LIB_RELEASE "E57RefImpl.lib")
-		else()
-			set(LIBE57_LIB_DEBUG "libE57RefImpl-d.a")
-			set(LIBE57_LIB_RELEASE "libE57RefImpl.a")
-		endif()
-		
-		if ( CMAKE_CONFIGURATION_TYPES )
-			target_link_libraries( ${ARGV0} debug ${LIBE57_INSTALL_DIR}/lib/${LIBE57_LIB_DEBUG} optimized ${LIBE57_INSTALL_DIR}/lib/${LIBE57_LIB_RELEASE} )
-		else()
-			target_link_libraries( ${ARGV0} ${LIBE57_INSTALL_DIR}/lib/${LIBE57_LIB_RELEASE} )
-		endif()
-		
-		#Xerces
-		if ( CMAKE_CONFIGURATION_TYPES )
-			if (Xerces_LIBRARY_DEBUG AND Xerces_LIBRARY_RELEASE)
-				target_link_libraries( ${ARGV0} debug ${Xerces_LIBRARY_DEBUG} optimized ${Xerces_LIBRARY_RELEASE} )
+# link project with libE57Format libraries
+function( target_link_LIBE57FORMAT ) # 1 argument: ARGV0 = project name
+	if( ${OPTION_USE_LIBE57FORMAT} )
+		if( LIBE57FORMAT_INSTALL_DIR )
+			if (WIN32 AND NOT MINGW)
+				set(LIBE57FORMAT_LIB_DEBUG "E57Format-d.lib")
+				set(LIBE57FORMAT_LIB_RELEASE "E57Format.lib")
 			else()
-				message( FATAL_ERROR "Unable to find Xerces library. Please set Xerces_LIBRARY_DEBUG and Xerces_LIBRARY_RELEASE to point to the release and debug library files." )
+				set(LIBE57FORMAT_LIB_DEBUG "libE57Format-d.a")
+				set(LIBE57FORMAT_LIB_RELEASE "libE57Format.a")
 			endif()
-		else()
-			if (Xerces_LIBRARY_RELEASE)
-				target_link_libraries( ${ARGV0} ${Xerces_LIBRARY_RELEASE} )
+			
+			if ( CMAKE_CONFIGURATION_TYPES )
+				target_link_libraries( ${ARGV0} debug ${LIBE57FORMAT_INSTALL_DIR}/lib/${LIBE57FORMAT_LIB_DEBUG} optimized ${LIBE57FORMAT_INSTALL_DIR}/lib/${LIBE57FORMAT_LIB_RELEASE} )
 			else()
-				message( FATAL_ERROR "Unable to find Xerces library. Please set Xerces_LIBRARY_RELEASE to point to the (release) library file." )
+				target_link_libraries( ${ARGV0} ${LIBE57FORMAT_INSTALL_DIR}/lib/${LIBE57FORMAT_LIB_RELEASE} )
 			endif()
+			
+			#Xerces
+			if ( CMAKE_CONFIGURATION_TYPES )
+				if (Xerces_LIBRARY_DEBUG AND Xerces_LIBRARY_RELEASE)
+					target_link_libraries( ${ARGV0} debug ${Xerces_LIBRARY_DEBUG} optimized ${Xerces_LIBRARY_RELEASE} )
+				else()
+					message( FATAL_ERROR "Unable to find Xerces library. Please set Xerces_LIBRARY_DEBUG and Xerces_LIBRARY_RELEASE to point to the release and debug library files." )
+				endif()
+			else()
+				if (Xerces_LIBRARY_RELEASE)
+					target_link_libraries( ${ARGV0} ${Xerces_LIBRARY_RELEASE} )
+				else()
+					message( FATAL_ERROR "Unable to find Xerces library. Please set Xerces_LIBRARY_RELEASE to point to the (release) library file." )
+				endif()
+			endif()
+			
+			#Boost
+			target_link_libraries( ${ARGV0} ${Boost_LIBRARIES} )
+	
+			set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS CC_E57_SUPPORT XERCES_STATIC_LIBRARY )
+		else()
+			message( SEND_ERROR "No libE57Format install dir specified (LIBE57FORMAT_INSTALL_DIR)" )
 		endif()
-		
-		#Boost
-		target_link_libraries( ${ARGV0} ${Boost_LIBRARIES} )
-
-		set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS CC_E57_SUPPORT XERCES_STATIC_LIBRARY )
-	else()
-		message( SEND_ERROR "No LibE57 install dir specified (LIBE57_INSTALL_DIR)" )
 	endif()
-endif()
-
 endfunction()
-

--- a/libs/qCC_io/E57Filter.cpp
+++ b/libs/qCC_io/E57Filter.cpp
@@ -22,9 +22,8 @@
 //Local
 #include "E57Header.h"
 
-//libE57
-#include <e57/E57Foundation.h>
-//using namespace e57; //conflict between boost and stdint!
+//libE57Format
+#include <E57Foundation.h>
 
 //CCLib
 #include <ScalarField.h>


### PR DESCRIPTION
The E57 plugin now uses [libE57Format](https://github.com/asmaloney/libE57Format) which is a fork of the old E57RefImpl.

If you compile CloudCompare with the E57 plugin, you will need to use this new lib and change some CMake options to point at it - specifically **OPTION_USE_LIBE57FORMAT** and **LIBE57FORMAT_INSTALL_DIR**

Allows the E57 plugin to compile on macOS.