### PR TITLE
Use std::function instead of references to functions in foreach()

### DIFF
--- a/CC/include/ChunkedPointCloud.h
+++ b/CC/include/ChunkedPointCloud.h
@@ -49,7 +49,7 @@ public:
 
 		//**** inherited form GenericCloud ****//
 		inline virtual unsigned size() const { return m_points->currentSize(); }
-		virtual void forEach(genericPointAction& action);
+		virtual void forEach(genericPointAction action);
 		virtual void getBoundingBox(CCVector3& bbMin, CCVector3& bbMax);
 		virtual void placeIteratorAtBegining();
 		virtual const CCVector3* getNextPoint();

--- a/CC/include/Delaunay2dMesh.h
+++ b/CC/include/Delaunay2dMesh.h
@@ -91,7 +91,7 @@ public:
 
 	//inherited methods (see GenericMesh)
 	virtual unsigned size() const { return m_numberOfTriangles; }
-	virtual void forEach(genericTriangleAction& action);
+	virtual void forEach(genericTriangleAction action);
 	virtual void getBoundingBox(CCVector3& bbMin, CCVector3& bbMax);
 	virtual void placeIteratorAtBegining();
 	virtual GenericTriangle* _getNextTriangle();

--- a/CC/include/DgmOctreeReferenceCloud.h
+++ b/CC/include/DgmOctreeReferenceCloud.h
@@ -41,7 +41,7 @@ public:
 
 	//**** inherited form GenericCloud ****//
 	inline virtual unsigned size() const { return m_size; }
-	virtual void forEach(genericPointAction& action);
+	virtual void forEach(genericPointAction action);
 	virtual void getBoundingBox(CCVector3& bbMin, CCVector3& bbMax);
 	//virtual unsigned char testVisibility(const CCVector3& P) const; //not supported
 	inline virtual void placeIteratorAtBegining() { m_globalIterator = 0; }

--- a/CC/include/GenericCloud.h
+++ b/CC/include/GenericCloud.h
@@ -19,6 +19,8 @@
 #ifndef GENERIC_CLOUD_HEADER
 #define GENERIC_CLOUD_HEADER
 
+#include <functional>
+
 //Local
 #include "CCGeom.h"
 #include "CCConst.h"
@@ -39,7 +41,7 @@ public:
 	virtual ~GenericCloud() {}
 
 	//! Generic function applied to a point (used by foreach)
-	typedef void genericPointAction(const CCVector3&, ScalarType&);
+	typedef std::function<void(const CCVector3&, ScalarType&)> genericPointAction;
 
 	//! Returns the number of points
 	/**	Virtual method to request the cloud size
@@ -51,7 +53,7 @@ public:
 	/**	Virtual method to apply a function to the whole cloud
 		\param action the function to apply (see GenericCloud::genericPointAction)
 	**/
-	virtual void forEach(genericPointAction& action) = 0;
+	virtual void forEach(genericPointAction action) = 0;
 
 	//! Returns the cloud bounding box
 	/**	Virtual method to request the cloud bounding box limits

--- a/CC/include/GenericMesh.h
+++ b/CC/include/GenericMesh.h
@@ -19,6 +19,8 @@
 #ifndef GENERIC_MESH_HEADER
 #define GENERIC_MESH_HEADER
 
+#include <functional>
+
 //Local
 #include "CCGeom.h"
 
@@ -36,7 +38,7 @@ public:
 	virtual ~GenericMesh() {}
 
 	//! Generic function to apply to a triangle (used by foreach)
-	typedef void genericTriangleAction(GenericTriangle&);
+	typedef std::function<void(GenericTriangle&)> genericTriangleAction;
 
 	//! Returns the number of triangles
 	/**	Virtual method to request the mesh size
@@ -48,7 +50,7 @@ public:
 	/**	Virtual method to apply a function to the whole mesh
 		\param action function to apply (see GenericMesh::genericTriangleAction)
 	**/
-	virtual void forEach(genericTriangleAction& action) = 0;
+	virtual void forEach(genericTriangleAction action) = 0;
 
 	//! Returns the mesh bounding-box
 	/**	Virtual method to request the mesh bounding-box limits. It is equivalent to

--- a/CC/include/ReferenceCloud.h
+++ b/CC/include/ReferenceCloud.h
@@ -45,7 +45,7 @@ public:
 
 	//**** inherited form GenericCloud ****//
 	inline virtual unsigned size() const { return m_theIndexes->currentSize(); }
-	virtual void forEach(genericPointAction& action);
+	virtual void forEach(genericPointAction action);
 	virtual void getBoundingBox(CCVector3& bbMin, CCVector3& bbMax);
 	inline virtual unsigned char testVisibility(const CCVector3& P) const { assert(m_theAssociatedCloud); return m_theAssociatedCloud->testVisibility(P); }
 	inline virtual void placeIteratorAtBegining() { m_globalIterator = 0; }

--- a/CC/include/SimpleCloud.h
+++ b/CC/include/SimpleCloud.h
@@ -46,7 +46,7 @@ public:
 
 	//**** inherited form GenericCloud ****//
 	virtual unsigned size() const;
-	virtual void forEach(genericPointAction& action);
+	virtual void forEach(genericPointAction action);
 	virtual void getBoundingBox(CCVector3& bbMin, CCVector3& bbMax);
 	virtual void placeIteratorAtBegining();
 	virtual const CCVector3* getNextPoint();

--- a/CC/include/SimpleMesh.h
+++ b/CC/include/SimpleMesh.h
@@ -48,7 +48,7 @@ public: //constructors
 
 public: //inherited methods
 
-	virtual void forEach(genericTriangleAction& action);
+	virtual void forEach(genericTriangleAction action);
 	virtual void placeIteratorAtBegining();
 	virtual GenericTriangle* _getNextTriangle(); //temporary
 	virtual GenericTriangle* _getTriangle(unsigned triangleIndex); //temporary

--- a/CC/src/ChunkedPointCloud.cpp
+++ b/CC/src/ChunkedPointCloud.cpp
@@ -50,7 +50,7 @@ void ChunkedPointCloud::clear()
 	invalidateBoundingBox();
 }
 
-void ChunkedPointCloud::forEach(genericPointAction& action)
+void ChunkedPointCloud::forEach(genericPointAction action)
 {
 	//there's no point of calling forEach if there's no activated scalar field!
 	ScalarField* currentOutScalarFieldArray = getCurrentOutScalarField();

--- a/CC/src/Delaunay2dMesh.cpp
+++ b/CC/src/Delaunay2dMesh.cpp
@@ -323,7 +323,7 @@ bool Delaunay2dMesh::removeTrianglesWithEdgesLongerThan(PointCoordinateType maxE
 	return true;
 }
 
-void Delaunay2dMesh::forEach(genericTriangleAction& action)
+void Delaunay2dMesh::forEach(genericTriangleAction action)
 {
 	if (!m_associatedCloud)
 		return;

--- a/CC/src/DgmOctreeReferenceCloud.cpp
+++ b/CC/src/DgmOctreeReferenceCloud.cpp
@@ -76,7 +76,7 @@ void DgmOctreeReferenceCloud::getBoundingBox(CCVector3& bbMin, CCVector3& bbMax)
 	bbMax = m_bbMax;
 }
 
-void DgmOctreeReferenceCloud::forEach(genericPointAction& action)
+void DgmOctreeReferenceCloud::forEach(genericPointAction action)
 {
 	unsigned count = size();
 	for (unsigned i=0; i<count; ++i)

--- a/CC/src/ReferenceCloud.cpp
+++ b/CC/src/ReferenceCloud.cpp
@@ -174,7 +174,7 @@ void ReferenceCloud::setPointIndex(unsigned localIndex, unsigned globalIndex)
 	invalidateBoundingBox();
 }
 
-void ReferenceCloud::forEach(genericPointAction& action)
+void ReferenceCloud::forEach(genericPointAction action)
 {
 	assert(m_theAssociatedCloud);
 

--- a/CC/src/SimpleCloud.cpp
+++ b/CC/src/SimpleCloud.cpp
@@ -65,7 +65,7 @@ void SimpleCloud::addPoint(const PointCoordinateType P[])
 	m_validBB=false;
 }
 
-void SimpleCloud::forEach(genericPointAction& action)
+void SimpleCloud::forEach(genericPointAction action)
 {
 	unsigned n = m_points->currentSize();
 

--- a/CC/src/SimpleMesh.cpp
+++ b/CC/src/SimpleMesh.cpp
@@ -50,7 +50,7 @@ unsigned SimpleMesh::size() const
     return m_triIndexes->currentSize();
 };
 
-void SimpleMesh::forEach(genericTriangleAction& action)
+void SimpleMesh::forEach(genericTriangleAction action)
 {
 	SimpleTriangle tri;
 	unsigned count = m_triIndexes->currentSize();

--- a/libs/qCC_db/ccMesh.cpp
+++ b/libs/qCC_db/ccMesh.cpp
@@ -1482,7 +1482,7 @@ unsigned ccMesh::capacity() const
 	return m_triVertIndexes->capacity();
 }
 
-void ccMesh::forEach(genericTriangleAction& action)
+void ccMesh::forEach(genericTriangleAction action)
 {
 	if (!m_associatedCloud)
 		return;

--- a/libs/qCC_db/ccMesh.h
+++ b/libs/qCC_db/ccMesh.h
@@ -103,7 +103,7 @@ public:
 	virtual unsigned capacity() const override;
 
 	//inherited methods (GenericIndexedMesh)
-	virtual void forEach(genericTriangleAction& action) override;
+	virtual void forEach(genericTriangleAction action) override;
 	virtual void placeIteratorAtBegining() override;
 	virtual CCLib::GenericTriangle* _getNextTriangle() override; //temporary
 	virtual CCLib::GenericTriangle* _getTriangle(unsigned triangleIndex) override; //temporary

--- a/libs/qCC_db/ccMeshGroup.h
+++ b/libs/qCC_db/ccMeshGroup.h
@@ -64,7 +64,7 @@ public:
 
 	//inherited methods (GenericIndexedMesh)
 	virtual unsigned size() const override { return 0; }
-	virtual void forEach(genericTriangleAction& action) override {}
+	virtual void forEach(genericTriangleAction action) override {}
 	virtual void placeIteratorAtBegining() override {}
 	virtual CCLib::GenericTriangle* _getNextTriangle() override { return 0; }
 	virtual CCLib::GenericTriangle* _getTriangle(unsigned index) override { return 0; }

--- a/libs/qCC_db/ccSubMesh.cpp
+++ b/libs/qCC_db/ccSubMesh.cpp
@@ -76,7 +76,7 @@ void ccSubMesh::onUpdateOf(ccHObject* obj)
 		m_bBox.setValidity(false);
 }
 
-void ccSubMesh::forEach(genericTriangleAction& action)
+void ccSubMesh::forEach(genericTriangleAction action)
 {
 	if (!m_associatedMesh)
 		return;

--- a/libs/qCC_db/ccSubMesh.h
+++ b/libs/qCC_db/ccSubMesh.h
@@ -73,7 +73,7 @@ public:
 
 	//inherited methods (GenericIndexedMesh)
 	inline virtual unsigned size() const override { return m_triIndexes->currentSize(); }
-	virtual void forEach(genericTriangleAction& action) override;
+	virtual void forEach(genericTriangleAction action) override;
 	inline virtual void placeIteratorAtBegining() override { m_globalIterator = 0; }
 	virtual CCLib::GenericTriangle* _getNextTriangle() override; //temporary object
 	virtual CCLib::GenericTriangle* _getTriangle(unsigned index) override; //temporary object


### PR DESCRIPTION
`GenericCloud::foreach()` and `GenericMesh::foreach()` could not accept lambdas because they were using references rather than function pointers.

This change allow us to call these with lambdas like this:

```cpp
someMesh->forEach( [=]( CCLib::GenericTriangle &inTri ) {
	//... do something with the tris
} );
```