### PR TITLE
{plugins} Change ccStdPluginInterface::getActions() interface

### DIFF
--- a/plugins/ccStdPluginInterface.h
+++ b/plugins/ccStdPluginInterface.h
@@ -67,8 +67,8 @@ public:
 	**/
 	virtual ccMainAppInterface * getMainAppInterface() { return m_app; }
 
-	//! Puts our plugin's action(s) into an action group
-	virtual void getActions(QActionGroup& group) = 0;
+	//! Get a list of actions for this plugin
+	virtual QList<QAction *> getActions() = 0;
 
 	//! This method is called by the main application whenever the entity selection changes
 	/** Does nothing by default. Should be re-implemented by the plugin if necessary.

--- a/plugins/core/qAnimation/qAnimation.cpp
+++ b/plugins/core/qAnimation/qAnimation.cpp
@@ -72,7 +72,7 @@ void qAnimation::onNewSelection(const ccHObject::Container& selectedEntities)
 	}
 }
 
-void qAnimation::getActions(QActionGroup& group)
+QList<QAction *> qAnimation::getActions()
 {
 	//default action (if it has not been already created, it's the moment to do it)
 	if (!m_action)
@@ -84,7 +84,7 @@ void qAnimation::getActions(QActionGroup& group)
 		connect(m_action, &QAction::triggered, this, &qAnimation::doAction);
 	}
 
-	group.addAction(m_action);
+	return QList<QAction *>{ m_action };
 }
 
 //what to do when clicked.

--- a/plugins/core/qAnimation/qAnimation.h
+++ b/plugins/core/qAnimation/qAnimation.h
@@ -43,7 +43,7 @@ public:
 	
 	//inherited from ccStdPluginInterface
 	void onNewSelection(const ccHObject::Container& selectedEntities) override;
-	virtual void getActions(QActionGroup& group) override;
+	virtual QList<QAction *> getActions() override;
 
 private:
 

--- a/plugins/core/qBroom/qBroom.cpp
+++ b/plugins/core/qBroom/qBroom.cpp
@@ -38,7 +38,7 @@ qBroom::qBroom(QObject* parent)
 {
 }
 
-void qBroom::getActions(QActionGroup& group)
+QList<QAction *> qBroom::getActions()
 {
 	//default action
 	if (!m_action)
@@ -50,7 +50,7 @@ void qBroom::getActions(QActionGroup& group)
 		connect(m_action, &QAction::triggered, this, &qBroom::doAction);
 	}
 
-	group.addAction(m_action);
+	return QList<QAction *>{ m_action };
 }
 
 void qBroom::onNewSelection(const ccHObject::Container& selectedEntities)

--- a/plugins/core/qBroom/qBroom.h
+++ b/plugins/core/qBroom/qBroom.h
@@ -35,8 +35,8 @@ public:
 	virtual ~qBroom() = default;
 
 	//inherited from ccStdPluginInterface
-	virtual void onNewSelection(const ccHObject::Container& selectedEntities);
-	virtual void getActions(QActionGroup& group);
+	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
+	virtual QList<QAction *> getActions() override;
 
 protected slots:
 

--- a/plugins/core/qCSF/qCSF.cpp
+++ b/plugins/core/qCSF/qCSF.cpp
@@ -76,7 +76,7 @@ void qCSF::onNewSelection(const ccHObject::Container& selectedEntities)
 		m_action->setEnabled(selectedEntities.size()==1 && selectedEntities[0]->isA(CC_TYPES::POINT_CLOUD));
 }
 
-void qCSF::getActions(QActionGroup& group)
+QList<QAction *> qCSF::getActions()
 {
 	if (!m_action)
 	{
@@ -87,7 +87,7 @@ void qCSF::getActions(QActionGroup& group)
 		connect(m_action, &QAction::triggered, this, &qCSF::doAction);
 	}
 
-	group.addAction(m_action);
+	return QList<QAction *>{ m_action };
 }
 
 void qCSF::doAction()

--- a/plugins/core/qCSF/qCSF.h
+++ b/plugins/core/qCSF/qCSF.h
@@ -50,7 +50,7 @@ public:
 
 	//inherited from ccStdPluginInterface
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
-	virtual void getActions(QActionGroup& group) override;
+	virtual QList<QAction *> getActions() override;
 
 protected slots:
 

--- a/plugins/core/qCompass/ccCompass.cpp
+++ b/plugins/core/qCompass/ccCompass.cpp
@@ -166,7 +166,7 @@ void ccCompass::onNewSelection(const ccHObject::Container& selectedEntities)
 }
 
 //Submit the action to launch ccCompass to CC
-void ccCompass::getActions(QActionGroup& group)
+QList<QAction *> ccCompass::getActions()
 {
 	//default action (if it has not been already created, it's the moment to do it)
 	if (!m_action) //this is the action triggered by clicking the "Compass" button in the plugin menu
@@ -178,12 +178,10 @@ void ccCompass::getActions(QActionGroup& group)
 		m_action->setIcon(getIcon());
 
 		//connect appropriate signal
-		QObject::connect(m_action, SIGNAL(triggered()), this, SLOT(doAction())); //this binds the m_action to the ccCompass::doAction() function
+		connect(m_action, &QAction::triggered, this, &ccCompass::doAction); //this binds the m_action to the ccCompass::doAction() function
 	}
-	group.addAction(m_action);
 
-	m_app->dispToConsole("[ccCompass] ccCompass plugin initialized successfully.", ccMainAppInterface::STD_CONSOLE_MESSAGE);
-
+	return QList<QAction *>{ m_action };
 }
 
 //Called by CC when the plugin should be activated - sets up the plugin and then calls startMeasuring()

--- a/plugins/core/qCompass/ccCompass.h
+++ b/plugins/core/qCompass/ccCompass.h
@@ -56,7 +56,7 @@ public:
 
 	//inherited from ccStdPluginInterface
 	void onNewSelection(const ccHObject::Container& selectedEntities) override;
-	virtual void getActions(QActionGroup& group) override;
+	virtual QList<QAction *> getActions() override;
 
 protected slots:
 

--- a/plugins/core/qCork/qCork.cpp
+++ b/plugins/core/qCork/qCork.cpp
@@ -43,13 +43,13 @@
 
 
 qCork::qCork(QObject* parent/*=0*/)
-	: QObject(parent)
-	, ccStdPluginInterface(":/CC/plugin/qCork/info.json")
-	, m_action(0)
+    : QObject(parent)
+    , ccStdPluginInterface(":/CC/plugin/qCork/info.json")
+    , m_action(nullptr)
 {
 }
 
-void qCork::getActions(QActionGroup& group)
+QList<QAction *> qCork::getActions()
 {
 	//default action
 	if (!m_action)
@@ -58,10 +58,10 @@ void qCork::getActions(QActionGroup& group)
 		m_action->setToolTip(getDescription());
 		m_action->setIcon(getIcon());
 		//connect signal
-		connect(m_action, SIGNAL(triggered()), this, SLOT(doAction()));
+		connect(m_action, &QAction::triggered, this, &qCork::doAction);
 	}
 
-	group.addAction(m_action);
+	return QList<QAction *>{ m_action };
 }
 
 void qCork::onNewSelection(const ccHObject::Container& selectedEntities)

--- a/plugins/core/qCork/qCork.h
+++ b/plugins/core/qCork/qCork.h
@@ -38,11 +38,11 @@ class qCork : public QObject, public ccStdPluginInterface
 public:
 
 	//! Default constructor
-	explicit qCork(QObject* parent = 0);
+	explicit qCork(QObject* parent = nullptr);
 
 	//inherited from ccStdPluginInterface
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities);
-	virtual void getActions(QActionGroup& group);
+	virtual QList<QAction *> getActions() override;
 
 protected slots:
 

--- a/plugins/core/qFacets/qFacets.cpp
+++ b/plugins/core/qFacets/qFacets.cpp
@@ -90,8 +90,8 @@ qFacets::~qFacets()
 	}
 }
 
-void qFacets::getActions(QActionGroup& group)
-{
+QList<QAction *> qFacets::getActions()
+{	
 	//actions
 	if (!m_doFuseKdTreeCells)
 	{
@@ -101,7 +101,6 @@ void qFacets::getActions(QActionGroup& group)
 		//connect signal
 		connect(m_doFuseKdTreeCells, &QAction::triggered, this, &qFacets::fuseKdTreeCells);
 	}
-	group.addAction(m_doFuseKdTreeCells);
 
 	if (!m_fastMarchingExtraction)
 	{
@@ -111,7 +110,6 @@ void qFacets::getActions(QActionGroup& group)
 		//connect signal
 		connect(m_fastMarchingExtraction, &QAction::triggered, this, &qFacets::extractFacetsWithFM);
 	}
-	group.addAction(m_fastMarchingExtraction);
 
 	if (!m_doExportFacets)
 	{
@@ -121,7 +119,6 @@ void qFacets::getActions(QActionGroup& group)
 		//connect signal
 		connect(m_doExportFacets, &QAction::triggered, this, &qFacets::exportFacets);
 	}
-	group.addAction(m_doExportFacets);
 
 	if (!m_doExportFacetsInfo)
 	{
@@ -131,7 +128,6 @@ void qFacets::getActions(QActionGroup& group)
 		//connect signal
 		connect(m_doExportFacetsInfo, &QAction::triggered, this, &qFacets::exportFacetsInfo);
 	}
-	group.addAction(m_doExportFacetsInfo);
 
 	if (!m_doClassifyFacetsByAngle)
 	{
@@ -143,7 +139,6 @@ void qFacets::getActions(QActionGroup& group)
 			classifyFacetsByAngle();
 		} );
 	}
-	group.addAction(m_doClassifyFacetsByAngle);
 
 	if (!m_doShowStereogram)
 	{
@@ -153,8 +148,15 @@ void qFacets::getActions(QActionGroup& group)
 		//connect signal
 		connect(m_doShowStereogram, &QAction::triggered, this, &qFacets::showStereogram);
 	}
-	group.addAction(m_doShowStereogram);
 
+	return QList<QAction *>{
+				m_doFuseKdTreeCells,
+				m_fastMarchingExtraction,
+				m_doExportFacets,
+				m_doExportFacetsInfo,
+				m_doClassifyFacetsByAngle,
+				m_doShowStereogram,
+	};
 }
 
 void qFacets::onNewSelection(const ccHObject::Container& selectedEntities)

--- a/plugins/core/qFacets/qFacets.h
+++ b/plugins/core/qFacets/qFacets.h
@@ -59,7 +59,7 @@ public:
 
 	//inherited from ccStdPluginInterface
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
-	virtual void getActions(QActionGroup& group) override;
+	virtual QList<QAction *> getActions() override;
 
 protected slots:
 

--- a/plugins/core/qHPR/qHPR.cpp
+++ b/plugins/core/qHPR/qHPR.cpp
@@ -48,7 +48,7 @@ qHPR::qHPR(QObject* parent)
 {
 }
 
-void qHPR::getActions(QActionGroup& group)
+QList<QAction *> qHPR::getActions()
 {
 	//default action
 	if (!m_action)
@@ -60,7 +60,7 @@ void qHPR::getActions(QActionGroup& group)
 		connect(m_action, &QAction::triggered, this, &qHPR::doAction);
 	}
 
-	group.addAction(m_action);
+	return QList<QAction *>{ m_action };
 }
 
 void qHPR::onNewSelection(const ccHObject::Container& selectedEntities)
@@ -78,7 +78,7 @@ CCLib::ReferenceCloud* qHPR::removeHiddenPoints(CCLib::GenericIndexedCloudPersis
 
 	unsigned nbPoints = theCloud->size();
 	if (nbPoints == 0)
-		return 0;
+		return nullptr;
 
 	//less than 4 points? no need for calculation, we return the whole cloud
 	if (nbPoints < 4)

--- a/plugins/core/qHPR/qHPR.h
+++ b/plugins/core/qHPR/qHPR.h
@@ -43,7 +43,7 @@ public:
 
 	//inherited from ccStdPluginInterface
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
-	virtual void getActions(QActionGroup& group) override;
+	virtual QList<QAction *> getActions() override;
 
 protected slots:
 

--- a/plugins/core/qHoughNormals/qHoughNormals.cpp
+++ b/plugins/core/qHoughNormals/qHoughNormals.cpp
@@ -56,7 +56,7 @@ void qHoughNormals::onNewSelection(const ccHObject::Container& selectedEntities)
 	}
 }
 
-void qHoughNormals::getActions(QActionGroup& group)
+QList<QAction *> qHoughNormals::getActions()
 {
 	//default action
 	if (!m_action)
@@ -68,7 +68,7 @@ void qHoughNormals::getActions(QActionGroup& group)
 		connect(m_action, &QAction::triggered, this, &qHoughNormals::doAction);
 	}
 
-	group.addAction(m_action);
+	return QList<QAction *>{ m_action };
 }
 
 //persistent settings during a single session

--- a/plugins/core/qHoughNormals/qHoughNormals.h
+++ b/plugins/core/qHoughNormals/qHoughNormals.h
@@ -39,7 +39,7 @@ public:
 	
 	//inherited from ccStdPluginInterface
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
-	virtual void getActions(QActionGroup& group) override;
+	virtual QList<QAction *> getActions() override;
 
 protected slots:
 

--- a/plugins/core/qM3C2/qM3C2.cpp
+++ b/plugins/core/qM3C2/qM3C2.cpp
@@ -47,7 +47,7 @@ void qM3C2Plugin::onNewSelection(const ccHObject::Container& selectedEntities)
 	m_selectedEntities = selectedEntities;
 }
 
-void qM3C2Plugin::getActions(QActionGroup& group)
+QList<QAction *> qM3C2Plugin::getActions()
 {
 	if (!m_action)
 	{
@@ -57,7 +57,7 @@ void qM3C2Plugin::getActions(QActionGroup& group)
 		connect(m_action, &QAction::triggered, this, &qM3C2Plugin::doAction);
 	}
 
-	group.addAction(m_action);
+	return QList<QAction *>{ m_action };
 }
 
 void qM3C2Plugin::doAction()

--- a/plugins/core/qM3C2/qM3C2.h
+++ b/plugins/core/qM3C2/qM3C2.h
@@ -45,7 +45,7 @@ public:
 
 	//inherited from ccStdPluginInterface
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
-	virtual void getActions(QActionGroup& group) override;
+	virtual QList<QAction *> getActions() override;
 	virtual void registerCommands(ccCommandLineInterface* cmd) override;
 
 private:

--- a/plugins/core/qPCL/qPCL.cpp
+++ b/plugins/core/qPCL/qPCL.cpp
@@ -29,8 +29,8 @@
 #include <MLSSmoothingUpsampling.h>
 
 qPCL::qPCL(QObject* parent/*=0*/)
-	: QObject(parent)
-	, ccStdPluginInterface(":/toolbar/info.json")
+    : QObject(parent)
+    , ccStdPluginInterface(":/toolbar/info.json")
 {
 }
 
@@ -63,7 +63,7 @@ void qPCL::handleErrorMessage(QString message)
 		m_app->dispToConsole(message,ccMainAppInterface::ERR_CONSOLE_MESSAGE);
 }
 
-void qPCL::getActions(QActionGroup& group)
+QList<QAction *> qPCL::getActions()
 {
 	if (m_filters.empty())
 	{
@@ -75,8 +75,14 @@ void qPCL::getActions(QActionGroup& group)
 		addFilter( new MLSSmoothingUpsampling() );
 	}
 
+	QList<QAction *> actions;
+
 	for (std::vector<BaseFilter*>::const_iterator it = m_filters.begin(); it != m_filters.end(); ++it)
-		group.addAction((*it)->getAction());
+	{
+		actions.append( (*it)->getAction() );
+	}
+
+	return actions;
 }
 
 int qPCL::addFilter(BaseFilter* filter)

--- a/plugins/core/qPCL/qPCL.h
+++ b/plugins/core/qPCL/qPCL.h
@@ -41,8 +41,8 @@ public:
 	virtual ~qPCL();
 
 	//inherited from ccStdPluginInterface
-	virtual void onNewSelection(const ccHObject::Container& selectedEntities);
-	virtual void getActions(QActionGroup& group);
+	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
+	virtual QList<QAction *> getActions() override;
 
 	//! Adds a filter
 	int addFilter(BaseFilter* filter);

--- a/plugins/core/qPCV/qPCV.cpp
+++ b/plugins/core/qPCV/qPCV.cpp
@@ -64,7 +64,7 @@ void qPCV::onNewSelection(const ccHObject::Container& selectedEntities)
 	}
 }
 
-void qPCV::getActions(QActionGroup& group)
+QList<QAction *> qPCV::getActions()
 {
 	//default action
 	if (!m_action)
@@ -76,7 +76,7 @@ void qPCV::getActions(QActionGroup& group)
 		connect(m_action, &QAction::triggered, this, &qPCV::doAction);
 	}
 
-	group.addAction(m_action);
+	return QList<QAction *>{ m_action };
 }
 
 //persistent settings during a single session

--- a/plugins/core/qPCV/qPCV.h
+++ b/plugins/core/qPCV/qPCV.h
@@ -40,7 +40,7 @@ public:
 
 	//inherited from ccStdPluginInterface
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
-	virtual void getActions(QActionGroup& group) override;
+	virtual QList<QAction *> getActions() override;
 
 protected slots:
 

--- a/plugins/core/qPoissonRecon/qPoissonRecon.cpp
+++ b/plugins/core/qPoissonRecon/qPoissonRecon.cpp
@@ -150,7 +150,7 @@ void qPoissonRecon::onNewSelection(const ccHObject::Container& selectedEntities)
 		m_action->setEnabled(selectedEntities.size()==1 && selectedEntities[0]->isA(CC_TYPES::POINT_CLOUD));
 }
 
-void qPoissonRecon::getActions(QActionGroup& group)
+QList<QAction *> qPoissonRecon::getActions()
 {
 	//default action
 	if (!m_action)
@@ -162,7 +162,7 @@ void qPoissonRecon::getActions(QActionGroup& group)
 		connect(m_action, &QAction::triggered, this, &qPoissonRecon::doAction);
 	}
 
-	group.addAction(m_action);
+	return QList<QAction *>{ m_action };
 }
 
 typedef PlyValueVertex< PointCoordinateType > Vertex;

--- a/plugins/core/qPoissonRecon/qPoissonRecon.h
+++ b/plugins/core/qPoissonRecon/qPoissonRecon.h
@@ -40,7 +40,7 @@ public:
 
 	//inherited from ccStdPluginInterface
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
-	virtual void getActions(QActionGroup& group) override;
+	virtual QList<QAction *> getActions() override;
 
 protected slots:
 

--- a/plugins/core/qRANSAC_SD/qRANSAC_SD.cpp
+++ b/plugins/core/qRANSAC_SD/qRANSAC_SD.cpp
@@ -64,9 +64,9 @@
 #endif
 
 qRansacSD::qRansacSD(QObject* parent/*=nullptr*/)
-	: QObject(parent)
-	, ccStdPluginInterface(":/CC/plugin/qRANSAC_SD/info.json")
-	, m_action(nullptr)
+    : QObject(parent)
+    , ccStdPluginInterface(":/CC/plugin/qRANSAC_SD/info.json")
+    , m_action(nullptr)
 {
 }
 
@@ -76,7 +76,7 @@ void qRansacSD::onNewSelection(const ccHObject::Container& selectedEntities)
 		m_action->setEnabled(selectedEntities.size()==1 && selectedEntities[0]->isA(CC_TYPES::POINT_CLOUD));
 }
 
-void qRansacSD::getActions(QActionGroup& group)
+QList<QAction *> qRansacSD::getActions()
 {
 	//default action
 	if (!m_action)
@@ -88,7 +88,7 @@ void qRansacSD::getActions(QActionGroup& group)
 		connect(m_action, SIGNAL(triggered()), this, SLOT(doAction()));
 	}
 
-	group.addAction(m_action);
+	return QList<QAction *>{ m_action };
 }
 
 static MiscLib::Vector< std::pair< MiscLib::RefCountPtr< PrimitiveShape >, size_t > >* s_shapes; // stores the detected shapes

--- a/plugins/core/qRANSAC_SD/qRANSAC_SD.h
+++ b/plugins/core/qRANSAC_SD/qRANSAC_SD.h
@@ -34,11 +34,11 @@ class qRansacSD : public QObject, public ccStdPluginInterface
 public:
 
 	//! Default constructor
-	explicit qRansacSD(QObject* parent = 0);
+	explicit qRansacSD(QObject* parent = nullptr);
 
 	//inherited from ccStdPluginInterface
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities);
-	virtual void getActions(QActionGroup& group);
+	virtual QList<QAction *> getActions() override;
 
 protected slots:
 

--- a/plugins/core/qSRA/qSRA.cpp
+++ b/plugins/core/qSRA/qSRA.cpp
@@ -55,7 +55,7 @@ qSRA::qSRA(QObject* parent/*=0*/)
 {
 }
 
-void qSRA::getActions(QActionGroup& group)
+QList<QAction *> qSRA::getActions()
 {
 	//actions
 	if (!m_doLoadProfile)
@@ -66,7 +66,6 @@ void qSRA::getActions(QActionGroup& group)
 		//connect signal
 		connect(m_doLoadProfile, &QAction::triggered, this, &qSRA::loadProfile);
 	}
-	group.addAction(m_doLoadProfile);
 
 	if (!m_doCompareCloudToProfile)
 	{
@@ -76,7 +75,6 @@ void qSRA::getActions(QActionGroup& group)
 		//connect signal
 		connect(m_doCompareCloudToProfile, &QAction::triggered, this, &qSRA::computeCloud2ProfileRadialDist);
 	}
-	group.addAction(m_doCompareCloudToProfile);
 
 	if (!m_doProjectCloudDists)
 	{
@@ -86,7 +84,12 @@ void qSRA::getActions(QActionGroup& group)
 		//connect signal
 		connect(m_doProjectCloudDists, &QAction::triggered, this, &qSRA::projectCloudDistsInGrid);
 	}
-	group.addAction(m_doProjectCloudDists);
+
+	return QList<QAction *>{
+				m_doLoadProfile,
+				m_doCompareCloudToProfile,
+				m_doProjectCloudDists,
+	};
 }
 
 void qSRA::onNewSelection(const ccHObject::Container& selectedEntities)

--- a/plugins/core/qSRA/qSRA.h
+++ b/plugins/core/qSRA/qSRA.h
@@ -39,7 +39,7 @@ public:
 
 	//inherited from ccStdPluginInterface
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
-	virtual void getActions(QActionGroup& group) override;
+	virtual QList<QAction *> getActions() override;
 
 protected slots:
 

--- a/plugins/example/ExamplePlugin/ExamplePlugin.cpp
+++ b/plugins/example/ExamplePlugin/ExamplePlugin.cpp
@@ -70,7 +70,7 @@ void ExamplePlugin::onNewSelection( const ccHObject::Container &selectedEntities
 
 // This method returns all the 'actions' your plugin can perform.
 // getActions() will be called only once, when plugin is loaded.
-void ExamplePlugin::getActions( QActionGroup &group )
+QList<QAction *> ExamplePlugin::getActions()
 {
 	// default action (if it has not been already created, this is the moment to do it)
 	if ( !m_action )
@@ -85,7 +85,7 @@ void ExamplePlugin::getActions( QActionGroup &group )
 		connect( m_action, &QAction::triggered, this, &ExamplePlugin::doAction );
 	}
 
-	group.addAction( m_action );
+	return QList<QAction *>{ m_action };
 }
 
 // This is an example of an action's method called when the corresponding action

--- a/plugins/example/ExamplePlugin/ExamplePlugin.h
+++ b/plugins/example/ExamplePlugin/ExamplePlugin.h
@@ -54,7 +54,7 @@ public:
 	
 	// inherited from ccStdPluginInterface
 	virtual void onNewSelection( const ccHObject::Container &selectedEntities ) override;
-	virtual void getActions( QActionGroup &group ) override;
+	virtual QList<QAction *> getActions() override;
 
 private:
 

--- a/qCC/pluginManager/ccPluginUIManager.cpp
+++ b/qCC/pluginManager/ccPluginUIManager.cpp
@@ -153,13 +153,11 @@ void ccPluginUIManager::init( const ccPluginInterfaceList &plugins )
 	
 	// add core standard plugins to menu & tool bar
 	for ( ccStdPluginInterface *plugin : coreStdPlugins )
-	{
-		QActionGroup actionGroup( this );
+	{		
+		QList<QAction *> actions = plugin->getActions();
 		
-		plugin->getActions( actionGroup );
-		
-		addActionsToMenu( plugin, actionGroup );
-		addActionsToToolBar( plugin, actionGroup );
+		addActionsToMenu( plugin, actions );
+		addActionsToToolBar( plugin, actions );
 
 		plugin->onNewSelection( m_appInterface->getSelectedEntities() );
 	}
@@ -170,13 +168,11 @@ void ccPluginUIManager::init( const ccPluginInterfaceList &plugins )
 		QAction	*separator = m_pluginMenu->addSection( "3rd Party" );
 		
 		for ( ccStdPluginInterface *plugin : thirdPartyStdPlugins )
-		{
-			QActionGroup actionGroup( this );
+		{			
+			QList<QAction *> actions = plugin->getActions();
 			
-			plugin->getActions( actionGroup );
-			
-			addActionsToMenu( plugin, actionGroup );
-			addActionsToToolBar( plugin, actionGroup );
+			addActionsToMenu( plugin, actions );
+			addActionsToToolBar( plugin, actions );
 
 			plugin->onNewSelection( m_appInterface->getSelectedEntities() );
 		}
@@ -321,19 +317,17 @@ void ccPluginUIManager::setupMenus()
 	m_glFilterActions.setExclusive( true );		
 }
 
-void ccPluginUIManager::addActionsToMenu( ccStdPluginInterface *stdPlugin, const QActionGroup &actionGroup )
+void ccPluginUIManager::addActionsToMenu( ccStdPluginInterface *stdPlugin, const QList<QAction *> &actions )
 {
-	const QList<QAction *>	actionList = actionGroup.actions();
-	
 	// If the plugin has more than one action we create its own menu
-	if (actionList.size() > 1 )
+	if ( actions.size() > 1 )
 	{
 		QMenu	*menu = new QMenu( stdPlugin->getName() );
 		
 		menu->setIcon( stdPlugin->getIcon() );
 		menu->setEnabled( true );
 		
-		for ( QAction* action : actionList )
+		for ( QAction* action : actions )
 		{
 			menu->addAction( action );
 		}
@@ -342,9 +336,9 @@ void ccPluginUIManager::addActionsToMenu( ccStdPluginInterface *stdPlugin, const
 	}
 	else // otherwise we just add it to the main menu
 	{		
-		Q_ASSERT( actionList.count() == 1 );
+		Q_ASSERT( actions.count() == 1 );
 		
-		m_pluginMenu->addAction( actionList.at( 0 ) );
+		m_pluginMenu->addAction( actions.at( 0 ) );
 	}
 }
 
@@ -364,14 +358,12 @@ void ccPluginUIManager::setupToolbars()
 	connect( m_showGLFilterToolbar, &QAction::toggled, m_glFiltersToolbar, &QToolBar::setVisible );
 }
 
-void ccPluginUIManager::addActionsToToolBar( ccStdPluginInterface *stdPlugin, const QActionGroup &actionGroup )
-{
-	const QList<QAction *>	actionList = actionGroup.actions();
-	
+void ccPluginUIManager::addActionsToToolBar( ccStdPluginInterface *stdPlugin, const QList<QAction *> &actions )
+{	
 	const QString pluginName = stdPlugin->getName();
 	
 	// If the plugin has more than one action we create its own tool bar
-	if (actionList.size() > 1 )
+	if ( actions.size() > 1 )
 	{
 		QToolBar *toolBar = new QToolBar( pluginName + QStringLiteral( " toolbar" ), m_parentWidget );
 		
@@ -382,7 +374,7 @@ void ccPluginUIManager::addActionsToToolBar( ccStdPluginInterface *stdPlugin, co
 			toolBar->setObjectName( pluginName );
 			toolBar->setEnabled( true );
 			
-			for ( QAction* action : actionList )
+			for ( QAction* action : actions )
 			{
 				toolBar->addAction( action );
 			}
@@ -390,9 +382,9 @@ void ccPluginUIManager::addActionsToToolBar( ccStdPluginInterface *stdPlugin, co
 	}
 	else // otherwise we just add it to the main tool bar
 	{		
-		Q_ASSERT( actionList.count() == 1 );
+		Q_ASSERT( actions.count() == 1 );
 		
-		m_mainPluginToolbar->addAction( actionList.at( 0 ) );
+		m_mainPluginToolbar->addAction( actions.at( 0 ) );
 	}
 }
 

--- a/qCC/pluginManager/ccPluginUIManager.cpp
+++ b/qCC/pluginManager/ccPluginUIManager.cpp
@@ -165,7 +165,7 @@ void ccPluginUIManager::init( const ccPluginInterfaceList &plugins )
 	// add 3rd standard party plugins to menu & tool bar (if any )
 	if ( !thirdPartyStdPlugins.isEmpty() )
 	{
-		QAction	*separator = m_pluginMenu->addSection( "3rd Party" );
+		m_pluginMenu->addSection( "3rd Party" );
 		
 		for ( ccStdPluginInterface *plugin : thirdPartyStdPlugins )
 		{			

--- a/qCC/pluginManager/ccPluginUIManager.h
+++ b/qCC/pluginManager/ccPluginUIManager.h
@@ -64,10 +64,10 @@ private:
 	void	setupActions();
 	
 	void	setupMenus();
-	void	addActionsToMenu( ccStdPluginInterface *stdPlugin, const QActionGroup &actionGroup );
+	void	addActionsToMenu( ccStdPluginInterface *stdPlugin, const QList<QAction *> &actions );
 
 	void	setupToolbars();
-	void	addActionsToToolBar( ccStdPluginInterface *stdPlugin, const QActionGroup &actionGroup );
+	void	addActionsToToolBar( ccStdPluginInterface *stdPlugin, const QList<QAction *> &actions );
 	
 	void	enableGLFilter();
 	void	disableGLFilter();


### PR DESCRIPTION
ccStdPluginInterface::getActions() returns a list of actions rather than filling in a QActionGroup