### PR TITLE
Orient normals toward a sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ v2.10.alpha - XX/XX/201X
 	* New behavior:
 		- Some load dialogs 'Apply all' button will only apply to the set of selected files (ASCII, PLY and LAS)
 
+	* Normals:
+		- Ergonomics of 'Normals > compute' dialog have been (hopefully) enhanced
+		- Normals can now be oriented toward a sensor even if there's no grid associated with the point cloud.
+
 	* PCV:
 		- the PCV plugin can now be applied on several clouds (batch mode)
 

--- a/libs/qCC_db/ccPointCloud.cpp
+++ b/libs/qCC_db/ccPointCloud.cpp
@@ -5485,36 +5485,36 @@ bool ccPointCloud::orientNormalsWithGrids(ccProgressDialog* pDlg/*=0*/)
 
 bool ccPointCloud::orientNormalsTowardViewPoint( CCVector3 & VP, ccProgressDialog* pDlg)
 {
-    int progressIndex = 0;
-    for (unsigned pointIndex = 0; pointIndex < m_points->capacity(); ++pointIndex)
-    {
-        const CCVector3* P = getPoint(pointIndex);
-        CCVector3 N = getPointNormal(pointIndex);
-        CCVector3 OP = *P - VP;
-        OP.normalize();
-        PointCoordinateType dotProd = OP.dot(N);
-        if (dotProd > 0)
-        {
-            N = -N;
-            setPointNormalIndex(pointIndex, ccNormalVectors::GetNormIndex(N));
-        }
+	int progressIndex = 0;
+	for (unsigned pointIndex = 0; pointIndex < m_points->capacity(); ++pointIndex)
+	{
+		const CCVector3* P = getPoint(pointIndex);
+		CCVector3 N = getPointNormal(pointIndex);
+		CCVector3 OP = *P - VP;
+		OP.normalize();
+		PointCoordinateType dotProd = OP.dot(N);
+		if (dotProd > 0)
+		{
+			N = -N;
+			setPointNormalIndex(pointIndex, ccNormalVectors::GetNormIndex(N));
+		}
 
-        if (pDlg)
-        {
-            //update progress dialog
-            if (pDlg->wasCanceled())
-            {
-                unallocateNorms();
-                ccLog::Warning("[orientNormalsWithSensors] Process cancelled by user");
-                return false;
-            }
-            else
-            {
-                pDlg->setValue(++progressIndex);
-            }
-        }
-    }
-    return true;
+		if (pDlg)
+		{
+			//update progress dialog
+			if (pDlg->wasCanceled())
+			{
+				unallocateNorms();
+				ccLog::Warning("[orientNormalsWithSensors] Process cancelled by user");
+				return false;
+			}
+			else
+			{
+				pDlg->setValue(++progressIndex);
+			}
+		}
+	}
+	return true;
 }
 
 bool ccPointCloud::computeNormalsWithOctree(CC_LOCAL_MODEL_TYPES model,
@@ -5598,7 +5598,7 @@ bool ccPointCloud::hasSensor() const
 	for (size_t i = 0; i < m_children.size(); ++i)
 	{
 		ccHObject* child = m_children[i];
-        if (child && child->isKindOf(CC_TYPES::SENSOR))
+		if (child && child->isKindOf(CC_TYPES::SENSOR))
 		{
 			return true;
 		}

--- a/libs/qCC_db/ccPointCloud.cpp
+++ b/libs/qCC_db/ccPointCloud.cpp
@@ -5483,6 +5483,40 @@ bool ccPointCloud::orientNormalsWithGrids(ccProgressDialog* pDlg/*=0*/)
 	return true;
 }
 
+bool ccPointCloud::orientNormalsTowardViewPoint( CCVector3 & VP, ccProgressDialog* pDlg)
+{
+    int progressIndex = 0;
+    for (unsigned pointIndex = 0; pointIndex < m_points->capacity(); ++pointIndex)
+    {
+        const CCVector3* P = getPoint(pointIndex);
+        CCVector3 N = getPointNormal(pointIndex);
+        CCVector3 OP = *P - VP;
+        OP.normalize();
+        PointCoordinateType dotProd = OP.dot(N);
+        if (dotProd > 0)
+        {
+            N = -N;
+            setPointNormalIndex(pointIndex, ccNormalVectors::GetNormIndex(N));
+        }
+
+        if (pDlg)
+        {
+            //update progress dialog
+            if (pDlg->wasCanceled())
+            {
+                unallocateNorms();
+                ccLog::Warning("[orientNormalsWithSensors] Process cancelled by user");
+                return false;
+            }
+            else
+            {
+                pDlg->setValue(++progressIndex);
+            }
+        }
+    }
+    return true;
+}
+
 bool ccPointCloud::computeNormalsWithOctree(CC_LOCAL_MODEL_TYPES model,
 											ccNormalVectors::Orientation preferredOrientation,
 											PointCoordinateType defaultRadius,
@@ -5564,7 +5598,7 @@ bool ccPointCloud::hasSensor() const
 	for (size_t i = 0; i < m_children.size(); ++i)
 	{
 		ccHObject* child = m_children[i];
-		if (child && child->isA(CC_TYPES::GBL_SENSOR))
+        if (child && child->isKindOf(CC_TYPES::SENSOR))
 		{
 			return true;
 		}

--- a/libs/qCC_db/ccPointCloud.h
+++ b/libs/qCC_db/ccPointCloud.h
@@ -355,27 +355,27 @@ public: //normals computation/orientation
 	/** Can also orient the normals in the same run.
 	**/
 	bool computeNormalsWithGrids(	double minTriangleAngle_deg = 1.0,
-                                    ccProgressDialog* pDlg = nullptr );
+									ccProgressDialog* pDlg = nullptr );
 
 	//! Orient the normals with the associated grid structure(s)
-    bool orientNormalsWithGrids(    ccProgressDialog* pDlg = nullptr );
+	bool orientNormalsWithGrids(    ccProgressDialog* pDlg = nullptr );
 
-    //! Normals are forced to point to O
-    bool orientNormalsTowardViewPoint( CCVector3 & VP, ccProgressDialog* pDlg = nullptr);
+	//! Normals are forced to point to O
+	bool orientNormalsTowardViewPoint( CCVector3 & VP, ccProgressDialog* pDlg = nullptr);
 
 	//! Compute the normals by approximating the local surface around each point
 	bool computeNormalsWithOctree(	CC_LOCAL_MODEL_TYPES model,
 									ccNormalVectors::Orientation preferredOrientation,
 									PointCoordinateType defaultRadius,
-                                    ccProgressDialog* pDlg = nullptr );
+									ccProgressDialog* pDlg = nullptr );
 
 	//! Orient the normals with a Minimum Spanning Tree
 	bool orientNormalsWithMST(		unsigned kNN = 6,
-                                    ccProgressDialog* pDlg = nullptr );
+									ccProgressDialog* pDlg = nullptr );
 
 	//! Orient normals with Fast Marching
 	bool orientNormalsWithFM(		unsigned char level,
-                                    ccProgressDialog* pDlg = nullptr);
+									ccProgressDialog* pDlg = nullptr);
 
 public: //waveform (e.g. from airborne scanners)
 

--- a/libs/qCC_db/ccPointCloud.h
+++ b/libs/qCC_db/ccPointCloud.h
@@ -355,24 +355,27 @@ public: //normals computation/orientation
 	/** Can also orient the normals in the same run.
 	**/
 	bool computeNormalsWithGrids(	double minTriangleAngle_deg = 1.0,
-									ccProgressDialog* pDlg = 0 );
+                                    ccProgressDialog* pDlg = nullptr );
 
 	//! Orient the normals with the associated grid structure(s)
-	bool orientNormalsWithGrids(	ccProgressDialog* pDlg = 0 );
+    bool orientNormalsWithGrids(    ccProgressDialog* pDlg = nullptr );
+
+    //! Normals are forced to point to O
+    bool orientNormalsTowardViewPoint( CCVector3 & VP, ccProgressDialog* pDlg = nullptr);
 
 	//! Compute the normals by approximating the local surface around each point
 	bool computeNormalsWithOctree(	CC_LOCAL_MODEL_TYPES model,
 									ccNormalVectors::Orientation preferredOrientation,
 									PointCoordinateType defaultRadius,
-									ccProgressDialog* pDlg = 0 );
+                                    ccProgressDialog* pDlg = nullptr );
 
 	//! Orient the normals with a Minimum Spanning Tree
 	bool orientNormalsWithMST(		unsigned kNN = 6,
-									ccProgressDialog* pDlg = 0 );
+                                    ccProgressDialog* pDlg = nullptr );
 
 	//! Orient normals with Fast Marching
 	bool orientNormalsWithFM(		unsigned char level,
-									ccProgressDialog* pDlg = 0 );
+                                    ccProgressDialog* pDlg = nullptr);
 
 public: //waveform (e.g. from airborne scanners)
 

--- a/qCC/ccEntityAction.cpp
+++ b/qCC/ccEntityAction.cpp
@@ -36,6 +36,7 @@
 #include "ccPointCloud.h"
 #include "ccPolyline.h"
 #include "ccPointCloudInterpolator.h"
+#include "ccSensor.h"
 
 //qCC_gl
 #include "ccGuiParameters.h"
@@ -1387,7 +1388,8 @@ namespace ccEntityAction
 		
 		//look for clouds and meshes
 		std::vector<ccPointCloud*> clouds;
-		size_t cloudsWithScanGrids = 0;
+        bool withScanGrid = false;
+        bool withSensor = false;
 		std::vector<ccMesh*> meshes;
 		PointCoordinateType defaultRadius = 0;
 		try
@@ -1400,9 +1402,17 @@ namespace ccEntityAction
 					ccPointCloud* cloud = static_cast<ccPointCloud*>(entity);
 					clouds.push_back(cloud);
 					
-					if (cloud->gridCount() != 0)
-						++cloudsWithScanGrids;
-					
+                    if(cloud->gridCount() > 0)
+                    {
+                        withScanGrid = true;
+                    }
+                    for(unsigned i = 0; i < cloud->getChildrenNumber(); ++i)
+                    {
+                        if(cloud->hasSensor()){
+                            withSensor = true;
+                        }
+                    }
+
 					if (defaultRadius == 0)
 					{
 						//default radius
@@ -1433,27 +1443,13 @@ namespace ccEntityAction
 		//compute normals for each selected cloud
 		if (!clouds.empty())
 		{
-			ccNormalComputationDlg::SelectionMode selectionMode = ccNormalComputationDlg::WITHOUT_SCAN_GRIDS;
-			if (cloudsWithScanGrids)
-			{
-				if (clouds.size() == cloudsWithScanGrids)
-				{
-					//all clouds have an associated grid
-					selectionMode = ccNormalComputationDlg::WITH_SCAN_GRIDS;
-				}
-				else
-				{
-					//only a part of the clouds have an associated grid
-					selectionMode = ccNormalComputationDlg::MIXED;
-				}
-			}
-			
+
 			static CC_LOCAL_MODEL_TYPES s_lastModelType = LS;
 			static ccNormalVectors::Orientation s_lastNormalOrientation = ccNormalVectors::UNDEFINED;
 			static int s_lastMSTNeighborCount = 6;
 			static double s_lastMinGridAngle_deg = 1.0;
 			
-			ccNormalComputationDlg ncDlg(selectionMode, parent);
+            ccNormalComputationDlg ncDlg(withScanGrid, withSensor, parent);
 			ncDlg.setLocalModel(s_lastModelType);
 			ncDlg.setRadius(defaultRadius);
 			ncDlg.setPreferredOrientation(s_lastNormalOrientation);
@@ -1468,14 +1464,15 @@ namespace ccEntityAction
 				return false;
 			
 			//normals computation
-			CC_LOCAL_MODEL_TYPES model = s_lastModelType = ncDlg.getLocalModel();
-			bool useGridStructure = cloudsWithScanGrids && ncDlg.useScanGridsForComputation();
+            CC_LOCAL_MODEL_TYPES model = s_lastModelType = ncDlg.getLocalModel();
+            bool useGridStructure = withScanGrid && ncDlg.useScanGridsForComputation();
 			defaultRadius = ncDlg.getRadius();
 			double minGridAngle_deg = s_lastMinGridAngle_deg = ncDlg.getMinGridAngle_deg();
 			
 			//normals orientation
 			bool orientNormals = ncDlg.orientNormals();
-			bool orientNormalsWithGrids = cloudsWithScanGrids && ncDlg.useScanGridsForOrientation();
+            bool orientNormalsWithGrids = withScanGrid && ncDlg.useScanGridsForOrientation();
+            bool orientNormalsWithSensors = withSensor && ncDlg.useSensorsForOrientation();
 			ccNormalVectors::Orientation preferredOrientation = s_lastNormalOrientation = ncDlg.getPreferredOrientation();
 			bool orientNormalsMST = ncDlg.useMSTOrientation();
 			int mstNeighbors = s_lastMSTNeighborCount = ncDlg.getMSTNeighborCount();
@@ -1543,7 +1540,32 @@ namespace ccEntityAction
 					{
 						//we can still use the grid structure(s) to orient the normals!
 						result = cloud->orientNormalsWithGrids();
-					}
+                    }
+                    else if (cloud->hasSensor() && orientNormalsWithSensors)
+                    {
+                        result = false;
+
+                        // RJ: TODO: the issue here is that a cloud can have multiple sensors.
+                        // As the association to sensor is not explicit in CC, given a cloud
+                        // some points can belong to one sensor and some others can belongs to others sensors.
+                        // so it's why here grid orientation has precedence over sensor orientation because in this
+                        // case association is more explicit.
+                        // Here we take the first valid viewpoint for now even if it's not a really good...
+                        CCVector3 sensorPosition;
+                        for (size_t i = 0; i < cloud->getChildrenNumber(); ++i)
+                        {
+                            ccHObject* child = cloud->getChild(i);
+                            if (child && child->isKindOf(CC_TYPES::SENSOR))
+                            {
+                                ccSensor* sensor = ccHObjectCaster::ToSensor(child);
+                                if(sensor->getActiveAbsoluteCenter(sensorPosition))
+                                {
+                                    result = cloud->orientNormalsTowardViewPoint(sensorPosition, &pDlg);
+                                    break;
+                                }
+                            }
+                        }
+                    }
 					else if (orientNormalsMST)
 					{
 						//use Minimum Spanning Tree to resolve normals direction

--- a/qCC/ccEntityAction.cpp
+++ b/qCC/ccEntityAction.cpp
@@ -1402,13 +1402,13 @@ namespace ccEntityAction
 					ccPointCloud* cloud = static_cast<ccPointCloud*>(entity);
 					clouds.push_back(cloud);
 					
-					if(cloud->gridCount() > 0)
+					if (cloud->gridCount() > 0)
 					{
 						withScanGrid = true;
 					}
-					for(unsigned i = 0; i < cloud->getChildrenNumber(); ++i)
+					for (unsigned i = 0; i < cloud->getChildrenNumber(); ++i)
 					{
-						if(cloud->hasSensor()){
+						if (cloud->hasSensor()){
 							withSensor = true;
 						}
 					}
@@ -1558,7 +1558,7 @@ namespace ccEntityAction
 							if (child && child->isKindOf(CC_TYPES::SENSOR))
 							{
 								ccSensor* sensor = ccHObjectCaster::ToSensor(child);
-								if(sensor->getActiveAbsoluteCenter(sensorPosition))
+								if (sensor->getActiveAbsoluteCenter(sensorPosition))
 								{
 									result = cloud->orientNormalsTowardViewPoint(sensorPosition, &pDlg);
 									break;

--- a/qCC/ccEntityAction.cpp
+++ b/qCC/ccEntityAction.cpp
@@ -1388,8 +1388,8 @@ namespace ccEntityAction
 		
 		//look for clouds and meshes
 		std::vector<ccPointCloud*> clouds;
-        bool withScanGrid = false;
-        bool withSensor = false;
+		bool withScanGrid = false;
+		bool withSensor = false;
 		std::vector<ccMesh*> meshes;
 		PointCoordinateType defaultRadius = 0;
 		try
@@ -1402,16 +1402,16 @@ namespace ccEntityAction
 					ccPointCloud* cloud = static_cast<ccPointCloud*>(entity);
 					clouds.push_back(cloud);
 					
-                    if(cloud->gridCount() > 0)
-                    {
-                        withScanGrid = true;
-                    }
-                    for(unsigned i = 0; i < cloud->getChildrenNumber(); ++i)
-                    {
-                        if(cloud->hasSensor()){
-                            withSensor = true;
-                        }
-                    }
+					if(cloud->gridCount() > 0)
+					{
+						withScanGrid = true;
+					}
+					for(unsigned i = 0; i < cloud->getChildrenNumber(); ++i)
+					{
+						if(cloud->hasSensor()){
+							withSensor = true;
+						}
+					}
 
 					if (defaultRadius == 0)
 					{
@@ -1449,7 +1449,7 @@ namespace ccEntityAction
 			static int s_lastMSTNeighborCount = 6;
 			static double s_lastMinGridAngle_deg = 1.0;
 			
-            ccNormalComputationDlg ncDlg(withScanGrid, withSensor, parent);
+			ccNormalComputationDlg ncDlg(withScanGrid, withSensor, parent);
 			ncDlg.setLocalModel(s_lastModelType);
 			ncDlg.setRadius(defaultRadius);
 			ncDlg.setPreferredOrientation(s_lastNormalOrientation);
@@ -1464,15 +1464,15 @@ namespace ccEntityAction
 				return false;
 			
 			//normals computation
-            CC_LOCAL_MODEL_TYPES model = s_lastModelType = ncDlg.getLocalModel();
-            bool useGridStructure = withScanGrid && ncDlg.useScanGridsForComputation();
+			CC_LOCAL_MODEL_TYPES model = s_lastModelType = ncDlg.getLocalModel();
+			bool useGridStructure = withScanGrid && ncDlg.useScanGridsForComputation();
 			defaultRadius = ncDlg.getRadius();
 			double minGridAngle_deg = s_lastMinGridAngle_deg = ncDlg.getMinGridAngle_deg();
 			
 			//normals orientation
 			bool orientNormals = ncDlg.orientNormals();
-            bool orientNormalsWithGrids = withScanGrid && ncDlg.useScanGridsForOrientation();
-            bool orientNormalsWithSensors = withSensor && ncDlg.useSensorsForOrientation();
+			bool orientNormalsWithGrids = withScanGrid && ncDlg.useScanGridsForOrientation();
+			bool orientNormalsWithSensors = withSensor && ncDlg.useSensorsForOrientation();
 			ccNormalVectors::Orientation preferredOrientation = s_lastNormalOrientation = ncDlg.getPreferredOrientation();
 			bool orientNormalsMST = ncDlg.useMSTOrientation();
 			int mstNeighbors = s_lastMSTNeighborCount = ncDlg.getMSTNeighborCount();
@@ -1540,32 +1540,32 @@ namespace ccEntityAction
 					{
 						//we can still use the grid structure(s) to orient the normals!
 						result = cloud->orientNormalsWithGrids();
-                    }
-                    else if (cloud->hasSensor() && orientNormalsWithSensors)
-                    {
-                        result = false;
+					}
+					else if (cloud->hasSensor() && orientNormalsWithSensors)
+					{
+						result = false;
 
-                        // RJ: TODO: the issue here is that a cloud can have multiple sensors.
-                        // As the association to sensor is not explicit in CC, given a cloud
-                        // some points can belong to one sensor and some others can belongs to others sensors.
-                        // so it's why here grid orientation has precedence over sensor orientation because in this
-                        // case association is more explicit.
-                        // Here we take the first valid viewpoint for now even if it's not a really good...
-                        CCVector3 sensorPosition;
-                        for (size_t i = 0; i < cloud->getChildrenNumber(); ++i)
-                        {
-                            ccHObject* child = cloud->getChild(i);
-                            if (child && child->isKindOf(CC_TYPES::SENSOR))
-                            {
-                                ccSensor* sensor = ccHObjectCaster::ToSensor(child);
-                                if(sensor->getActiveAbsoluteCenter(sensorPosition))
-                                {
-                                    result = cloud->orientNormalsTowardViewPoint(sensorPosition, &pDlg);
-                                    break;
-                                }
-                            }
-                        }
-                    }
+						// RJ: TODO: the issue here is that a cloud can have multiple sensors.
+						// As the association to sensor is not explicit in CC, given a cloud
+						// some points can belong to one sensor and some others can belongs to others sensors.
+						// so it's why here grid orientation has precedence over sensor orientation because in this
+						// case association is more explicit.
+						// Here we take the first valid viewpoint for now even if it's not a really good...
+						CCVector3 sensorPosition;
+						for (size_t i = 0; i < cloud->getChildrenNumber(); ++i)
+						{
+							ccHObject* child = cloud->getChild(i);
+							if (child && child->isKindOf(CC_TYPES::SENSOR))
+							{
+								ccSensor* sensor = ccHObjectCaster::ToSensor(child);
+								if(sensor->getActiveAbsoluteCenter(sensorPosition))
+								{
+									result = cloud->orientNormalsTowardViewPoint(sensorPosition, &pDlg);
+									break;
+								}
+							}
+						}
+					}
 					else if (orientNormalsMST)
 					{
 						//use Minimum Spanning Tree to resolve normals direction

--- a/qCC/ccNormalComputationDlg.cpp
+++ b/qCC/ccNormalComputationDlg.cpp
@@ -28,63 +28,45 @@
 //system
 #include <assert.h>
 
-ccNormalComputationDlg::ccNormalComputationDlg(SelectionMode selectionMode, QWidget* parent/*=0*/)
+ccNormalComputationDlg::ccNormalComputationDlg(bool withScanGrid, bool withSensor, QWidget* parent/*=nullptr*/)
 	: QDialog(parent, Qt::Tool)
 	, Ui::NormalComputationDlg()
-	, m_cloud(0)
-	, m_selectionMode(selectionMode)
+    , m_cloud(nullptr)
 {
 	setupUi(this);
 
 	//by default, the 'auto' button is hidden (as long as setCloud is not called)
 	autoRadiusToolButton->setVisible(false);
 
-	connect(localModelComboBox,			SIGNAL(currentIndexChanged(int)), this, SLOT(localModelChanged(int)));
-	connect(autoRadiusToolButton,		SIGNAL(clicked()),                this, SLOT(autoEstimateRadius()));
+    connect(localModelComboBox,			SIGNAL(currentIndexChanged(int)), this, SLOT(localModelChanged(int)));
+    connect(autoRadiusToolButton,		SIGNAL(clicked()),                this, SLOT(autoEstimateRadius()));
 
-	//selection mode
-	{
-		//warning label (for MIXED selection)
-		mixedSelectionLabel->setVisible(selectionMode == MIXED);
+        if(withScanGrid)
+        {
+            useScanGridCheckBox->setChecked(true);
+            scanGridsOrientCheckBox->setChecked(true);
+        }
+        else
+        {
+            //disable 'scan grid' options
+            useScanGridCheckBox->setChecked(false);
+            useScanGridCheckBox->setEnabled(false);
+            gridAngleFrame->setEnabled(false);
 
-		switch (selectionMode)
-		{
-		case WITH_SCAN_GRIDS:
-			{
-				useScanGridRadioButton->setChecked(true);
-				scanGridsOrientRadioButton->setChecked(true);
-			}
-			break;
+            scanGridsOrientCheckBox->setChecked(false);
+            scanGridsOrientCheckBox->setEnabled(false);
+        }
 
-		case MIXED:
-			{
-				//both computation methods can be chosen
-				useScanGridRadioButton->setAutoExclusive(false);
-				useOctreeRadioButton->setAutoExclusive(false);
-				useOctreeRadioButton->setChecked(true);
-				useOctreeRadioButton->setEnabled(true);
-				//and the orientation methods can also be mixed
-				scanGridsOrientRadioButton->setAutoExclusive(false);
-			}
-			break;
-
-		case WITHOUT_SCAN_GRIDS:
-			{
-				//disable 'scan grid' options
-				useScanGridRadioButton->setChecked(false);
-				useScanGridRadioButton->setEnabled(false);
-
-				scanGridsOrientRadioButton->setChecked(false);
-				scanGridsOrientRadioButton->setEnabled(false);
-
-			}
-			break;
-
-		default:
-			assert(false);
-			break;
-		}
-	}
+        if(withSensor)
+        {
+            sensorOrientCheckBox->setChecked(true);
+        }
+        else
+        {
+            //disable 'sensor' options
+            sensorOrientCheckBox->setChecked(false);
+            sensorOrientCheckBox->setEnabled(false);
+        }
 }
 
 void ccNormalComputationDlg::setLocalModel(CC_LOCAL_MODEL_TYPES  model)
@@ -163,7 +145,7 @@ void ccNormalComputationDlg::setPreferredOrientation(ccNormalVectors::Orientatio
 
 bool ccNormalComputationDlg::useScanGridsForComputation() const
 {
-	return useScanGridRadioButton->isChecked();
+	return useScanGridCheckBox->isChecked();
 }
 
 double ccNormalComputationDlg::getMinGridAngle_deg() const
@@ -183,7 +165,12 @@ bool ccNormalComputationDlg::orientNormals() const
 
 bool ccNormalComputationDlg::useScanGridsForOrientation() const
 {
-	return scanGridsOrientRadioButton->isChecked();
+	return scanGridsOrientCheckBox->isChecked();
+}
+
+bool ccNormalComputationDlg::useSensorsForOrientation() const
+{
+	return sensorOrientCheckBox->isChecked();
 }
 
 bool ccNormalComputationDlg::usePreferredOrientation() const

--- a/qCC/ccNormalComputationDlg.cpp
+++ b/qCC/ccNormalComputationDlg.cpp
@@ -31,42 +31,42 @@
 ccNormalComputationDlg::ccNormalComputationDlg(bool withScanGrid, bool withSensor, QWidget* parent/*=nullptr*/)
 	: QDialog(parent, Qt::Tool)
 	, Ui::NormalComputationDlg()
-    , m_cloud(nullptr)
+	, m_cloud(nullptr)
 {
 	setupUi(this);
 
 	//by default, the 'auto' button is hidden (as long as setCloud is not called)
 	autoRadiusToolButton->setVisible(false);
 
-    connect(localModelComboBox,			SIGNAL(currentIndexChanged(int)), this, SLOT(localModelChanged(int)));
-    connect(autoRadiusToolButton,		SIGNAL(clicked()),                this, SLOT(autoEstimateRadius()));
+	connect(localModelComboBox,			SIGNAL(currentIndexChanged(int)), this, SLOT(localModelChanged(int)));
+	connect(autoRadiusToolButton,		SIGNAL(clicked()),                this, SLOT(autoEstimateRadius()));
 
-        if(withScanGrid)
-        {
-            useScanGridCheckBox->setChecked(true);
-            scanGridsOrientCheckBox->setChecked(true);
-        }
-        else
-        {
-            //disable 'scan grid' options
-            useScanGridCheckBox->setChecked(false);
-            useScanGridCheckBox->setEnabled(false);
-            gridAngleFrame->setEnabled(false);
+	if(withScanGrid)
+	{
+		useScanGridCheckBox->setChecked(true);
+		scanGridsOrientCheckBox->setChecked(true);
+	}
+	else
+	{
+		//disable 'scan grid' options
+		useScanGridCheckBox->setChecked(false);
+		useScanGridCheckBox->setEnabled(false);
+		gridAngleFrame->setEnabled(false);
 
-            scanGridsOrientCheckBox->setChecked(false);
-            scanGridsOrientCheckBox->setEnabled(false);
-        }
+		scanGridsOrientCheckBox->setChecked(false);
+		scanGridsOrientCheckBox->setEnabled(false);
+	}
 
-        if(withSensor)
-        {
-            sensorOrientCheckBox->setChecked(true);
-        }
-        else
-        {
-            //disable 'sensor' options
-            sensorOrientCheckBox->setChecked(false);
-            sensorOrientCheckBox->setEnabled(false);
-        }
+	if(withSensor)
+	{
+		sensorOrientCheckBox->setChecked(true);
+	}
+	else
+	{
+		//disable 'sensor' options
+		sensorOrientCheckBox->setChecked(false);
+		sensorOrientCheckBox->setEnabled(false);
+	}
 }
 
 void ccNormalComputationDlg::setLocalModel(CC_LOCAL_MODEL_TYPES  model)

--- a/qCC/ccNormalComputationDlg.cpp
+++ b/qCC/ccNormalComputationDlg.cpp
@@ -41,7 +41,7 @@ ccNormalComputationDlg::ccNormalComputationDlg(bool withScanGrid, bool withSenso
 	connect(localModelComboBox,			SIGNAL(currentIndexChanged(int)), this, SLOT(localModelChanged(int)));
 	connect(autoRadiusToolButton,		SIGNAL(clicked()),                this, SLOT(autoEstimateRadius()));
 
-	if(withScanGrid)
+	if (withScanGrid)
 	{
 		useScanGridCheckBox->setChecked(true);
 		scanGridsOrientCheckBox->setChecked(true);

--- a/qCC/ccNormalComputationDlg.cpp
+++ b/qCC/ccNormalComputationDlg.cpp
@@ -57,7 +57,7 @@ ccNormalComputationDlg::ccNormalComputationDlg(bool withScanGrid, bool withSenso
 		scanGridsOrientCheckBox->setEnabled(false);
 	}
 
-	if(withSensor)
+	if (withSensor)
 	{
 		sensorOrientCheckBox->setChecked(true);
 	}

--- a/qCC/ccNormalComputationDlg.h
+++ b/qCC/ccNormalComputationDlg.h
@@ -33,14 +33,12 @@ class ccNormalComputationDlg : public QDialog, public Ui::NormalComputationDlg
 
 public:
 
-	//! Types of the clouds in the current selection (i.e. with or without scan grids)
-	enum SelectionMode { WITH_SCAN_GRIDS = 1, WITHOUT_SCAN_GRIDS = 2, MIXED = 3 };
-
 	//! Default constructor
-	/** \param selectionMode selection mode
+    /** \param withScanGrid whether the selection contains some structured point clouds
+     *  \param withSensor whether the selection contains some sensors associated to the point clouds
 		\param parent parent widget
 	**/
-	explicit ccNormalComputationDlg(SelectionMode selectionMode, QWidget* parent = 0);
+    explicit ccNormalComputationDlg(bool withScanGrid, bool withSensor, QWidget* parent = nullptr);
 
 	//! Returns the local model chosen for normal computation
 	CC_LOCAL_MODEL_TYPES getLocalModel() const;
@@ -75,6 +73,9 @@ public:
 	//! Returns whether scan grids should be used for normals orientation
 	bool useScanGridsForOrientation() const;
 
+	//! Returns whether scan grids should be used for normals computation
+	bool useSensorsForOrientation() const;
+
 	//! Returns whether a preferred orientation should be used
 	bool usePreferredOrientation() const;
 
@@ -102,10 +103,6 @@ protected:
 
 	//! Selected cloud
 	ccPointCloud* m_cloud;
-
-	//! Current selection mode
-	SelectionMode m_selectionMode;
-
 };
 
 #endif // CC_NORMAL_COMPUTATION_DLG_HEADER

--- a/qCC/ccNormalComputationDlg.h
+++ b/qCC/ccNormalComputationDlg.h
@@ -38,7 +38,7 @@ public:
 	 *  \param withSensor whether the selection contains some sensors associated to the point clouds
 		\param parent parent widget
 	**/
-    explicit ccNormalComputationDlg(bool withScanGrid, bool withSensor, QWidget* parent = nullptr);
+	explicit ccNormalComputationDlg(bool withScanGrid, bool withSensor, QWidget* parent = nullptr);
 
 	//! Returns the local model chosen for normal computation
 	CC_LOCAL_MODEL_TYPES getLocalModel() const;

--- a/qCC/ccNormalComputationDlg.h
+++ b/qCC/ccNormalComputationDlg.h
@@ -34,8 +34,8 @@ class ccNormalComputationDlg : public QDialog, public Ui::NormalComputationDlg
 public:
 
 	//! Default constructor
-    /** \param withScanGrid whether the selection contains some structured point clouds
-     *  \param withSensor whether the selection contains some sensors associated to the point clouds
+	/** \param withScanGrid whether the selection contains some structured point clouds
+	 *  \param withSensor whether the selection contains some sensors associated to the point clouds
 		\param parent parent widget
 	**/
     explicit ccNormalComputationDlg(bool withScanGrid, bool withSensor, QWidget* parent = nullptr);

--- a/qCC/ui_templates/normalComputationDlg.ui
+++ b/qCC/ui_templates/normalComputationDlg.ui
@@ -6,27 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>418</width>
-    <height>387</height>
+    <width>482</width>
+    <height>434</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Compute normals</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
-   <item>
-    <widget class="QLabel" name="mixedSelectionLabel">
-     <property name="styleSheet">
-      <string notr="true">color: red;</string>
-     </property>
-     <property name="text">
-      <string>Mixed selection: some clouds don't have scan grid(s)</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
    <item>
     <widget class="QGroupBox" name="surfaceGroupBox">
      <property name="title">
@@ -89,7 +76,7 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
-         <widget class="QRadioButton" name="useScanGridRadioButton">
+         <widget class="QCheckBox" name="useScanGridCheckBox">
           <property name="toolTip">
            <string>Using scan grid(s) instead of the octree</string>
           </property>
@@ -112,9 +99,9 @@
          </spacer>
         </item>
         <item>
-         <widget class="QFrame" name="gridKernelFrame">
+         <widget class="QFrame" name="gridAngleFrame">
           <property name="enabled">
-           <bool>false</bool>
+           <bool>true</bool>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout">
            <property name="leftMargin">
@@ -131,8 +118,11 @@
            </property>
            <item>
             <widget class="QLabel" name="label_3">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
              <property name="toolTip">
-              <string>Each normal will be computed using the (2p+1)*(2p+1) neighbors in the grid</string>
+              <string>min triangulation angle</string>
              </property>
              <property name="text">
               <string>min angle</string>
@@ -141,6 +131,9 @@
            </item>
            <item>
             <widget class="QDoubleSpinBox" name="gridAngleDoubleSpinBox">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
              <property name="toolTip">
               <string>Min angle of local triangles (in degrees)</string>
              </property>
@@ -190,15 +183,9 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_10">
         <item>
-         <widget class="QRadioButton" name="useOctreeRadioButton">
-          <property name="toolTip">
-           <string>The octree works for any cloud</string>
-          </property>
+         <widget class="QLabel" name="label_4">
           <property name="text">
-           <string>use octree</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
+           <string>Octree</string>
           </property>
          </widget>
         </item>
@@ -296,12 +283,25 @@
        <number>30</number>
       </property>
       <item>
-       <widget class="QRadioButton" name="scanGridsOrientRadioButton">
+       <widget class="QCheckBox" name="scanGridsOrientCheckBox">
         <property name="toolTip">
-         <string>Using scan grid(s) is the most robust method</string>
+         <string>Use scan grid(s) (robust method)</string>
         </property>
         <property name="text">
-         <string>Use scan grid(s) whenever possible</string>
+         <string>Use scan grid(s)  whenever possible</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="sensorOrientCheckBox">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Use sensor position to orient normals (if both grid and sensor ar ticked, sensor has precedence over grid)</string>
+        </property>
+        <property name="text">
+         <string>Use sensor(s) whenever possible</string>
         </property>
        </widget>
       </item>
@@ -475,7 +475,6 @@
   </layout>
   <zorder>buttonBox</zorder>
   <zorder>normalsOrientGroupBox</zorder>
-  <zorder>mixedSelectionLabel</zorder>
   <zorder>surfaceGroupBox</zorder>
   <zorder>neighborsGroupBox</zorder>
  </widget>
@@ -488,8 +487,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
+     <x>257</x>
+     <y>424</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -504,44 +503,12 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
+     <x>325</x>
+     <y>424</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>useScanGridRadioButton</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>gridKernelFrame</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>136</x>
-     <y>120</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>414</x>
-     <y>120</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>useOctreeRadioButton</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>localRadiusFrame</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>77</x>
-     <y>154</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>364</x>
-     <y>154</y>
     </hint>
    </hints>
   </connection>
@@ -552,12 +519,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>145</x>
-     <y>238</y>
+     <x>188</x>
+     <y>316</y>
     </hint>
     <hint type="destinationlabel">
-     <x>359</x>
-     <y>238</y>
+     <x>456</x>
+     <y>317</y>
     </hint>
    </hints>
   </connection>
@@ -568,12 +535,28 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>118</x>
-     <y>266</y>
+     <x>161</x>
+     <y>349</y>
     </hint>
     <hint type="destinationlabel">
-     <x>332</x>
-     <y>266</y>
+     <x>456</x>
+     <y>351</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>useScanGridCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>gridAngleFrame</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>276</x>
+     <y>128</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>388</x>
+     <y>129</y>
     </hint>
    </hints>
   </connection>

--- a/qCC/ui_templates/normalComputationDlg.ui
+++ b/qCC/ui_templates/normalComputationDlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>482</width>
-    <height>434</height>
+    <height>411</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -298,7 +298,7 @@
          <bool>true</bool>
         </property>
         <property name="toolTip">
-         <string>Use sensor position to orient normals (if both grid and sensor ar ticked, sensor has precedence over grid)</string>
+         <string>Use sensor position to orient normals (if both grid and sensor are selected, 'grid' has precedence over 'sensor')</string>
         </property>
         <property name="text">
          <string>Use sensor(s) whenever possible</string>


### PR DESCRIPTION
This commit :
-  Adds a new method to ccPointCloud : orientNormalsTowardViewPoint
- Use this method in qCC to add a optional "use sensor" method to "Normal > compute" that could be useful in the case user have a sensor but no grid associated with the point cloud.
- Improve ergonomics of "Normal > compute" dialog: previous "use grid" radio button behave like and was semantically a checkbox

