### PR TITLE
Add some TBB

### DIFF
--- a/cmake/CMakeExternalLibs.cmake
+++ b/cmake/CMakeExternalLibs.cmake
@@ -73,3 +73,8 @@ if (OPENMP_FOUND)
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 endif()
+
+# Intel's Threading Building Blocks (TBB)
+if (COMPILE_CC_CORE_LIB_WITH_TBB)
+	set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_TBB")
+endif()

--- a/qCC/ccContourExtractor.cpp
+++ b/qCC/ccContourExtractor.cpp
@@ -33,6 +33,10 @@
 #include <Neighbourhood.h>
 #include <PointProjectionTools.h>
 
+#ifdef USE_TBB
+#include <tbb/parallel_for.h>
+#endif
+
 //System
 #include <assert.h>
 #include <cmath>
@@ -71,7 +75,7 @@ struct Edge
 //! Finds the nearest (available) point to an edge
 /** \return The nearest point distance (or -1 if no point was found!)
 **/
-PointCoordinateType FindNearestCandidate(	unsigned& minIndex,
+static PointCoordinateType FindNearestCandidate(unsigned& minIndex,
 											const VertexIterator& itA,
 											const VertexIterator& itB,
 											const std::vector<Vertex2D>& points,
@@ -82,9 +86,65 @@ PointCoordinateType FindNearestCandidate(	unsigned& minIndex,
 {
 	//look for the nearest point in the input set
 	PointCoordinateType minDist2 = -1;
-	CCVector2 AB = **itB-**itA;
-	PointCoordinateType squareLengthAB = AB.norm2();
-	unsigned pointCount = static_cast<unsigned>(points.size());
+	const CCVector2 AB = **itB-**itA;
+	const PointCoordinateType squareLengthAB = AB.norm2();
+	const unsigned pointCount = static_cast<unsigned>(points.size());
+
+#ifdef USE_TBB
+	tbb::parallel_for( static_cast<unsigned int>(0), pointCount, [&](unsigned int i) {
+		const Vertex2D& P = points[i];
+		if (pointFlags[P.index] != POINT_NOT_USED)
+			return;
+
+		//skip the edge vertices!
+		if (P.index == (*itA)->index || P.index == (*itB)->index)
+		{
+			return;
+		}
+
+		//we only consider 'inner' points
+		const CCVector2 AP = P-**itA;
+		if (AB.x * AP.y - AB.y * AP.x < 0)
+		{
+			return;
+		}
+
+		//check the angle
+		if (minCosAngle > -1.0)
+		{
+			const CCVector2 PB = **itB - P;
+			const PointCoordinateType dotProd = AP.x * PB.x + AP.y * PB.y;
+			const PointCoordinateType minDotProd = static_cast<PointCoordinateType>(minCosAngle * std::sqrt(AP.norm2() * PB.norm2()));
+			if (dotProd < minDotProd)
+			{
+				return;
+			}
+		}
+
+		const PointCoordinateType dot = AB.dot(AP); // = cos(PAB) * ||AP|| * ||AB||
+		if (dot >= 0 && dot <= squareLengthAB)
+		{
+			const CCVector2 HP = AP - AB * (dot / squareLengthAB);
+			const PointCoordinateType dist2 = HP.norm2();
+			if (minDist2 < 0 || dist2 < minDist2)
+			{
+				//the 'nearest' point must also be a valid candidate
+				//(i.e. at least one of the created edges is smaller than the original one
+				//and we don't create too small edges!)
+				const PointCoordinateType squareLengthAP = AP.norm2();
+				const PointCoordinateType squareLengthBP = (P-**itB).norm2();
+				if (	squareLengthAP >= minSquareEdgeLength
+					&&	squareLengthBP >= minSquareEdgeLength
+					&&	(allowLongerChunks || (squareLengthAP < squareLengthAB || squareLengthBP < squareLengthAB))
+					)
+				{
+					minDist2 = dist2;
+					minIndex = i;
+				}
+			}
+		}
+	} );
+#else
 	for (unsigned i=0; i<pointCount; ++i)
 	{
 		const Vertex2D& P = points[i];
@@ -139,6 +199,8 @@ PointCoordinateType FindNearestCandidate(	unsigned& minIndex,
 			}
 		}
 	}
+#endif
+	
 	return (minDist2 < 0 ? minDist2 : minDist2/squareLengthAB);
 }
 

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -128,6 +128,10 @@
 #include "devices/gamepad/ccGamepadManager.h"
 #endif
 
+#ifdef USE_TBB
+#include <tbb/tbb_stddef.h>
+#endif
+
 //Qt UI files
 #include <ui_distanceMapDlg.h>
 #include <ui_globalShiftSettingsDlg.h>
@@ -281,6 +285,12 @@ MainWindow::MainWindow()
 	updateUI();
 
 	QMainWindow::statusBar()->showMessage(QString("Ready"));
+	
+#ifdef USE_TBB
+	ccConsole::Print( QStringLiteral( "[TBB] Using Intel's Threading Building Blocks %1.%2" )
+					  .arg( QString::number( TBB_VERSION_MAJOR ), QString::number( TBB_VERSION_MINOR ) ) );
+#endif
+	
 	ccConsole::Print("CloudCompare started!");
 }
 


### PR DESCRIPTION
If CCLib is configured with TBB, use it in CC as well.

Output the TBB version to the console so we know that it's active and which version is being used.

Convert an OpenMP use to see what the syntax change is like.

Add a new parallelization to speed up contour extraction. This duplicates the code in the for loop. Could `#ifdef` the continue/return, but I feel like that gets messy as well. I think it's worth living with the duplication (2-4x speedup on a 4 core machine) for these targeted optimisations, but I don't feel too strongly about it.