### PR TITLE
Fix multiplier of epsilon parameter in qRansac_SD

### DIFF
--- a/plugins/core/qRANSAC_SD/qRANSAC_SD.cpp
+++ b/plugins/core/qRANSAC_SD/qRANSAC_SD.cpp
@@ -233,7 +233,7 @@ void qRansacSD::doAction()
 	//import parameters from dialog
 	RansacShapeDetector::Options ransacOptions;
 	{
-		ransacOptions.m_epsilon			= static_cast<float>(rsdDlg.epsilonDoubleSpinBox->value() * 3.0); //internally this threshold is multiplied by 3!
+		ransacOptions.m_epsilon			= static_cast<float>(rsdDlg.epsilonDoubleSpinBox->value());
 		ransacOptions.m_bitmapEpsilon	= static_cast<float>(rsdDlg.bitmapEpsilonDoubleSpinBox->value());
 		ransacOptions.m_normalThresh	= static_cast<float>(cos(rsdDlg.maxNormDevAngleSpinBox->value() * CC_DEG_TO_RAD));
 		assert( ransacOptions.m_normalThresh >= 0 );


### PR DESCRIPTION
Internally the parameter is already multiplied by 3 (but why?) 
see:
- https://github.com/CloudCompare/CloudCompare/blob/master/plugins/core/qRANSAC_SD/RANSAC_SD_orig/RansacShapeDetector.cpp#L628.
https://github.com/CloudCompare/CloudCompare/blob/master/plugins/core/qRANSAC_SD/RANSAC_SD_orig/ReadMe.txt#L75