### PR TITLE
Replace obsolete CMake macro qt5_use_module()

### DIFF
--- a/CC/CMakeLists.txt
+++ b/CC/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 
 if ( COMPILE_CC_CORE_LIB_WITH_QT )
 	include_directories( ${Qt5Widgets_INCLUDE_DIRS} ${Qt5Core_INCLUDE_DIRS} )
-	qt5_use_modules(${PROJECT_NAME} Core Widgets Concurrent)
+	target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Widgets Qt5::Concurrent)
 	set_property( TARGET ${PROJECT_NAME} APPEND PROPERTY COMPILE_DEFINITIONS USE_QT )
 endif()
 

--- a/ccViewer/CMakeLists.txt
+++ b/ccViewer/CMakeLists.txt
@@ -57,7 +57,7 @@ target_link_libraries( ${PROJECT_NAME} QCC_IO_LIB )
 target_link_libraries( ${PROJECT_NAME} QCC_GL_LIB )
 
 # Qt
-qt5_use_modules(${PROJECT_NAME} Core Gui Widgets OpenGL)
+target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL)
 if (WIN32)
 	target_link_libraries( ${PROJECT_NAME} Qt5::WinMain )
 endif()

--- a/contrib/GamepadSupport.cmake
+++ b/contrib/GamepadSupport.cmake
@@ -18,7 +18,7 @@ function( target_link_GAMEPADS ) # 1 argument: ARGV0 = project name
 
 	if( ${OPTION_SUPPORT_GAMEPADS} )
 	
-		qt5_use_modules(${PROJECT_NAME} Gamepad)
+		target_link_libraries(${PROJECT_NAME} Qt5::Gamepad)
 		
 		if ( CMAKE_CONFIGURATION_TYPES )
 		

--- a/libs/CCFbo/CMakeLists.txt
+++ b/libs/CCFbo/CMakeLists.txt
@@ -9,4 +9,4 @@ file( GLOB source_list src/*.cpp )
 
 add_library( ${PROJECT_NAME} STATIC ${header_list} ${source_list} )
 
-qt5_use_modules(${PROJECT_NAME} Core OpenGL OpenGLExtensions )
+target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::OpenGL Qt5::OpenGLExtensions )

--- a/libs/qCC_db/CMakeLists.txt
+++ b/libs/qCC_db/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries( ${PROJECT_NAME} CC_CORE_LIB )
 target_link_libraries( ${PROJECT_NAME} CC_FBO_LIB )
 
 # Qt
-qt5_use_modules(${PROJECT_NAME} Core Gui Widgets OpenGL)
+target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL)
 
 # Add custom preprocessor definitions
 if (WIN32)

--- a/libs/qCC_glWindow/CMakeLists.txt
+++ b/libs/qCC_glWindow/CMakeLists.txt
@@ -24,7 +24,7 @@ target_link_libraries( ${PROJECT_NAME} CC_FBO_LIB )
 target_link_OCULUS_SDK( ${PROJECT_NAME} )
 
 # Qt
-qt5_use_modules(${PROJECT_NAME} Core Gui Widgets OpenGL OpenGLExtensions)
+target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL Qt5::OpenGLExtensions)
 
 # Add custom preprocessor definitions
 # set_property( TARGET ${PROJECT_NAME} APPEND PROPERTY COMPILE_DEFINITIONS )

--- a/libs/qCC_io/CMakeLists.txt
+++ b/libs/qCC_io/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries( ${PROJECT_NAME} CC_FBO_LIB )
 target_link_libraries( ${PROJECT_NAME} QCC_DB_LIB )
 
 # Qt
-qt5_use_modules(${PROJECT_NAME} Core)	
+target_link_libraries(${PROJECT_NAME} Qt5::Core)	
 
 # contrib. libraries support
 target_link_contrib( ${PROJECT_NAME} )

--- a/plugins/CMakePluginTpl.cmake
+++ b/plugins/CMakePluginTpl.cmake
@@ -71,7 +71,7 @@ target_link_libraries( ${PROJECT_NAME} QCC_IO_LIB )
 target_link_libraries( ${PROJECT_NAME} QCC_GL_LIB )
 
 # Qt
-qt5_use_modules(${PROJECT_NAME} Core Gui Widgets OpenGL Concurrent)
+target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL Qt5::Concurrent)
 
 if( APPLE )
     # put all the plugins we build into one directory

--- a/plugins/core/qPCL/PclUtils/CMakeLists.txt
+++ b/plugins/core/qPCL/PclUtils/CMakeLists.txt
@@ -51,5 +51,5 @@ add_definitions( ${PCL_DEFINITIONS} )
 target_link_libraries( ${PROJECT_NAME} ${PCL_LIBRARIES})
 
 # Qt
-qt5_use_modules(${PROJECT_NAME} Core Gui Widgets)
+target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Gui Qt5::Widgets)
 

--- a/plugins/core/qPhotoscanIO/src/contrib/QuazipLibSupport.cmake
+++ b/plugins/core/qPhotoscanIO/src/contrib/QuazipLibSupport.cmake
@@ -40,7 +40,7 @@ add_library( ${PROJECT_NAME} STATIC ${header_list} ${source_list} )
 # Zlib
 target_link_libraries(${PROJECT_NAME} ${ZLIB_LIBRARIES})
 # Qt
-qt5_use_modules(${PROJECT_NAME} Core)
+target_link_libraries(${PROJECT_NAME} Qt5::Core)
 
 set_property( TARGET ${PROJECT_NAME} APPEND PROPERTY COMPILE_DEFINITIONS QUAZIP_STATIC )
 

--- a/qCC/CMakeLists.txt
+++ b/qCC/CMakeLists.txt
@@ -61,7 +61,7 @@ target_link_libraries( ${PROJECT_NAME} QCC_GL_LIB )
 target_link_libraries( ${PROJECT_NAME} qcustomplot )
 
 # Qt
-qt5_use_modules(${PROJECT_NAME} Core Gui Widgets OpenGL PrintSupport)
+target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Gui Qt5::Widgets Qt5::OpenGL Qt5::PrintSupport)
 if (WIN32)
 	target_link_libraries( ${PROJECT_NAME} Qt5::WinMain )
 endif()


### PR DESCRIPTION
I'm on CMake 3.11.2 and failed to run cmake because the obsolete qt5_use_module is no longer recognized. Updated the CMakeLists.txt files to make it work.