### PR TITLE
Set CMAKE_INSTALL_LIBDIR to default, if undefined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ set( INSTALL_DESTINATIONS CloudCompare )
 # RPATH Linux/Unix: (dynamic) libs are put in a subdir of prefix/lib,
 # since they are only used by qCC/ccViewer
 if( UNIX AND NOT APPLE )
+	if( NOT CMAKE_INSTALL_LIBDIR )
+		set( CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib CACHE PATH "CloudCompare lib dir" )
+	endif( NOT CMAKE_INSTALL_LIBDIR )
 	set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}/cloudcompare")
 endif()
 


### PR DESCRIPTION
Fixes a bug introduced with #746 

CMAKE_INSTALL_LIBDIR is not set by default in some environments, e.g. remains unset with cmake 3.5.1 on ubuntu 16.04. This causes all CloudCompare libs to be installed to `/cloudcompare` instead of `/usr/local/lib/cloudcompare` by default.