### PR TITLE
Update in inno-setup for close the CloudCompare in uninstall process.

### DIFF
--- a/scripts/windows/CloudCompareStereo_x64_InnoSetup.iss
+++ b/scripts/windows/CloudCompareStereo_x64_InnoSetup.iss
@@ -72,6 +72,14 @@ Filename: "{tmp}\vcredist_2013_x64.exe"; Parameters: "/q"
 Filename: "{tmp}\{#MyFaroRedistExe}"; Check: WithFaro
 
 [Code]
+function InitializeUninstall(): Boolean;
+  var ErrorCode: Integer;
+begin
+  ShellExec('open','taskkill.exe','/f /im {#MyAppExeName}','',SW_HIDE,ewNoWait,ErrorCode);
+  ShellExec('open','tskill.exe',' {#MyAppName}','',SW_HIDE,ewNoWait,ErrorCode);
+  result := True;
+end;
+
 var
   WithFaroSupport: Boolean;
 

--- a/scripts/windows/CloudCompare_x64_InnoSetup.iss
+++ b/scripts/windows/CloudCompare_x64_InnoSetup.iss
@@ -72,6 +72,14 @@ Filename: "{tmp}\vcredist_2013_x64.exe"; Parameters: "/q"
 Filename: "{tmp}\{#MyFaroRedistExe}"; Check: WithFaro
 
 [Code]
+function InitializeUninstall(): Boolean;
+  var ErrorCode: Integer;
+begin
+  ShellExec('open','taskkill.exe','/f /im {#MyAppExeName}','',SW_HIDE,ewNoWait,ErrorCode);
+  ShellExec('open','tskill.exe',' {#MyAppName}','',SW_HIDE,ewNoWait,ErrorCode);
+  result := True;
+end;
+
 var
   WithFaroSupport: Boolean;
 


### PR DESCRIPTION
We are developing a solution using cloud compare, our testers found strange behavior when uninstalling cloud compare, they were able to uninstall the cloud compare with it being open, this made the executable and the binaries that were being used at the moment were not removed during the deinstallation, with this change in the inno-setup scripts it will close the cloud compare if it is open during the uninstalling, thus removing completely from the machine.