### PR TITLE
Fix build error on a Linux host.

### DIFF
--- a/plugins/core/qCompass/ccCompass.cpp
+++ b/plugins/core/qCompass/ccCompass.cpp
@@ -20,6 +20,7 @@
 //Qt
 #include <QFileDialog>
 #include <QFileInfo>
+#include <QIntValidator>
 #include <qcheckbox.h>
 #include <ccPickingHub.h>
 #include <ccProgressDialog.h>


### PR DESCRIPTION
Won't build on a Linux host .({gcc=8.1.1,qt=5.11}@arch-linux) without including QIntValidator header.
Compiler error:
```
/home/bartus/AUR/cloudcompare-git/src/cloudcompare/plugins/core/qCompass/ccCompass.cpp: In member function ‘void ccCompass::estimateStructureNormals()’
/home/bartus/AUR/cloudcompare-git/src/cloudcompare/plugins/core/qCompass/ccCompass.cpp:1304:57: error: expected type-specifier before ‘QIntValidator’
  QLineEdit lineEditA("100"); lineEditA.setValidator(new QIntValidator(5, std::numeric_limits<int>::max(),&lineEditA));
                                                         ^~~~~~~~~~~~~
/home/bartus/AUR/cloudcompare-git/src/cloudcompare/plugins/core/qCompass/ccCompass.cpp:1306:58: error: expected type-specifier before ‘QIntValidator’
  QLineEdit lineEditB("1000"); lineEditB.setValidator(new QIntValidator(50, std::numeric_limits<int>::max(),&lineEditB));
                                                          ^~~~~~~~~~~~~
/home/bartus/AUR/cloudcompare-git/src/cloudcompare/plugins/core/qCompass/ccCompass.cpp:1308:58: error: expected type-specifier before ‘QDoubleValidator’
  QLineEdit lineEditC("10.0"); lineEditC.setValidator(new QDoubleValidator(0, std::numeric_limits<double>::max(), 6,&lineEditC));
  ```