### PR TITLE
Fix sensor depth map writing crash

### DIFF
--- a/libs/qCC_db/ccGBLSensor.cpp
+++ b/libs/qCC_db/ccGBLSensor.cpp
@@ -332,7 +332,7 @@ ccGBLSensor::ColorGrid* ccGBLSensor::projectColors(	CCLib::GenericCloud* cloud,
 
 	unsigned gridSize = m_depthBuffer.height*m_depthBuffer.width;
 	if (gridSize == 0)
-		return 0; //depth buffer empty or not initialized!
+		return nullptr; //depth buffer empty or not initialized!
 
 	//number of points per cell of the depth map
 	std::vector<size_t> pointPerDMCell;
@@ -362,7 +362,7 @@ ccGBLSensor::ColorGrid* ccGBLSensor::projectColors(	CCLib::GenericCloud* cloud,
 	}
 	
 	//final array
-	ColorsTableType* colorGrid = new ColorsTableType;
+	ColorGrid* colorGrid = new ColorGrid;
 	try
 	{
 		colorGrid->resize(gridSize, ccColor::black);

--- a/libs/qCC_io/DepthMapFileFilter.cpp
+++ b/libs/qCC_io/DepthMapFileFilter.cpp
@@ -28,7 +28,7 @@
 #include <QString>
 
 //system
-#include <assert.h>
+#include <cassert>
 
 bool DepthMapFileFilter::canLoadExtension(const QString& upperCaseExt) const
 {
@@ -232,17 +232,17 @@ CC_FILE_ERROR DepthMapFileFilter::saveToFile(const QString& filename, ccGBLSenso
 	}
 
 	fclose(fp);
-	fp = 0;
+	fp = nullptr;
 
 	if (theNorms)
 	{
 		delete theNorms;
-		theNorms = 0;
+		theNorms = nullptr;
 	}
 	if (theColors)
 	{
 		delete theColors;
-		theColors = 0;
+		theColors = nullptr;
 	}
 
 	return CC_FERR_NO_ERROR;


### PR DESCRIPTION
ccGBLSensor was allocating an incorrect type which was causing issues with deleting the object

Although the types seem to be compatible, there's an issue deleting a CCShareable directly in DepthMapFileFilter::saveToFile().

Fixes #729