### PR TITLE
Only show a folder for a HIERARCHY_OBJECT if it has children

### DIFF
--- a/qCC/db_tree/ccDBRoot.cpp
+++ b/qCC/db_tree/ccDBRoot.cpp
@@ -530,10 +530,16 @@ QVariant ccDBRoot::data(const QModelIndex &index, int role) const
 		switch (item->getClassID())
 		{
 		case CC_TYPES::HIERARCHY_OBJECT:
-			if (locked)
-				return QIcon(QStringLiteral(":/CC/images/dbHObjectSymbolLocked.png"));
-			else
-				return QIcon(QStringLiteral(":/CC/images/dbHObjectSymbol.png"));
+			if ( item->getChildrenNumber() )
+			{
+				if (locked)
+					return QIcon(QStringLiteral(":/CC/images/dbHObjectSymbolLocked.png"));
+				else
+					return QIcon(QStringLiteral(":/CC/images/dbHObjectSymbol.png"));
+			}
+				
+			return QIcon();
+				
 		case CC_TYPES::POINT_CLOUD:
 			if (locked)
 				return QIcon(QStringLiteral(":/CC/images/dbCloudSymbolLocked.png"));


### PR DESCRIPTION
It's confusing to show a folder if the item isn't expandable, so just don't show an icon for these "leaf nodes" in the tree.