### PR TITLE
Fix PointCloudTpl's clear() inheritance/override problem

### DIFF
--- a/CC/include/PointCloudTpl.h
+++ b/CC/include/PointCloudTpl.h
@@ -34,7 +34,6 @@ namespace CCLib
 	template<class T> class PointCloudTpl : public T
 	{
 	public:
-
 		//! Default constructor
 		PointCloudTpl()
 			: T()
@@ -237,7 +236,7 @@ namespace CCLib
 		//! Clears the cloud database
 		/** Equivalent to resize(0).
 		**/
-		void clear()
+		void reset()
 		{
 			m_points.clear();
 			deleteAllScalarFields();
@@ -465,7 +464,6 @@ namespace CCLib
 		inline unsigned capacity() const { return static_cast<unsigned>(m_points.capacity()); }
 
 	protected:
-
 		//! Swaps two points (and their associated scalar values!)
 		virtual void swapPoints(unsigned firstIndex, unsigned secondIndex)
 		{

--- a/CC/include/PointCloudTpl.h
+++ b/CC/include/PointCloudTpl.h
@@ -20,7 +20,7 @@
 #define CC_LIB_POINT_CLOUD_TPL_HEADER
 
 //Local
-#include "GenericCloud.h"
+#include "GenericIndexedCloudPersist.h"
 #include "BoundingBox.h"
 #include "ScalarField.h"
 
@@ -33,6 +33,11 @@ namespace CCLib
 	//! A storage-efficient point cloud structure that can also handle an unlimited number of scalar fields
 	template<class T> class PointCloudTpl : public T
 	{
+		static_assert(
+				std::is_base_of<GenericIndexedCloudPersist, T>::value, 
+				"T must be a descendant of GenericIndexedCloudPersist"
+				);
+		
 	public:
 		//! Default constructor
 		PointCloudTpl()
@@ -48,9 +53,9 @@ namespace CCLib
 			deleteAllScalarFields();
 		}
 
-		inline unsigned size() const { return static_cast<unsigned>(m_points.size()); }
+		inline unsigned size() const override { return static_cast<unsigned>(m_points.size()); }
 
-		void forEach(GenericCloud::genericPointAction action)
+		void forEach(GenericCloud::genericPointAction action) override
 		{
 			//there's no point of calling forEach if there's no activated scalar field!
 			ScalarField* currentOutScalarFieldArray = getCurrentOutScalarField();
@@ -67,7 +72,7 @@ namespace CCLib
 			}
 		}
 
-		void getBoundingBox(CCVector3& bbMin, CCVector3& bbMax)
+		void getBoundingBox(CCVector3& bbMin, CCVector3& bbMax) override
 		{
 			if (!m_bbox.isValid())
 			{
@@ -82,11 +87,11 @@ namespace CCLib
 			bbMax = m_bbox.maxCorner();
 		}
 
-		void placeIteratorAtBeginning() { m_currentPointIndex = 0; }
+		void placeIteratorAtBeginning() override { m_currentPointIndex = 0; }
 		
-		const CCVector3* getNextPoint() { return (m_currentPointIndex < m_points.size() ? point(m_currentPointIndex++) : 0); }
+		const CCVector3* getNextPoint() override { return (m_currentPointIndex < m_points.size() ? point(m_currentPointIndex++) : 0); }
 		
-		bool enableScalarField()
+		bool enableScalarField() override
 		{
 			ScalarField* currentInScalarField = getCurrentInScalarField();
 
@@ -121,7 +126,7 @@ namespace CCLib
 			return currentInScalarField->resizeSafe(m_points.capacity());
 		}
 		
-		bool isScalarFieldEnabled() const
+		bool isScalarFieldEnabled() const override
 		{
 			ScalarField* currentInScalarFieldArray = getCurrentInScalarField();
 			if (!currentInScalarFieldArray)
@@ -133,7 +138,7 @@ namespace CCLib
 			return (sfValuesCount != 0 && sfValuesCount >= m_points.size());
 		}
 
-		void setPointScalarValue(unsigned pointIndex, ScalarType value)
+		void setPointScalarValue(unsigned pointIndex, ScalarType value) override
 		{
 			assert(m_currentInScalarFieldIndex >= 0 && m_currentInScalarFieldIndex<(int)m_scalarFields.size());
 			//slow version
@@ -145,18 +150,18 @@ namespace CCLib
 			m_scalarFields[m_currentInScalarFieldIndex]->setValue(pointIndex, value);
 		}
 		
-		ScalarType getPointScalarValue(unsigned pointIndex) const
+		ScalarType getPointScalarValue(unsigned pointIndex) const override
 		{
 			assert(m_currentOutScalarFieldIndex >= 0 && m_currentOutScalarFieldIndex < static_cast<int>(m_scalarFields.size()));
 
 			return m_scalarFields[m_currentOutScalarFieldIndex]->getValue(pointIndex);
 		}
 
-		inline const CCVector3* getPoint(unsigned index) { return point(index); }
+		inline const CCVector3* getPoint(unsigned index) override { return point(index); }
 		inline const CCVector3* getPoint(unsigned index) const { return point(index); }
-		inline void getPoint(unsigned index, CCVector3& P) const { P = *point(index); }
+		inline void getPoint(unsigned index, CCVector3& P) const override { P = *point(index); }
 
-		inline const CCVector3* getPointPersistentPtr(unsigned index) { return point(index); }
+		inline const CCVector3* getPointPersistentPtr(unsigned index) override { return point(index); }
 		inline const CCVector3* getPointPersistentPtr(unsigned index) const { return point(index); }
 
 		//! Resizes the point database

--- a/CC/src/ManualSegmentationTools.cpp
+++ b/CC/src/ManualSegmentationTools.cpp
@@ -1317,7 +1317,7 @@ bool ManualSegmentationTools::segmentMeshWitAABox(GenericIndexedMesh* origMesh,
 				{
 					assert(sourceMesh == insideMesh2 || sourceMesh == origMesh);
 					insideMesh2->clear();
-					insideVertices2->clear();
+					insideVertices2->reset();
 					sourceMesh = insideMesh1;
 					sourceVertices = insideVertices1;
 					insideMesh = insideMesh2;
@@ -1330,7 +1330,7 @@ bool ManualSegmentationTools::segmentMeshWitAABox(GenericIndexedMesh* origMesh,
 				{
 					assert(sourceMesh == insideMesh1 || sourceMesh == origMesh);
 					insideMesh1->clear();
-					insideVertices1->clear();
+					insideVertices1->reset();
 					sourceMesh = insideMesh2;
 					sourceVertices = insideVertices2;
 					insideMesh = insideMesh1;

--- a/CC/src/RegistrationTools.cpp
+++ b/CC/src/RegistrationTools.cpp
@@ -1707,7 +1707,7 @@ bool FPCSRegistrationTools::FilterCandidates(	GenericIndexedCloud *modelCloud,
 	{
 		for (unsigned i=0; i<table.size(); i++)
 		{
-			dataBaseCloud.clear();
+			dataBaseCloud.reset();
 			if (!dataBaseCloud.reserve(4)) //we never know ;)
 				return false;
 			for (unsigned j=0; j<4; j++)

--- a/libs/qCC_db/ccPointCloud.cpp
+++ b/libs/qCC_db/ccPointCloud.cpp
@@ -455,7 +455,7 @@ void ccPointCloud::unalloactePoints()
 {
 	clearLOD();	// we have to clear the LOD structure before clearing the colors / SFs, so we can't leave it to notifyGeometryUpdate()
 	showSFColorsScale(false); //SFs will be destroyed
-	BaseClass::clear();
+	BaseClass::reset();
 	ccGenericPointCloud::clear();
 
 	notifyGeometryUpdate(); //calls releaseVBOs()


### PR DESCRIPTION
- rename PointCloudTpl's clear() to reset()
- ensure we are inheriting from GenericIndexedCloudPersist so we can override the correct methods

Fixes #794