### PR TITLE
Checkboxes on hierarchy objects

### DIFF
--- a/libs/qCC_db/ccHObject.cpp
+++ b/libs/qCC_db/ccHObject.cpp
@@ -376,6 +376,18 @@ bool ccHObject::addChild(ccHObject* child, int dependencyFlags/*=DP_PARENT_OF_OT
 	return true;
 }
 
+unsigned int ccHObject::getChildCountRecursive() const
+{
+	unsigned int	count = static_cast<unsigned>(m_children.size());
+	
+	for ( auto child : m_children )
+	{
+		count += child->getChildCountRecursive();
+	}
+	
+	return count;
+}
+
 ccHObject* ccHObject::find(unsigned uniqueID)
 {
 	//found the right item?

--- a/libs/qCC_db/ccHObject.h
+++ b/libs/qCC_db/ccHObject.h
@@ -125,6 +125,11 @@ public: //children management
 	/** \return children number
 	**/
 	inline unsigned getChildrenNumber() const { return static_cast<unsigned>(m_children.size()); }
+	
+	//! Returns the total number of children under this object recursively
+	/** \return Number of children
+	**/
+	unsigned int getChildCountRecursive() const;
 
 	//! Returns the ith child
 	/** \param childPos child position

--- a/qCC/db_tree/ccDBRoot.cpp
+++ b/qCC/db_tree/ccDBRoot.cpp
@@ -616,6 +616,24 @@ QVariant ccDBRoot::data(const QModelIndex &index, int role) const
 
 	case Qt::CheckStateRole:
 	{
+		// Don't include checkboxes for hierarchy objects if they have no children or only contain hierarchy objects (recursively)
+		if ( item->getClassID() == CC_TYPES::HIERARCHY_OBJECT )
+		{
+			if ( item->getChildrenNumber() == 0 )
+			{
+				return {};
+			}
+			
+			ccHObject::Container	drawableObjects;
+			
+			unsigned int	count = item->filterChildren( drawableObjects, true, CC_TYPES::HIERARCHY_OBJECT, true );
+			
+			if ( item->getChildCountRecursive() == count )
+			{
+				return {};
+			}
+		}
+		
 		if (item->isEnabled())
 			return Qt::Checked;
 		else


### PR DESCRIPTION
Don't include checkboxes in the DB tree for hierarchy objects if they have no children or only contain hierarchy objects (recursively)

For example, E57 shows the file structure as hierarchy objects. The checkboxes don't do anything for these tree nodes, so don't show them.