### PR TITLE
Use an enum for CC_TYPES/CC_CLASS_ENUM

### DIFF
--- a/libs/qCC_db/ccObject.h
+++ b/libs/qCC_db/ccObject.h
@@ -78,73 +78,71 @@ enum CC_OBJECT_FLAG {	//CC_UNUSED			= 1, //DGM: not used anymore (former CC_FATH
 //#define CC_FREE_BIT					...
 
 //! Type of object type flags (64 bits)
-typedef int64_t CC_CLASS_ENUM;
+using CC_CLASS_ENUM = int64_t;
 
 //! CloudCompare object type flags
-class CC_TYPES
+namespace CC_TYPES
 {
-public:
-
-	//Warning: never pass a 'constant initializer' by reference
-	static const CC_CLASS_ENUM OBJECT = 0;
-	static const CC_CLASS_ENUM HIERARCHY_OBJECT		=	CC_HIERARCH_BIT;
-	static const CC_CLASS_ENUM POINT_CLOUD			=	HIERARCHY_OBJECT	| CC_CLOUD_BIT;
-	static const CC_CLASS_ENUM MESH					=	HIERARCHY_OBJECT	| CC_MESH_BIT;
-	static const CC_CLASS_ENUM SUB_MESH				=	HIERARCHY_OBJECT	| CC_MESH_BIT				| CC_LEAF_BIT;
-	static const CC_CLASS_ENUM MESH_GROUP			=	MESH				| CC_GROUP_BIT;								//DEPRECATED; DEFINITION REMAINS FOR BACKWARD COMPATIBILITY ONLY!
-	static const CC_CLASS_ENUM FACET				=	HIERARCHY_OBJECT	| CC_FACET_BIT;
-	static const CC_CLASS_ENUM POINT_OCTREE			=	HIERARCHY_OBJECT	| CC_OCTREE_BIT				| CC_LEAF_BIT;
-	static const CC_CLASS_ENUM POINT_KDTREE			=	HIERARCHY_OBJECT	| CC_KDTREE_BIT				| CC_LEAF_BIT;
-	static const CC_CLASS_ENUM POLY_LINE			=	HIERARCHY_OBJECT	| CC_POLYLINE_BIT;
-	static const CC_CLASS_ENUM IMAGE				=	CC_HIERARCH_BIT		| CC_IMAGE_BIT;
-	static const CC_CLASS_ENUM CALIBRATED_IMAGE		=	IMAGE				| CC_LEAF_BIT;
-	static const CC_CLASS_ENUM SENSOR				=	CC_HIERARCH_BIT		| CC_SENSOR_BIT;
-	static const CC_CLASS_ENUM GBL_SENSOR			=	SENSOR				| CC_GROUND_BASED_BIT;
-	static const CC_CLASS_ENUM CAMERA_SENSOR		=	SENSOR				| CC_CAMERA_BIT;
-	static const CC_CLASS_ENUM PRIMITIVE			=	MESH				| CC_PRIMITIVE_BIT;							//primitives are meshes!
-	static const CC_CLASS_ENUM PLANE				=	PRIMITIVE			| CC_PLANE_BIT;
-	static const CC_CLASS_ENUM SPHERE				=	PRIMITIVE			| CC_SPHERE_BIT;
-	static const CC_CLASS_ENUM TORUS				=	PRIMITIVE			| CC_TORUS_BIT;
-	static const CC_CLASS_ENUM CONE					=	PRIMITIVE			| CC_CONE_BIT;
-	static const CC_CLASS_ENUM OLD_CYLINDER_ID		=	PRIMITIVE			| CC_CYLINDER_BIT;							//for backward compatibility!
-	static const CC_CLASS_ENUM CYLINDER				=	PRIMITIVE			| CC_CYLINDER_BIT			| CC_CONE_BIT;	//cylinders are cones!
-	static const CC_CLASS_ENUM BOX					=	PRIMITIVE			| CC_BOX_BIT;
-	static const CC_CLASS_ENUM DISH					=	PRIMITIVE			| CC_DISH_BIT;
-	static const CC_CLASS_ENUM EXTRU				=	PRIMITIVE			| CC_EXTRU_BIT;
-	static const CC_CLASS_ENUM QUADRIC				=	PRIMITIVE			| CC_QUADRIC_BIT;
-	static const CC_CLASS_ENUM MATERIAL_SET			=	CC_MATERIAL_BIT		| CC_GROUP_BIT				| CC_LEAF_BIT;
-	static const CC_CLASS_ENUM ARRAY				=	CC_ARRAY_BIT;
-	static const CC_CLASS_ENUM NORMALS_ARRAY		=	CC_ARRAY_BIT		| CC_NORMAL_BIT				| CC_LEAF_BIT;
-	static const CC_CLASS_ENUM NORMAL_INDEXES_ARRAY	=	CC_ARRAY_BIT		| CC_COMPRESSED_NORMAL_BIT	| CC_LEAF_BIT;
-	static const CC_CLASS_ENUM RGB_COLOR_ARRAY		=	CC_ARRAY_BIT		| CC_RGB_COLOR_BIT			| CC_LEAF_BIT;
-	static const CC_CLASS_ENUM TEX_COORDS_ARRAY		=	CC_ARRAY_BIT		| CC_TEX_COORDS_BIT			| CC_LEAF_BIT;
-	static const CC_CLASS_ENUM LABEL_2D				=	HIERARCHY_OBJECT	| CC_LABEL_BIT				| CC_LEAF_BIT;
-	static const CC_CLASS_ENUM VIEWPORT_2D_OBJECT	=	HIERARCHY_OBJECT	| CC_VIEWPORT_BIT			| CC_LEAF_BIT;
-	static const CC_CLASS_ENUM VIEWPORT_2D_LABEL	=	VIEWPORT_2D_OBJECT	| CC_LABEL_BIT;
-	static const CC_CLASS_ENUM CLIPPING_BOX			=	CC_CLIP_BOX_BIT		| CC_LEAF_BIT;
-	static const CC_CLASS_ENUM TRANS_BUFFER			=	HIERARCHY_OBJECT	| CC_TRANS_BUFFER_BIT		| CC_LEAF_BIT;
-
-	//  Custom types
-	/** Custom objects are typically defined by plugins. They can be inserted in an object
-		hierarchy or displayed in an OpenGL context like any other ccHObject.
-		To differentiate custom objects, use the meta-data mechanism (see ccObject::getMetaData
-		and ccObject::setMetaData). You can also define a custom icon (see ccHObject::getIcon).
-
-		It is highly advised to use the ccCustomHObject and ccCustomLeafObject interfaces to
-		define a custom types. Carefully read the ccCustomHObject::isDeserialized method's
-		description and the warning below!
-
-		Warning: custom objects can't be 'fully' serialized. Don't overload the
-		'ccSerializableObject::toFile' method for them as this would break the deserialization mechanism!
-		They can only be serialized as plain ccHObject instances (CC_TYPES::HIERARCHY_OBJECT).
-		Hierarchical custom objects (CC_TYPES::CUSTOM_H_OBJECT) will be deserialized as ccCustomHObject
-		instances. Leaf custom objects (CC_TYPES::CUSTOM_LEAF_OBJECT) will be deserialized as
-		ccCustomLeafObject instances.
-	**/
-	static const CC_CLASS_ENUM CUSTOM_H_OBJECT		=	HIERARCHY_OBJECT | CC_CUSTOM_BIT;
-	static const CC_CLASS_ENUM CUSTOM_LEAF_OBJECT	=	CUSTOM_H_OBJECT | CC_LEAF_BIT;
-
-};
+	enum : CC_CLASS_ENUM {
+		OBJECT = 0,
+		HIERARCHY_OBJECT	=	CC_HIERARCH_BIT,
+		POINT_CLOUD			=	HIERARCHY_OBJECT	| CC_CLOUD_BIT,
+		MESH				=	HIERARCHY_OBJECT	| CC_MESH_BIT,
+		SUB_MESH			=	HIERARCHY_OBJECT	| CC_MESH_BIT				| CC_LEAF_BIT,
+		MESH_GROUP			=	MESH				| CC_GROUP_BIT,								//DEPRECATED; DEFINITION REMAINS FOR BACKWARD COMPATIBILITY ONLY
+		FACET				=	HIERARCHY_OBJECT	| CC_FACET_BIT,
+		POINT_OCTREE		=	HIERARCHY_OBJECT	| CC_OCTREE_BIT				| CC_LEAF_BIT,
+		POINT_KDTREE		=	HIERARCHY_OBJECT	| CC_KDTREE_BIT				| CC_LEAF_BIT,
+		POLY_LINE			=	HIERARCHY_OBJECT	| CC_POLYLINE_BIT,
+		IMAGE				=	CC_HIERARCH_BIT		| CC_IMAGE_BIT,
+		CALIBRATED_IMAGE	=	IMAGE				| CC_LEAF_BIT,
+		SENSOR				=	CC_HIERARCH_BIT		| CC_SENSOR_BIT,
+		GBL_SENSOR			=	SENSOR				| CC_GROUND_BASED_BIT,
+		CAMERA_SENSOR		=	SENSOR				| CC_CAMERA_BIT,
+		PRIMITIVE			=	MESH				| CC_PRIMITIVE_BIT,							//primitives are meshes
+		PLANE				=	PRIMITIVE			| CC_PLANE_BIT,
+		SPHERE				=	PRIMITIVE			| CC_SPHERE_BIT,
+		TORUS				=	PRIMITIVE			| CC_TORUS_BIT,
+		CONE				=	PRIMITIVE			| CC_CONE_BIT,
+		OLD_CYLINDER_ID		=	PRIMITIVE			| CC_CYLINDER_BIT,							//for backward compatibility
+		CYLINDER			=	PRIMITIVE			| CC_CYLINDER_BIT			| CC_CONE_BIT,	//cylinders are cones
+		BOX					=	PRIMITIVE			| CC_BOX_BIT,
+		DISH				=	PRIMITIVE			| CC_DISH_BIT,
+		EXTRU				=	PRIMITIVE			| CC_EXTRU_BIT,
+		QUADRIC				=	PRIMITIVE			| CC_QUADRIC_BIT,
+		MATERIAL_SET		=	CC_MATERIAL_BIT		| CC_GROUP_BIT				| CC_LEAF_BIT,
+		ARRAY				=	CC_ARRAY_BIT,
+		NORMALS_ARRAY		=	CC_ARRAY_BIT		| CC_NORMAL_BIT				| CC_LEAF_BIT,
+		NORMAL_INDEXES_ARRAY=	CC_ARRAY_BIT		| CC_COMPRESSED_NORMAL_BIT	| CC_LEAF_BIT,
+		RGB_COLOR_ARRAY		=	CC_ARRAY_BIT		| CC_RGB_COLOR_BIT			| CC_LEAF_BIT,
+		TEX_COORDS_ARRAY	=	CC_ARRAY_BIT		| CC_TEX_COORDS_BIT			| CC_LEAF_BIT,
+		LABEL_2D			=	HIERARCHY_OBJECT	| CC_LABEL_BIT				| CC_LEAF_BIT,
+		VIEWPORT_2D_OBJECT	=	HIERARCHY_OBJECT	| CC_VIEWPORT_BIT			| CC_LEAF_BIT,
+		VIEWPORT_2D_LABEL	=	VIEWPORT_2D_OBJECT	| CC_LABEL_BIT,
+		CLIPPING_BOX		=	CC_CLIP_BOX_BIT		| CC_LEAF_BIT,
+		TRANS_BUFFER		=	HIERARCHY_OBJECT	| CC_TRANS_BUFFER_BIT		| CC_LEAF_BIT,
+		
+		//  Custom types
+		/** Custom objects are typically defined by plugins. They can be inserted in an object
+			hierarchy or displayed in an OpenGL context like any other ccHObject.
+			To differentiate custom objects, use the meta-data mechanism (see ccObject::getMetaData
+			and ccObject::setMetaData). You can also define a custom icon (see ccHObject::getIcon).
+	
+			It is highly advised to use the ccCustomHObject and ccCustomLeafObject interfaces to
+			define a custom types. Carefully read the ccCustomHObject::isDeserialized method's
+			description and the warning below!
+	
+			Warning: custom objects can't be 'fully' serialized. Don't overload the
+			'ccSerializableObject::toFile' method for them as this would break the deserialization mechanism!
+			They can only be serialized as plain ccHObject instances (CC_TYPES::HIERARCHY_OBJECT).
+			Hierarchical custom objects (CC_TYPES::CUSTOM_H_OBJECT) will be deserialized as ccCustomHObject
+			instances. Leaf custom objects (CC_TYPES::CUSTOM_LEAF_OBJECT) will be deserialized as
+			ccCustomLeafObject instances.
+		**/
+		CUSTOM_H_OBJECT		=	HIERARCHY_OBJECT | CC_CUSTOM_BIT,
+		CUSTOM_LEAF_OBJECT	=	CUSTOM_H_OBJECT | CC_LEAF_BIT,
+	};
+}
 
 //! Unique ID generator (should be unique for the whole application instance - with plugins, etc.)
 class QCC_DB_LIB_API ccUniqueIDGenerator


### PR DESCRIPTION
 (and use a namespace instead of a class)

Now that we can specify enum types in C++, this is much cleaner.

It also avoids linking issues if you want to use these in a container (like a map). They are
declared and can be used as integral constant expressions (like switches), but they aren't
defined in the cpp, so they can't be used in a map (at least with clang).