### PR TITLE
Use a scroll area in ASCII dialog to better handle a large number of columns

### DIFF
--- a/libs/qCC_io/AsciiOpenDlg.cpp
+++ b/libs/qCC_io/AsciiOpenDlg.cpp
@@ -880,8 +880,8 @@ void AsciiOpenDlg::updateTable()
 
 	//check for invalid columns
 	checkSelectedColumnsValidity(); //will eventually enable of disable the "OK" button
-	//expand dialog width to display all table columns
-	resizeWidthToFitTableColumns();
+	
+	m_ui->tableWidget->resizeColumnsToContents();
 }
 
 void AsciiOpenDlg::checkSelectedColumnsValidity()
@@ -1268,38 +1268,4 @@ unsigned AsciiOpenDlg::getMaxCloudSize() const
 bool AsciiOpenDlg::showLabelsIn2D() const
 {
 	return m_ui->show2DLabelsCheckBox->isEnabled() && m_ui->show2DLabelsCheckBox->isChecked();
-}
-
-void AsciiOpenDlg::resizeWidthToFitTableColumns()
-{
-/*!
- * Increases dialog width if table widget contains many columns.
- * Increases table column widths to fill dialog if only a few
- * columns are present.
-*/
-    // First make sure all columns are wide enought to fit data
-    // Then get combined width of all columns.
-    m_ui->tableWidget->resizeColumnsToContents();
-    int totalColumnsWidth = m_ui->tableWidget->horizontalHeader()->length();
-
-    // To display whole table widget without h. scrollbars, need to add
-    // table and layout margin pixel values to get a total required dialog width
-    int leftTable, rightTable, leftLayout, rightLayout, top, bottom;
-    m_ui->tableWidget->getContentsMargins(&leftTable, &top, &rightTable, &bottom);
-    m_ui->verticalLayout->getContentsMargins(&leftLayout, &top, &rightLayout, &bottom);
-    int totalMarginsWidth = leftTable + rightTable + leftLayout + rightLayout;
-    int minDialogWidth = totalColumnsWidth + totalMarginsWidth;
-
-    // If table requires more space, resize dialog
-    if (minDialogWidth > this->width())
-        this->resize(minDialogWidth, this->height());
-
-    // Make columns stretchy and auto-resize
-    // This is done differently in Qt5 vs. Qt4
-#if QT_VERSION >= 0x050000
-    m_ui->tableWidget->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
-#else
-    m_ui->tableWidget->horizontalHeader()->setResizeMode(QHeaderView::Stretch);
-#endif
-
 }

--- a/libs/qCC_io/AsciiOpenDlg.h
+++ b/libs/qCC_io/AsciiOpenDlg.h
@@ -200,9 +200,6 @@ protected:
 	//! Tries to guess the best separator automagically
 	void autoFindBestSeparator();
 
-	// Resizes dialog width to fit all displayed table columns
-	void resizeWidthToFitTableColumns();
-
 	//associated UI
 	Ui_AsciiOpenDialog* m_ui;
 

--- a/libs/qCC_io/ui_templates/openAsciiFileDlg.ui
+++ b/libs/qCC_io/ui_templates/openAsciiFileDlg.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>700</width>
-    <height>600</height>
+    <width>1008</width>
+    <height>657</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -47,7 +47,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Here are the first lines of this file. Choose each column attribution (one cloud at a time):</string>
+      <string>Here are the first lines of this file. Choose an attribute for each column (one cloud at a time):</string>
      </property>
     </widget>
    </item>
@@ -62,25 +62,56 @@
     </widget>
    </item>
    <item>
-    <widget class="QTableWidget" name="tableWidget">
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
      </property>
-     <property name="alternatingRowColors">
+     <property name="widgetResizable">
       <bool>true</bool>
      </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::NoSelection</enum>
-     </property>
-     <property name="cornerButtonEnabled">
-      <bool>false</bool>
-     </property>
-     <property name="rowCount">
-      <number>0</number>
-     </property>
-     <attribute name="verticalHeaderVisible">
-      <bool>false</bool>
-     </attribute>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>984</width>
+        <height>430</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTableWidget" name="tableWidget">
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+         <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::NoSelection</enum>
+         </property>
+         <property name="cornerButtonEnabled">
+          <bool>false</bool>
+         </property>
+         <attribute name="verticalHeaderVisible">
+          <bool>false</bool>
+         </attribute>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
When there are many columns, the dialog currently has one of two issues:

- all the columns are squished together which makes it's fairly unusable
- massively wide dialog (on macOS) which would crash under Qt 5.9.x and display an unusable dialog on Qt 5.12

This fixes the problems by putting the table in a scroll area.

Addresses the crashing part of issue #801.