### PR TITLE
Consolidate plugin and shader path construction

### DIFF
--- a/common/ccApplicationBase.h
+++ b/common/ccApplicationBase.h
@@ -37,7 +37,12 @@ public:
 	QString versionLongStr( bool includeOS ) const;
 
 private:
+	void setupPaths();
+	
 	const QString c_VersionStr;
+	
+	QString	m_ShaderPath;
+	QStringList m_PluginPaths;
 };
 
 #endif

--- a/common/ccPluginManager.h
+++ b/common/ccPluginManager.h
@@ -35,15 +35,17 @@ public:
 	explicit ccPluginManager( QObject *parent = nullptr );
 	~ccPluginManager() override = default;
 	
-	static void loadPlugins();
-
+	static void setPaths( const QStringList &paths );
 	static QStringList pluginPaths();
+	
+	static void loadPlugins();
 	
 	static ccPluginInterfaceList &pluginList();
 	
 private:	
 	static void loadFromPathsAndAddToList();	
 	
+	static QStringList m_PluginPaths;
 	static ccPluginInterfaceList m_pluginList;
 };
 

--- a/libs/qCC_glWindow/ccGLWindow.h
+++ b/libs/qCC_glWindow/ccGLWindow.h
@@ -443,6 +443,8 @@ public:
 								bool dontScaleFeatures = false,
 								bool renderOverlayItems = false);
 
+	static void setShaderPath( const QString &path );
+	
 	virtual void setShader(ccShader* shader);
 	virtual void setGlFilter(ccGlFilter* filter);
 	ccGlFilter* getGlFilter() { return m_activeGLFilter; }
@@ -1391,9 +1393,7 @@ protected: //members
 	CCVector3d m_lockedRotationAxis;
 
 private:
-
-	//! Returns shaders path
-	static QString getShadersPath();
+	static QString	s_shaderPath;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(ccGLWindow::INTERACTION_FLAGS);


### PR DESCRIPTION
It's now done once in ccApplicationBase::setupPaths() when the application is constructed instead of on each use.

The path for translation files will be added here as well.