### PR TITLE
Save las point format & version

### DIFF
--- a/libs/qCC_io/LASFields.h
+++ b/libs/qCC_io/LASFields.h
@@ -33,6 +33,9 @@ class ccPointCloud;
 static const char LAS_SCALE_X_META_DATA[] = "LAS.scale.x";
 static const char LAS_SCALE_Y_META_DATA[] = "LAS.scale.y";
 static const char LAS_SCALE_Z_META_DATA[] = "LAS.scale.z";
+static const char LAS_VERSION_MAJOR_META_DATA[] = "LAS.version.major";
+static const char LAS_VERSION_MINOR_META_DATA[] = "LAS.version.minor";
+static const char LAS_POINT_FORMAT_META_DATA[] = "LAS.point_format";
 
 enum LAS_FIELDS {
 	LAS_X = 0,

--- a/libs/qCC_io/LASFilter.cpp
+++ b/libs/qCC_io/LASFilter.cpp
@@ -365,7 +365,7 @@ CC_FILE_ERROR LASFilter::saveToFile(ccHObject* entity, const QString& filename, 
 		pdalId = id(dimName);
 		table.layout()->registerDim(pdalId);
 	}
-	
+
 	std::vector<ExtraLasField::Shared> extraFieldsToSave;
 
 	for (unsigned int i = 0; i < extraFields.size(); ++i)
@@ -489,9 +489,27 @@ CC_FILE_ERROR LASFilter::saveToFile(ccHObject* entity, const QString& filename, 
 
 	writerOptions.add("filename", filename.toLocal8Bit().toStdString());
 	writerOptions.add("extra_dims", "all");
-	//make a dialog for this ?
-	//writerOptions.add("minor_version", )
-	//writerOptions.add("dataformat_id", );
+
+	const QVariant minor_version_meta_data = theCloud->getMetaData(LAS_VERSION_MINOR_META_DATA);
+	if (!minor_version_meta_data.isNull())
+    {
+		bool ok = false;
+		int minor_version = minor_version_meta_data.toInt(&ok);
+		if (ok)
+			writerOptions.add("minor_version", minor_version);
+		else
+			ccLog::Warning(QString("Could not convert minor_version to int"));
+	}
+	const QVariant point_format_meta_data = theCloud->getMetaData(LAS_POINT_FORMAT_META_DATA);
+	if (!point_format_meta_data.isNull())
+	{
+	 	bool ok = false;
+	 	int point_format = point_format_meta_data.toInt(&ok);
+	 		if (ok)
+	 			writerOptions.add("dataformat_id", point_format);
+	 		else
+				ccLog::Warning(QString("Could not convert point_format to int"));
+	}
 
 	StreamCallbackFilter f;
 	f.setCallback(convertOne);
@@ -1078,7 +1096,7 @@ CC_FILE_ERROR LASFilter::loadFile(const QString& filename, ccHObject& container,
 				pDlg->exec();
 			}
 			reader.waitForFinished();
-		
+
 			PointViewSet viewSet = reader.result();
 			PointViewPtr pointView = *viewSet.begin();
 
@@ -1417,6 +1435,9 @@ CC_FILE_ERROR LASFilter::loadFile(const QString& filename, ccHObject& container,
 					loadedCloud->setMetaData(LAS_SCALE_X_META_DATA, QVariant(lasScale.x));
 					loadedCloud->setMetaData(LAS_SCALE_Y_META_DATA, QVariant(lasScale.y));
 					loadedCloud->setMetaData(LAS_SCALE_Z_META_DATA, QVariant(lasScale.z));
+					loadedCloud->setMetaData(LAS_VERSION_MAJOR_META_DATA, QVariant(lasHeader.versionMajor()));
+					loadedCloud->setMetaData(LAS_VERSION_MINOR_META_DATA, QVariant(lasHeader.versionMinor()));
+					loadedCloud->setMetaData(LAS_POINT_FORMAT_META_DATA, QVariant(lasHeader.pointFormat()));
 
 					container.addChild(loadedCloud);
 					loadedCloud = nullptr;


### PR DESCRIPTION
Currently  when a file is saved as LAS, the version & point format (an id that gives the defaults dimensions present in the file), it is saved with the default values chosen by PDAL (version 1.2 & point format 3)

Which means that if you open a LAS file with a version & point format different than the defaults,
when saving, the file version & point format changes.

This is mostly a problem when opening LAS files with version >= 1.4 & point format >= 6 because
it would downgrade the file and even sometime CC could not save the file as some fields in point format >= 6 are not compatible with point format 3.

This PR adds the code to save the LAS file version & point format as meta-data and try to load them when saving a file in order to preserve the original version & point format of the loaded file.

I also did a bit of 'refactoring'.

