### PR TITLE
Optimization for DgmOctree::getCellIndex

### DIFF
--- a/CC/include/DgmOctree.h
+++ b/CC/include/DgmOctree.h
@@ -1163,6 +1163,9 @@ protected:
 
 	//! Number of points projected in the octree
 	unsigned m_numberOfProjectedPoints;
+	
+	//! Nearest power of 2 less than the number of points (used for binary search)
+	unsigned m_nearestPow2;
 
 	//! Min coordinates of the octree bounding-box
 	CCVector3 m_dimMin;


### PR DESCRIPTION
- calculations using log() can be quite slow
- for a small example (< 6k points) from issue #816, getCellIndex() was called over 15k times through getPointsInNeighbourCellsAround()
- since the power of 2 only changes with the number of points (m_numberOfProjectedPoints), we can calculate it once and store it
- it does not make the pathological case from the issue fast, but it does cut the time by 30%

This method is used frequently, so it may help other pathological cases.