### PR TITLE
Use QDataStream to read SHP files

### DIFF
--- a/libs/qCC_io/ShpFilter.cpp
+++ b/libs/qCC_io/ShpFilter.cpp
@@ -843,7 +843,8 @@ static CC_FILE_ERROR LoadCloud(QDataStream &shpStream,
 	//Points (An array of length NumPoints)
 	for (int32_t i = 0; i < numPoints; ++i)
 	{
-		double  x, y;
+		double x;
+		double y;
 		shpStream >> x >> y;
 		CCVector3 P(static_cast<PointCoordinateType>(x + Pshift.x),
 					static_cast<PointCoordinateType>(y + Pshift.y),

--- a/libs/qCC_io/ShpFilter.cpp
+++ b/libs/qCC_io/ShpFilter.cpp
@@ -231,13 +231,6 @@ double swapD(double in)
 	return in;
 }
 
-double qFromLittleEndianD(double in)
-{
-#if Q_BYTE_ORDER == Q_BIG_ENDIAN
-	return swapD(in);
-#endif
-	return in;
-}
 
 double qToLittleEndianD(double in)
 {
@@ -428,7 +421,8 @@ static CC_FILE_ERROR LoadPolyline(QDataStream &shpStream,
 	// skip record bbox
 	shpStream.skipRawData(4 * sizeof(double));
 
-	int32_t numParts, numPoints;
+	int32_t numParts;
+	int32_t numPoints;
 	shpStream >> numParts >> numPoints;
 
 


### PR DESCRIPTION
The main change is to use QDataStream to read the input shp file, which in my opinion makes the code easier to maintain.

Also adds POLYLINE_M & POLYGON_M as supported shape type