### PR TITLE
Cleanup ccColorType

### DIFF
--- a/common/ccApplicationBase.cpp
+++ b/common/ccApplicationBase.cpp
@@ -15,6 +15,8 @@
 //#                                                                        #
 //##########################################################################
 
+#include <clocale>
+
 //Qt
 #include <QDir>
 #include <QStandardPaths>

--- a/libs/qCC_db/ccColorTypes.cpp
+++ b/libs/qCC_db/ccColorTypes.cpp
@@ -15,39 +15,72 @@
 //#                                                                        #
 //##########################################################################
 
+#include <cmath>
+#include <random>
+
 #include "ccColorTypes.h"
+
 
 namespace ccColor
 {
-	// Predefined colors (default type)
-	QCC_DB_LIB_API const Rgb white						(MAX, MAX, MAX);
-	QCC_DB_LIB_API const Rgb lightGrey					(static_cast<ColorCompType>(MAX*0.8), static_cast<ColorCompType>(MAX*0.8), static_cast<ColorCompType>(MAX*0.8));
-	QCC_DB_LIB_API const Rgb darkGrey					(MAX / 2, MAX / 2, MAX / 2);
-	QCC_DB_LIB_API const Rgb red						(MAX, 0, 0);
-	QCC_DB_LIB_API const Rgb green						(0, MAX, 0);
-	QCC_DB_LIB_API const Rgb blue						(0, 0, MAX);
-	QCC_DB_LIB_API const Rgb darkBlue					(0, 0, MAX / 2);
-	QCC_DB_LIB_API const Rgb magenta					(MAX, 0, MAX);
-	QCC_DB_LIB_API const Rgb cyan						(0, MAX, MAX);
-	QCC_DB_LIB_API const Rgb orange						(MAX, MAX / 2, 0);
-	QCC_DB_LIB_API const Rgb black						(0, 0, 0);
-	QCC_DB_LIB_API const Rgb yellow						(MAX, MAX, 0);
+	
+	Rgb Generator::Random(bool lightOnly)
+	{
+		std::random_device rd;   // non-deterministic generator
+		std::mt19937 gen(rd());  // to seed mersenne twister.
+		std::uniform_int_distribution<unsigned char> dist(0, MAX);
+		
+		Rgb col;
+		col.r = dist(gen);
+		col.g = dist(gen);
+		if (lightOnly)
+		{
+			col.b = MAX - static_cast<ColorCompType>((static_cast<double>(col.r) + static_cast<double>(col.g)) / 2); //cast to double to avoid overflow (whatever the type of ColorCompType!!!)
+		}
+		else
+		{
+			col.b = dist(gen);
+		}
+		
+		return col;
+	}
+	
+	Rgb Convert::hsv2rgb(float H, float S, float V)
+	{
+		float hi = 0;
+		float f = std::modf(H / 60.0f, &hi);
+		
+		float l = V*(1.0f - S);
+		float m = V*(1.0f - f*S);
+		float n = V*(1.0f - (1.0f - f)*S);
+		
+		Rgbf rgb(0, 0, 0);
+		
+		switch (static_cast<int>(hi) % 6)
+		{
+			case 0:
+				rgb.r = V; rgb.g = n; rgb.b = l;
+				break;
+			case 1:
+				rgb.r = m; rgb.g = V; rgb.b = l;
+				break;
+			case 2:
+				rgb.r = l; rgb.g = V; rgb.b = n;
+				break;
+			case 3:
+				rgb.r = l; rgb.g = m; rgb.b = V;
+				break;
+			case 4:
+				rgb.r = n; rgb.g = l; rgb.b = V;
+				break;
+			case 5:
+				rgb.r = V; rgb.g = l; rgb.b = m;
+				break;
+		}
+		
+		return Rgb (static_cast<ColorCompType>(rgb.r * ccColor::MAX),
+					static_cast<ColorCompType>(rgb.g * ccColor::MAX),
+					static_cast<ColorCompType>(rgb.b * ccColor::MAX));
+	}
 
-	// Predefined materials (float)
-	QCC_DB_LIB_API const Rgbaf bright					(1.00f, 1.00f, 1.00f, 1.00f);
-	QCC_DB_LIB_API const Rgbaf lighter					(0.83f, 0.83f, 0.83f, 1.00f);
-	QCC_DB_LIB_API const Rgbaf light					(0.66f, 0.66f, 0.66f, 1.00f);
-	QCC_DB_LIB_API const Rgbaf middle					(0.50f, 0.50f, 0.50f, 1.00f);
-	QCC_DB_LIB_API const Rgbaf dark						(0.34f, 0.34f, 0.34f, 1.00f);
-	QCC_DB_LIB_API const Rgbaf darker					(0.17f, 0.17f, 0.17f, 1.00f);
-	QCC_DB_LIB_API const Rgbaf darkest					(0.08f, 0.08f, 0.08f, 1.00f);
-	QCC_DB_LIB_API const Rgbaf night					(0.00f, 0.00f, 0.00f, 1.00F);
-	QCC_DB_LIB_API const Rgbaf defaultMeshFrontDiff		(0.00f, 0.90f, 0.27f, 1.00f);
-	QCC_DB_LIB_API const Rgbaf defaultMeshBackDiff		(0.27f, 0.90f, 0.90f, 1.00f);
-
-	// Default foreground color (unsigned byte)
-	QCC_DB_LIB_API const Rgbub defaultColor				(255, 255, 255); //white
-	QCC_DB_LIB_API const Rgbub defaultBkgColor			( 10, 102, 151); //dark blue
-	QCC_DB_LIB_API const Rgbub defaultLabelBkgColor		(255, 255, 255); //white
-	QCC_DB_LIB_API const Rgbub defaultLabelMarkerColor	(255,   0, 255); //magenta
 };

--- a/libs/qCC_db/ccColorTypes.h
+++ b/libs/qCC_db/ccColorTypes.h
@@ -24,18 +24,14 @@
 //Qt
 #include <QColor>
 
-//system
-#include <cmath>
-#include <random>
-
 //! Default color components type (R,G and B)
-typedef unsigned char ColorCompType;
+using ColorCompType = unsigned char;
 
 //! Colors namespace
 namespace ccColor
 {
 	//! Max value of a single color component (default type)
-	const ColorCompType MAX = 255;
+	constexpr ColorCompType MAX = 255;
 
 	//! RGB color structure
 	template <typename Type> class RgbTpl
@@ -55,24 +51,24 @@ namespace ccColor
 		//! Default constructor
 		/** Inits color to (0,0,0).
 		**/
-		inline RgbTpl() : r(0), g(0), b(0) {}
+		constexpr inline RgbTpl() : r(0), g(0), b(0) {}
 
 		//! Constructor from a triplet of r,g,b values
-		explicit inline RgbTpl(Type red, Type green, Type blue) : r(red), g(green), b(blue) {}
+		explicit constexpr inline RgbTpl(Type red, Type green, Type blue) : r(red), g(green), b(blue) {}
 
 		//! Constructor from an array of 3 values
-		explicit inline RgbTpl(const Type col[3]) : r(col[0]), g(col[1]), b(col[2]) {}
+		explicit constexpr inline RgbTpl(const Type col[3]) : r(col[0]), g(col[1]), b(col[2]) {}
 
 		//! Comparison operator
 		inline bool operator != (const RgbTpl<Type>& t) const { return (r != t.r || g != t.g || b != t.b); }
 	};
 
 	//! 3 components, float type
-	typedef RgbTpl<float> Rgbf;
+	using Rgbf = RgbTpl<float>;
 	//! 3 components, unsigned byte type
-	typedef RgbTpl<unsigned char> Rgbub;
+	using Rgbub = RgbTpl<unsigned char>;
 	//! 3 components, default type
-	typedef RgbTpl<ColorCompType> Rgb;
+	using Rgb = RgbTpl<ColorCompType>;
 
 	//! RGBA color structure
 	template <class Type> class RgbaTpl
@@ -92,15 +88,15 @@ namespace ccColor
 		//! Default constructor
 		/** Inits color to (0,0,0,0).
 		**/
-		inline RgbaTpl() : r(0), g(0), b(0), a(0) {}
+		constexpr inline RgbaTpl() : r(0), g(0), b(0), a(0) {}
 
 		//! Constructor from a triplet of r,g,b values and a transparency value
-		explicit inline RgbaTpl(Type red, Type green, Type blue, Type alpha) : r(red), g(green), b(blue), a(alpha) {}
+		explicit constexpr inline RgbaTpl(Type red, Type green, Type blue, Type alpha) : r(red), g(green), b(blue), a(alpha) {}
 
 		//! RgbaTpl from an array of 4 values
-		explicit inline RgbaTpl(const Type col[4]) : r(col[0]), g(col[1]), b(col[2]), a(col[3]) {}
+		explicit constexpr inline RgbaTpl(const Type col[4]) : r(col[0]), g(col[1]), b(col[2]), a(col[3]) {}
 		//! RgbaTpl from an array of 3 values and a transparency value
-		explicit inline RgbaTpl(const Type col[3], Type alpha) : r(col[0]), g(col[1]), b(col[2]), a(alpha) {}
+		explicit constexpr inline RgbaTpl(const Type col[3], Type alpha) : r(col[0]), g(col[1]), b(col[2]), a(alpha) {}
 	
 		//! Copy constructor
 		inline RgbaTpl(const RgbTpl<Type>& c, Type alpha) : r(c.r), g(c.g), b(c.b), a(alpha) {}
@@ -115,43 +111,43 @@ namespace ccColor
 	};
 
 	//! 4 components, float type
-	typedef RgbaTpl<float> Rgbaf;
+	using Rgbaf = RgbaTpl<float>;
 	//! 4 components, unsigned byte type
-	typedef RgbaTpl<unsigned char> Rgbaub;
+	using Rgbaub = RgbaTpl<unsigned char>;
 	//! 4 components, default type
-	typedef RgbaTpl<ColorCompType> Rgba;
+	using Rgba = RgbaTpl<ColorCompType>;
 
 	// Predefined colors (default type)
-	QCC_DB_LIB_API extern const Rgb white;
-	QCC_DB_LIB_API extern const Rgb lightGrey;
-	QCC_DB_LIB_API extern const Rgb darkGrey;
-	QCC_DB_LIB_API extern const Rgb red;
-	QCC_DB_LIB_API extern const Rgb green;
-	QCC_DB_LIB_API extern const Rgb blue;
-	QCC_DB_LIB_API extern const Rgb darkBlue;
-	QCC_DB_LIB_API extern const Rgb magenta;
-	QCC_DB_LIB_API extern const Rgb cyan;
-	QCC_DB_LIB_API extern const Rgb orange;
-	QCC_DB_LIB_API extern const Rgb black;
-	QCC_DB_LIB_API extern const Rgb yellow;
+	constexpr Rgb white						(MAX, MAX, MAX);
+	constexpr Rgb lightGrey					(static_cast<ColorCompType>(MAX*0.8), static_cast<ColorCompType>(MAX*0.8), static_cast<ColorCompType>(MAX*0.8));
+	constexpr Rgb darkGrey					(MAX / 2, MAX / 2, MAX / 2);
+	constexpr Rgb red						(MAX, 0, 0);
+	constexpr Rgb green						(0, MAX, 0);
+	constexpr Rgb blue						(0, 0, MAX);
+	constexpr Rgb darkBlue					(0, 0, MAX / 2);
+	constexpr Rgb magenta					(MAX, 0, MAX);
+	constexpr Rgb cyan						(0, MAX, MAX);
+	constexpr Rgb orange					(MAX, MAX / 2, 0);
+	constexpr Rgb black						(0, 0, 0);
+	constexpr Rgb yellow					(MAX, MAX, 0);
 
 	// Predefined materials (float)
-	QCC_DB_LIB_API extern const Rgbaf bright;
-	QCC_DB_LIB_API extern const Rgbaf lighter;
-	QCC_DB_LIB_API extern const Rgbaf light;
-	QCC_DB_LIB_API extern const Rgbaf middle;
-	QCC_DB_LIB_API extern const Rgbaf dark;
-	QCC_DB_LIB_API extern const Rgbaf darker;
-	QCC_DB_LIB_API extern const Rgbaf darkest;
-	QCC_DB_LIB_API extern const Rgbaf night;
-	QCC_DB_LIB_API extern const Rgbaf defaultMeshFrontDiff;
-	QCC_DB_LIB_API extern const Rgbaf defaultMeshBackDiff;
+	constexpr Rgbaf bright					(1.00f, 1.00f, 1.00f, 1.00f);
+	constexpr Rgbaf lighter					(0.83f, 0.83f, 0.83f, 1.00f);
+	constexpr Rgbaf light					(0.66f, 0.66f, 0.66f, 1.00f);
+	constexpr Rgbaf middle					(0.50f, 0.50f, 0.50f, 1.00f);
+	constexpr Rgbaf dark					(0.34f, 0.34f, 0.34f, 1.00f);
+	constexpr Rgbaf darker					(0.17f, 0.17f, 0.17f, 1.00f);
+	constexpr Rgbaf darkest					(0.08f, 0.08f, 0.08f, 1.00f);
+	constexpr Rgbaf night					(0.00f, 0.00f, 0.00f, 1.00F);
+	constexpr Rgbaf defaultMeshFrontDiff	(0.00f, 0.90f, 0.27f, 1.00f);
+	constexpr Rgbaf defaultMeshBackDiff		(0.27f, 0.90f, 0.90f, 1.00f);
 
 	// Default foreground color (unsigned byte)
-	QCC_DB_LIB_API extern const Rgbub defaultColor;				//white
-	QCC_DB_LIB_API extern const Rgbub defaultBkgColor;			//dark blue
-	QCC_DB_LIB_API extern const Rgbub defaultLabelBkgColor;		//white
-	QCC_DB_LIB_API extern const Rgbub defaultLabelMarkerColor;	//magenta
+	constexpr Rgbub defaultColor			(255, 255, 255);	// white
+	constexpr Rgbub defaultBkgColor			( 10, 102, 151);	// dark blue
+	constexpr Rgbub defaultLabelBkgColor	(255, 255, 255);	// white
+	constexpr Rgbub defaultLabelMarkerColor	(255,   0, 255);	// magenta
 
 	//! Colors generator
 	class Generator
@@ -159,26 +155,7 @@ namespace ccColor
 	public:
 		
 		//! Generates a random color
-		static Rgb Random(bool lightOnly = true)
-		{
-			std::random_device rd;   // non-deterministic generator
-			std::mt19937 gen(rd());  // to seed mersenne twister.
-			std::uniform_int_distribution<unsigned> dist(0, MAX);
-
-			Rgb col;
-			col.r = dist(gen);
-			col.g = dist(gen);
-			if (lightOnly)
-			{
-				col.b = MAX - static_cast<ColorCompType>((static_cast<double>(col.r) + static_cast<double>(col.g)) / 2); //cast to double to avoid overflow (whatever the type of ColorCompType!!!)
-			}
-			else
-			{
-				col.b = dist(gen);
-			}
-
-			return col;
-		}
+		QCC_DB_LIB_API static Rgb Random(bool lightOnly = true);
 	};
 
 	//! Color space conversion
@@ -204,7 +181,7 @@ namespace ccColor
 
 			return Rgb(	static_cast<ColorCompType>(r * ccColor::MAX),
 						static_cast<ColorCompType>(g * ccColor::MAX),
-						static_cast<ColorCompType>(b * ccColor::MAX));
+						static_cast<ColorCompType>(b * ccColor::MAX) );
 
 		}
 
@@ -214,45 +191,9 @@ namespace ccColor
 			\param V [out] value [0;1]
 			\return RGB color (unsigned byte)
 		**/
-		static Rgb hsv2rgb(float H, float S, float V)
-		{
-			float hi = 0;
-			float f = std::modf(H / 60.0f, &hi);
+		QCC_DB_LIB_API static Rgb hsv2rgb(float H, float S, float V);
 
-			float l = V*(1.0f - S);
-			float m = V*(1.0f - f*S);
-			float n = V*(1.0f - (1.0f - f)*S);
-
-			Rgbf rgb(0, 0, 0);
-
-			switch (static_cast<int>(hi) % 6)
-			{
-			case 0:
-				rgb.r = V; rgb.g = n; rgb.b = l;
-				break;
-			case 1:
-				rgb.r = m; rgb.g = V; rgb.b = l;
-				break;
-			case 2:
-				rgb.r = l; rgb.g = V; rgb.b = n;
-				break;
-			case 3:
-				rgb.r = l; rgb.g = m; rgb.b = V;
-				break;
-			case 4:
-				rgb.r = n; rgb.g = l; rgb.b = V;
-				break;
-			case 5:
-				rgb.r = V; rgb.g = l; rgb.b = m;
-				break;
-			}
-
-			return Rgb (static_cast<ColorCompType>(rgb.r * ccColor::MAX),
-						static_cast<ColorCompType>(rgb.g * ccColor::MAX),
-						static_cast<ColorCompType>(rgb.b * ccColor::MAX));
-		}
-
-	protected:
+	private:
 
 		//! Method used by hsl2rgb
 		static float hue2rgb(float m1, float m2, float hue)
@@ -274,46 +215,70 @@ namespace ccColor
 	};
 
 	//! Conversion from Rgbf
-	inline Rgb FromRgbf(const Rgbf& color) { return Rgb(static_cast<ColorCompType>(color.r * MAX),
-														static_cast<ColorCompType>(color.g * MAX),
-														static_cast<ColorCompType>(color.b * MAX)); }
-
+	inline Rgb FromRgbf(const Rgbf& color)
+	{
+		return Rgb( static_cast<ColorCompType>(color.r * MAX),
+					static_cast<ColorCompType>(color.g * MAX),
+					static_cast<ColorCompType>(color.b * MAX) );
+	}
+	
 	//! Conversion from Rgbaf
-	inline Rgb FromRgbf(const Rgbaf& color) { return Rgb(	static_cast<ColorCompType>(color.r * MAX),
-															static_cast<ColorCompType>(color.g * MAX),
-															static_cast<ColorCompType>(color.b * MAX)); }
-
+	inline Rgb FromRgbf(const Rgbaf& color)
+	{
+		return Rgb( static_cast<ColorCompType>(color.r * MAX),
+					static_cast<ColorCompType>(color.g * MAX),
+					static_cast<ColorCompType>(color.b * MAX) );
+	}
+	
 	//! Conversion from QRgb
-	inline Rgb FromQRgb(QRgb qColor) { return Rgb(	static_cast<unsigned char>(qRed(qColor)),
-													static_cast<unsigned char>(qGreen(qColor)),
-													static_cast<unsigned char>(qBlue(qColor))); }
-
+	inline Rgb FromQRgb(QRgb qColor)
+	{
+		return Rgb( static_cast<unsigned char>(qRed(qColor)),
+					static_cast<unsigned char>(qGreen(qColor)),
+					static_cast<unsigned char>(qBlue(qColor)) );
+	}
+	
 	//! Conversion from QRgb'a'
-	inline Rgba FromQRgba(QRgb qColor) { return Rgba(	static_cast<unsigned char>(qRed(qColor)),
-														static_cast<unsigned char>(qGreen(qColor)),
-														static_cast<unsigned char>(qBlue(qColor)),
-														static_cast<unsigned char>(qAlpha(qColor))); }
-
+	inline Rgba FromQRgba(QRgb qColor)
+	{
+		return Rgba( static_cast<unsigned char>(qRed(qColor)),
+					 static_cast<unsigned char>(qGreen(qColor)),
+					 static_cast<unsigned char>(qBlue(qColor)),
+					 static_cast<unsigned char>(qAlpha(qColor)) );
+	}
+	
 	//! Conversion from QColor
-	inline Rgb FromQColor(QColor qColor) { return Rgb(	static_cast<unsigned char>(qColor.red()),
-														static_cast<unsigned char>(qColor.green()),
-														static_cast<unsigned char>(qColor.blue())); }
-
+	inline Rgb FromQColor(const QColor& qColor)
+	{
+		return Rgb( static_cast<unsigned char>(qColor.red()),
+					static_cast<unsigned char>(qColor.green()),
+					static_cast<unsigned char>(qColor.blue()) );
+	}
+	
 	//! Conversion from QColor'a'
-	inline Rgba FromQColora(QColor qColor) { return Rgba(	static_cast<unsigned char>(qColor.red()),
-															static_cast<unsigned char>(qColor.green()),
-															static_cast<unsigned char>(qColor.blue()),
-															static_cast<unsigned char>(qColor.alpha())); }
-
+	inline Rgba FromQColora(const QColor& qColor)
+	{
+		return Rgba( static_cast<unsigned char>(qColor.red()),
+					 static_cast<unsigned char>(qColor.green()),
+					 static_cast<unsigned char>(qColor.blue()),
+					 static_cast<unsigned char>(qColor.alpha()) );
+	}
+	
 	//! Conversion from QColor (floating point)
-	inline Rgbf FromQColorf(QColor qColor) { return Rgbf(	static_cast<float>(qColor.redF()),
-															static_cast<float>(qColor.greenF()),
-															static_cast<float>(qColor.blueF())); }
+	inline Rgbf FromQColorf(const QColor& qColor)
+	{
+		return Rgbf( static_cast<float>(qColor.redF()),
+					 static_cast<float>(qColor.greenF()),
+					 static_cast<float>(qColor.blueF()) );
+	}
+	
 	//! Conversion from QColor'a' (floating point)
-	inline Rgbaf FromQColoraf(QColor qColor) { return Rgbaf(	static_cast<float>(qColor.redF()),
-																static_cast<float>(qColor.greenF()),
-																static_cast<float>(qColor.blueF()),
-																static_cast<float>(qColor.alphaF()));
+	inline Rgbaf FromQColoraf(const QColor& qColor)
+	{
+		return Rgbaf( static_cast<float>(qColor.redF()),
+					  static_cast<float>(qColor.greenF()),
+					  static_cast<float>(qColor.blueF()),
+					  static_cast<float>(qColor.alphaF()) );
 	}
 };
 

--- a/qCC/ccColorScaleEditorWidget.cpp
+++ b/qCC/ccColorScaleEditorWidget.cpp
@@ -28,11 +28,12 @@
 
 //System
 #include <cassert>
+#include <cmath>
 
-static const int DEFAULT_SLIDER_SYMBOL_SIZE = 8;
-static const int DEFAULT_MARGIN = DEFAULT_SLIDER_SYMBOL_SIZE/2+1;
-static const int DEFAULT_TEXT_MARGIN = 2;
-static const int DEFAULT_LABEL_HEIGHT = 12;
+constexpr int DEFAULT_SLIDER_SYMBOL_SIZE = 8;
+constexpr int DEFAULT_MARGIN = DEFAULT_SLIDER_SYMBOL_SIZE/2+1;
+constexpr int DEFAULT_TEXT_MARGIN = 2;
+constexpr int DEFAULT_LABEL_HEIGHT = 12;
 
 /*******************************/
 /*** ColorScaleElementSlider ***/


### PR DESCRIPTION
General cleanup:
- "using" instead of "typedef"
- use "constexpr" in place of "extern const"s
- pass some args by const ref
- reformat conversion functions for readability

`ccColorType.h` is indirectly included in about *80%* of CloudCompare's cpp files, so the fewer includes the better for compilation speed.

- move Generator::Random() definition into cpp
	- `<random>` is very heavy (a dozen includes and 6700 lines of templates in llvm version), so get `<random>` out of the header
	- it is not used very frequently in the codebase
	- it is unlikely to be inlined by the compiler anyways
- move Convert::hsv2rgb() definition into cpp
	- this method is unused and this allows us to move `<cmath>` into the cpp
- because the headers were moved, a couple of other files required new includes
	- there may be other changes required for Windows