### PR TITLE
Update LASFilter.cpp

### DIFF
--- a/libs/qCC_io/LASFilter.cpp
+++ b/libs/qCC_io/LASFilter.cpp
@@ -27,6 +27,7 @@
 #include <ccPointCloud.h>
 #include <ccProgressDialog.h>
 #include <ccScalarField.h>
+#include <ccHObjectCaster.h>
 #include "ccColorScalesManager.h"
 
 //CCLib


### PR DESCRIPTION
ccHObjectCaster.h was missing. It solve's compilation error (Ubuntu 18.04).