### PR TITLE
{cmake} Replace uses of COMPILE_DEFINITIONS_*

### DIFF
--- a/cmake/CMakePolicies.cmake
+++ b/cmake/CMakePolicies.cmake
@@ -11,10 +11,4 @@ if ( WIN32 )
     endif()
 endif()
 
-# https://cmake.org/cmake/help/v3.0/policy/CMP0043.html
-if (POLICY CMP0043)
-    cmake_policy(SET CMP0043 OLD)
-    set( POLICY_LIST "${POLICY_LIST} CMP0043" )
-endif()
-
 message( "cmake policies active:${POLICY_LIST}")

--- a/contrib/3DXSupport.cmake
+++ b/contrib/3DXSupport.cmake
@@ -27,19 +27,10 @@ function( target_link_3DXWARE ) # 1 argument: ARGV0 = project name
 				target_link_libraries( ${ARGV0} optimized ${3DXWARE_LIB_DIR}/siapp.lib ${3DXWARE_LIB_DIR}/spwmath.lib)
 			
 				if ( CMAKE_CONFIGURATION_TYPES )
-				
 					target_link_libraries( ${ARGV0} debug ${3DXWARE_LIB_DIR}/siapp.lib ${3DXWARE_LIB_DIR}/spwmathD.lib )
-
-					#Anytime we use COMPILE_DEFINITIONS_XXX we must define this policy!
-					#(and setting it outside of the function/file doesn't seem to work...)
-					cmake_policy(SET CMP0043 OLD)
-
-					set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS_RELEASE CC_3DXWARE_SUPPORT )
-					set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS_RELWITHDEBINFO CC_3DXWARE_SUPPORT )
-					set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS_DEBUG CC_3DXWARE_SUPPORT )
-				else()
-					set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS CC_3DXWARE_SUPPORT )
 				endif()
+				
+				set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS CC_3DXWARE_SUPPORT )
 			else()
 				message( SEND_ERROR "3DXWARE libraries folder is not specified (3DXWARE_LIB_DIR)" )
 			endif()

--- a/contrib/FBXSupport.cmake
+++ b/contrib/FBXSupport.cmake
@@ -27,15 +27,11 @@ function( target_link_FBX_SDK ) # 2 arguments: ARGV0 = project name
 
 if( ${OPTION_USE_FBX_SDK} )
 	
-	#Anytime we use COMPILE_DEFINITIONS_XXX we must define this policy!
-	#(and setting it outside of the function/file doesn't seem to work...)
-	cmake_policy(SET CMP0043 OLD)
-
 	#release/general
 	if( FBX_SDK_LIBRARY_FILE )
 
 		if ( CMAKE_CONFIGURATION_TYPES )
-			set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS_RELEASE CC_FBX_SUPPORT )
+			set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Release>:CC_FBX_SUPPORT> )
 			target_link_libraries( ${ARGV0} optimized ${FBX_SDK_LIBRARY_FILE} )
 		else()
 			set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS CC_FBX_SUPPORT )
@@ -61,7 +57,7 @@ if( ${OPTION_USE_FBX_SDK} )
 	
 		if (FBX_SDK_LIBRARY_FILE_DEBUG)
 			
-			set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS_DEBUG CC_FBX_SUPPORT )
+			set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:CC_FBX_SUPPORT> )
 			target_link_libraries( ${ARGV0} debug ${FBX_SDK_LIBRARY_FILE_DEBUG} )
 
 		else()

--- a/contrib/GamepadSupport.cmake
+++ b/contrib/GamepadSupport.cmake
@@ -20,18 +20,7 @@ function( target_link_GAMEPADS ) # 1 argument: ARGV0 = project name
 	
 		target_link_libraries(${PROJECT_NAME} Qt5::Gamepad)
 		
-		if ( CMAKE_CONFIGURATION_TYPES )
-		
-			#Anytime we use COMPILE_DEFINITIONS_XXX we must define this policy!
-			#(and setting it outside of the function/file doesn't seem to work...)
-			cmake_policy(SET CMP0043 OLD)
-
-			set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS_RELEASE CC_GAMEPADS_SUPPORT )
-			set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS_RELWITHDEBINFO CC_GAMEPADS_SUPPORT )
-			set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS_DEBUG CC_GAMEPADS_SUPPORT )
-		else()
-			set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS CC_GAMEPADS_SUPPORT )
-		endif()
+		set_property( TARGET ${ARGV0} APPEND PROPERTY COMPILE_DEFINITIONS CC_GAMEPADS_SUPPORT )
 
 	endif()
 

--- a/plugins/CMakePluginTpl.cmake
+++ b/plugins/CMakePluginTpl.cmake
@@ -53,15 +53,7 @@ endif()
 
 # Plugins need the QT_NO_DEBUG preprocessor in release!
 if( WIN32 )
-	if( NOT CMAKE_CONFIGURATION_TYPES )
-		set_property( TARGET ${PROJECT_NAME} APPEND PROPERTY COMPILE_DEFINITIONS QT_NO_DEBUG )
-	else()
-		#Anytime we use COMPILE_DEFINITIONS_XXX we must define this policy!
-		#(and setting it outside of the function/file doesn't seem to work...)
-		cmake_policy(SET CMP0043 OLD)
-	
-		set_property( TARGET ${PROJECT_NAME} APPEND PROPERTY COMPILE_DEFINITIONS_RELEASE QT_NO_DEBUG)
-	endif()
+	set_property( TARGET ${PROJECT_NAME} APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Release>:QT_NO_DEBUG>)
 endif()
 
 target_link_libraries( ${PROJECT_NAME} CC_FBO_LIB )


### PR DESCRIPTION
Replace uses of COMPILE_DEFINITIONS_* with generators to fix deprecated policy CMP0043.