### PR TITLE
Add -PCV option to command line interface for ambient occlusion

### DIFF
--- a/plugins/core/qPCV/PCVCommand.cpp
+++ b/plugins/core/qPCV/PCVCommand.cpp
@@ -8,11 +8,11 @@
 #include <ccPointCloud.h>
 #include <ccProgressDialog.h>
 
-static const char COMMAND_PCV[] = "PCV";
-static const char COMMAND_PCV_N_RAYS[] = "N_RAYS";
-static const char COMMAND_PCV_IS_CLOSED[] = "IS_CLOSED";
-static const char COMMAND_PCV_180[] = "180";
-static const char COMMAND_PCV_RESOLUTION[] = "RESOLUTION";
+constexpr char COMMAND_PCV[] = "PCV";
+constexpr char COMMAND_PCV_N_RAYS[] = "N_RAYS";
+constexpr char COMMAND_PCV_IS_CLOSED[] = "IS_CLOSED";
+constexpr char COMMAND_PCV_180[] = "180";
+constexpr char COMMAND_PCV_RESOLUTION[] = "RESOLUTION";
 
 PCVCommand::PCVCommand() :
 	Command("PCV", COMMAND_PCV)

--- a/plugins/core/qPCV/PCVCommand.cpp
+++ b/plugins/core/qPCV/PCVCommand.cpp
@@ -77,7 +77,8 @@ bool PCVCommand::process(ccCommandLineInterface& cmd)
 			qPCV::tr("No mesh is available. The CLI PCV implementation currently only supports a single mesh."));
 	}
 
-	ccPointCloud* pc = ccHObjectCaster::ToPointCloud(cmd.meshes()[0].mesh->getAssociatedCloud());
+	ccGenericPointCloud* meshCloud = cmd.meshes()[0].mesh->getAssociatedCloud();
+	ccPointCloud* pc = ccHObjectCaster::ToPointCloud(meshCloud);
 	ccGenericMesh* mesh = cmd.meshes()[0].mesh;
 
 	int point_count = pc->size();

--- a/plugins/core/qPCV/PCVCommand.cpp
+++ b/plugins/core/qPCV/PCVCommand.cpp
@@ -9,6 +9,10 @@
 #include <ccProgressDialog.h>
 
 static const char COMMAND_PCV[] = "PCV";
+static const char COMMAND_PCV_N_RAYS[] = "N_RAYS";
+static const char COMMAND_PCV_IS_CLOSED[] = "IS_CLOSED";
+static const char COMMAND_PCV_180[] = "180";
+static const char COMMAND_PCV_RESOLUTION[] = "RESOLUTION";
 
 PCVCommand::PCVCommand() :
 	Command("PCV", COMMAND_PCV)
@@ -17,16 +21,60 @@ PCVCommand::PCVCommand() :
 
 bool PCVCommand::process(ccCommandLineInterface& cmd)
 {
-	static int n_rays = 256;
-	static bool meshIsClosed = true;
-	static bool mode360 = true;
-	static unsigned resolution = 1024;
-
 	cmd.print("[PCV]");
+
+	// Initialize to match PCV::Launch defaults
+	unsigned nRays = 256;
+	bool meshIsClosed = false;
+	bool mode360 = true;
+	unsigned resolution = 1024;
+
+	while (!cmd.arguments().empty())
+	{
+		QString arg = cmd.arguments().front();
+		if (ccCommandLineInterface::IsCommand(arg, COMMAND_PCV_IS_CLOSED))
+		{
+			cmd.arguments().pop_front();
+			meshIsClosed = true;
+		}
+
+		// PCV::Launch mode360 defaults to true. To make absence / presence of command map to false / true,
+		// the command is named "180," and is the inverse of mode360.
+		else if (ccCommandLineInterface::IsCommand(arg, COMMAND_PCV_180))
+		{
+			cmd.arguments().pop_front();
+			mode360 = false;
+		}
+		else if (ccCommandLineInterface::IsCommand(arg, COMMAND_PCV_N_RAYS))
+		{
+			cmd.arguments().pop_front();
+			bool conversionOk = false;
+			nRays = cmd.arguments().takeFirst().toFloat(&conversionOk);
+			if (!conversionOk)
+			{
+				return cmd.error(QObject::tr("Invalid parameter: value after \"-%1\"").arg(COMMAND_PCV_N_RAYS));
+			}
+		}
+		else if (ccCommandLineInterface::IsCommand(arg, COMMAND_PCV_RESOLUTION))
+		{
+			cmd.arguments().pop_front();
+			bool conversionOk = false;
+			resolution = cmd.arguments().takeFirst().toFloat(&conversionOk);
+			if (!conversionOk)
+			{
+				return cmd.error(QObject::tr("Invalid parameter: value after \"-%1\"").arg(COMMAND_PCV_RESOLUTION));
+			}
+		}
+		else
+		{
+			break;
+		}
+	}
+
 	if (cmd.meshes().empty())
 	{
 		return cmd.error(
-			QString("No mesh is available. The CLI PCV implementation currently only supports a single mesh."));
+			QObject::tr("No mesh is available. The CLI PCV implementation currently only supports a single mesh."));
 	}
 
 	ccPointCloud* pc = ccHObjectCaster::ToPointCloud(cmd.meshes()[0].mesh->getAssociatedCloud());
@@ -39,7 +87,7 @@ bool PCVCommand::process(ccCommandLineInterface& cmd)
 	ccProgressDialog pcvProgressCb(true);
 	pcvProgressCb.setAutoClose(false);
 
-	PCV::Launch(n_rays, pc, mesh, meshIsClosed, mode360, resolution, resolution,
+	PCV::Launch(nRays, pc, mesh, meshIsClosed, mode360, resolution, resolution,
 	            &pcvProgressCb, QString(mesh->getName()));
 
 	cmd.meshes()[0].basename += QString("_PCV");

--- a/plugins/core/qPCV/PCVCommand.cpp
+++ b/plugins/core/qPCV/PCVCommand.cpp
@@ -52,7 +52,7 @@ bool PCVCommand::process(ccCommandLineInterface& cmd)
 			nRays = cmd.arguments().takeFirst().toFloat(&conversionOk);
 			if (!conversionOk)
 			{
-				return cmd.error(QObject::tr("Invalid parameter: value after \"-%1\"").arg(COMMAND_PCV_N_RAYS));
+				return cmd.error(qPCV::tr("Invalid parameter: value after \"-%1\"").arg(COMMAND_PCV_N_RAYS));
 			}
 		}
 		else if (ccCommandLineInterface::IsCommand(arg, COMMAND_PCV_RESOLUTION))
@@ -62,7 +62,7 @@ bool PCVCommand::process(ccCommandLineInterface& cmd)
 			resolution = cmd.arguments().takeFirst().toFloat(&conversionOk);
 			if (!conversionOk)
 			{
-				return cmd.error(QObject::tr("Invalid parameter: value after \"-%1\"").arg(COMMAND_PCV_RESOLUTION));
+				return cmd.error(qPCV::tr("Invalid parameter: value after \"-%1\"").arg(COMMAND_PCV_RESOLUTION));
 			}
 		}
 		else
@@ -74,7 +74,7 @@ bool PCVCommand::process(ccCommandLineInterface& cmd)
 	if (cmd.meshes().empty())
 	{
 		return cmd.error(
-			QObject::tr("No mesh is available. The CLI PCV implementation currently only supports a single mesh."));
+			qPCV::tr("No mesh is available. The CLI PCV implementation currently only supports a single mesh."));
 	}
 
 	ccPointCloud* pc = ccHObjectCaster::ToPointCloud(cmd.meshes()[0].mesh->getAssociatedCloud());
@@ -82,7 +82,7 @@ bool PCVCommand::process(ccCommandLineInterface& cmd)
 
 	int point_count = pc->size();
 
-	cmd.print(QString("Size is %1").arg(point_count));
+	cmd.print(qPCV::tr("Size is %1").arg(point_count));
 
 	ccProgressDialog pcvProgressCb(true);
 	pcvProgressCb.setAutoClose(false);

--- a/plugins/core/qPCV/PCVCommand.cpp
+++ b/plugins/core/qPCV/PCVCommand.cpp
@@ -1,0 +1,22 @@
+#include "PCVCommand.h"
+#include "PCV.h"
+#include "qPCV.h"
+
+static const char COMMAND_PCV[] = "PCV";
+
+PCVCommand::PCVCommand() :
+	ccCommandLineInterface::Command("PCV", COMMAND_PCV) {
+}
+
+bool PCVCommand::process(ccCommandLineInterface &cmd) {
+	cmd.print("[PCV]");
+	if (cmd.meshes().empty()) {
+		return cmd.error(QObject::tr("No point cloud or mesh available. Be sure to open or generate one first!"));
+	}
+
+	return true;
+}
+
+void qPCV::registerCommands(ccCommandLineInterface *cmd) {
+	cmd->registerCommand(ccCommandLineInterface::Command::Shared(new PCVCommand));
+}

--- a/plugins/core/qPCV/PCVCommand.cpp
+++ b/plugins/core/qPCV/PCVCommand.cpp
@@ -52,7 +52,7 @@ bool PCVCommand::process(ccCommandLineInterface& cmd)
 			nRays = cmd.arguments().takeFirst().toFloat(&conversionOk);
 			if (!conversionOk)
 			{
-				return cmd.error(qPCV::tr("Invalid parameter: value after \"-%1\"").arg(COMMAND_PCV_N_RAYS));
+				return cmd.error(QObject::tr("Invalid parameter: value after \"-%1\"").arg(COMMAND_PCV_N_RAYS));
 			}
 		}
 		else if (ccCommandLineInterface::IsCommand(arg, COMMAND_PCV_RESOLUTION))
@@ -62,7 +62,7 @@ bool PCVCommand::process(ccCommandLineInterface& cmd)
 			resolution = cmd.arguments().takeFirst().toFloat(&conversionOk);
 			if (!conversionOk)
 			{
-				return cmd.error(qPCV::tr("Invalid parameter: value after \"-%1\"").arg(COMMAND_PCV_RESOLUTION));
+				return cmd.error(QObject::tr("Invalid parameter: value after \"-%1\"").arg(COMMAND_PCV_RESOLUTION));
 			}
 		}
 		else
@@ -80,10 +80,6 @@ bool PCVCommand::process(ccCommandLineInterface& cmd)
 	ccGenericPointCloud* meshCloud = cmd.meshes()[0].mesh->getAssociatedCloud();
 	ccPointCloud* pc = ccHObjectCaster::ToPointCloud(meshCloud);
 	ccGenericMesh* mesh = cmd.meshes()[0].mesh;
-
-	int point_count = pc->size();
-
-	cmd.print(qPCV::tr("Size is %1").arg(point_count));
 
 	ccProgressDialog pcvProgressCb(true);
 	pcvProgressCb.setAutoClose(false);

--- a/plugins/core/qPCV/PCVCommand.cpp
+++ b/plugins/core/qPCV/PCVCommand.cpp
@@ -31,7 +31,7 @@ bool PCVCommand::process(ccCommandLineInterface& cmd)
 
 	while (!cmd.arguments().empty())
 	{
-		QString arg = cmd.arguments().front();
+		const QString arg = cmd.arguments().front();
 		if (ccCommandLineInterface::IsCommand(arg, COMMAND_PCV_IS_CLOSED))
 		{
 			cmd.arguments().pop_front();

--- a/plugins/core/qPCV/PCVCommand.cpp
+++ b/plugins/core/qPCV/PCVCommand.cpp
@@ -3,31 +3,30 @@
 #include "qPCV.h"
 
 //qCC_db
-#include <ccHObjectCaster.h>
-#include <ccGenericPointCloud.h>
-#include <ccPointCloud.h>
 #include <ccGenericMesh.h>
+#include <ccHObjectCaster.h>
+#include <ccPointCloud.h>
 #include <ccProgressDialog.h>
-#include <ccScalarField.h>
-#include <ccColorScalesManager.h>
-
-#include <QProgressBar>
 
 static const char COMMAND_PCV[] = "PCV";
 
 PCVCommand::PCVCommand() :
-	ccCommandLineInterface::Command("PCV", COMMAND_PCV) {
+	Command("PCV", COMMAND_PCV)
+{
 }
 
-bool PCVCommand::process(ccCommandLineInterface &cmd) {
+bool PCVCommand::process(ccCommandLineInterface& cmd)
+{
 	static int n_rays = 256;
 	static bool meshIsClosed = true;
 	static bool mode360 = true;
 	static unsigned resolution = 1024;
 
 	cmd.print("[PCV]");
-	if (cmd.meshes().empty()) {
-		return cmd.error(QObject::tr("No mesh is available. The CLI PCV impementation currently only supports a single mesh."));
+	if (cmd.meshes().empty())
+	{
+		return cmd.error(
+			QString("No mesh is available. The CLI PCV implementation currently only supports a single mesh."));
 	}
 
 	ccPointCloud* pc = ccHObjectCaster::ToPointCloud(cmd.meshes()[0].mesh->getAssociatedCloud());
@@ -35,19 +34,20 @@ bool PCVCommand::process(ccCommandLineInterface &cmd) {
 
 	int point_count = pc->size();
 
-	cmd.print(QObject::tr("Size is %1").arg(point_count));
+	cmd.print(QString("Size is %1").arg(point_count));
 
 	ccProgressDialog pcvProgressCb(true);
 	pcvProgressCb.setAutoClose(false);
 
 	PCV::Launch(n_rays, pc, mesh, meshIsClosed, mode360, resolution, resolution,
-		&pcvProgressCb, QString(mesh->getName()));
+	            &pcvProgressCb, QString(mesh->getName()));
 
-	cmd.meshes()[0].basename += QObject::tr("_PCV");
+	cmd.meshes()[0].basename += QString("_PCV");
 
 	return true;
 }
 
-void qPCV::registerCommands(ccCommandLineInterface *cmd) {
+void qPCV::registerCommands(ccCommandLineInterface* cmd)
+{
 	cmd->registerCommand(ccCommandLineInterface::Command::Shared(new PCVCommand));
 }

--- a/plugins/core/qPCV/PCVCommand.cpp
+++ b/plugins/core/qPCV/PCVCommand.cpp
@@ -19,7 +19,6 @@ PCVCommand::PCVCommand() :
 
 bool PCVCommand::process(ccCommandLineInterface &cmd) {
 	static int n_rays = 256;
-	static int s_resSpinBoxValue = 1024;
 	static bool mode360 = true;
 
 	cmd.print("[PCV]");
@@ -27,15 +26,16 @@ bool PCVCommand::process(ccCommandLineInterface &cmd) {
 		return cmd.error(QObject::tr("No point cloud or mesh available. Be sure to open or generate one first!"));
 	}
 
-	ccGenericMesh* mesh = ccHObjectCaster::ToGenericMesh(cmd.meshes()[0].mesh);
+	ccPointCloud* pc = ccHObjectCaster::ToPointCloud(cmd.meshes()[0].mesh->getAssociatedCloud());
+	ccGenericMesh* mesh = cmd.meshes()[0].mesh;
 
-	ccGenericPointCloud* pc = mesh->getAssociatedCloud();
+	int point_count = pc->size();
 
-	unsigned point_count = pc->size();
+	cmd.print(QObject::tr("Size is %1").arg(point_count));
 
-	PCV::Launch(n_rays, pc);
+	PCV::Launch(n_rays, pc, mesh, mode360);
 
-	cmd.exportEntity(pc, "PCV");
+	cmd.meshes()[0].basename += QObject::tr("_PCV");
 
 	return true;
 }

--- a/plugins/core/qPCV/PCVCommand.cpp
+++ b/plugins/core/qPCV/PCVCommand.cpp
@@ -31,7 +31,7 @@ bool PCVCommand::process(ccCommandLineInterface& cmd)
 
 	while (!cmd.arguments().empty())
 	{
-		const QString arg = cmd.arguments().front();
+		const QString& arg = cmd.arguments().front();
 		if (ccCommandLineInterface::IsCommand(arg, COMMAND_PCV_IS_CLOSED))
 		{
 			cmd.arguments().pop_front();

--- a/plugins/core/qPCV/PCVCommand.cpp
+++ b/plugins/core/qPCV/PCVCommand.cpp
@@ -11,6 +11,8 @@
 #include <ccScalarField.h>
 #include <ccColorScalesManager.h>
 
+#include <QProgressBar>
+
 static const char COMMAND_PCV[] = "PCV";
 
 PCVCommand::PCVCommand() :
@@ -19,11 +21,13 @@ PCVCommand::PCVCommand() :
 
 bool PCVCommand::process(ccCommandLineInterface &cmd) {
 	static int n_rays = 256;
+	static bool meshIsClosed = true;
 	static bool mode360 = true;
+	static unsigned resolution = 1024;
 
 	cmd.print("[PCV]");
 	if (cmd.meshes().empty()) {
-		return cmd.error(QObject::tr("No point cloud or mesh available. Be sure to open or generate one first!"));
+		return cmd.error(QObject::tr("No mesh is available. The CLI PCV impementation currently only supports a single mesh."));
 	}
 
 	ccPointCloud* pc = ccHObjectCaster::ToPointCloud(cmd.meshes()[0].mesh->getAssociatedCloud());
@@ -33,7 +37,11 @@ bool PCVCommand::process(ccCommandLineInterface &cmd) {
 
 	cmd.print(QObject::tr("Size is %1").arg(point_count));
 
-	PCV::Launch(n_rays, pc, mesh, mode360);
+	ccProgressDialog pcvProgressCb(true);
+	pcvProgressCb.setAutoClose(false);
+
+	PCV::Launch(n_rays, pc, mesh, meshIsClosed, mode360, resolution, resolution,
+		&pcvProgressCb, QString(mesh->getName()));
 
 	cmd.meshes()[0].basename += QObject::tr("_PCV");
 

--- a/plugins/core/qPCV/PCVCommand.cpp
+++ b/plugins/core/qPCV/PCVCommand.cpp
@@ -2,6 +2,15 @@
 #include "PCV.h"
 #include "qPCV.h"
 
+//qCC_db
+#include <ccHObjectCaster.h>
+#include <ccGenericPointCloud.h>
+#include <ccPointCloud.h>
+#include <ccGenericMesh.h>
+#include <ccProgressDialog.h>
+#include <ccScalarField.h>
+#include <ccColorScalesManager.h>
+
 static const char COMMAND_PCV[] = "PCV";
 
 PCVCommand::PCVCommand() :
@@ -9,10 +18,24 @@ PCVCommand::PCVCommand() :
 }
 
 bool PCVCommand::process(ccCommandLineInterface &cmd) {
+	static int n_rays = 256;
+	static int s_resSpinBoxValue = 1024;
+	static bool mode360 = true;
+
 	cmd.print("[PCV]");
 	if (cmd.meshes().empty()) {
 		return cmd.error(QObject::tr("No point cloud or mesh available. Be sure to open or generate one first!"));
 	}
+
+	ccGenericMesh* mesh = ccHObjectCaster::ToGenericMesh(cmd.meshes()[0].mesh);
+
+	ccGenericPointCloud* pc = mesh->getAssociatedCloud();
+
+	unsigned point_count = pc->size();
+
+	PCV::Launch(n_rays, pc);
+
+	cmd.exportEntity(pc, "PCV");
 
 	return true;
 }

--- a/plugins/core/qPCV/PCVCommand.h
+++ b/plugins/core/qPCV/PCVCommand.h
@@ -24,9 +24,12 @@ class PCVCommand : public ccCommandLineInterface::Command
 {
 public:
 	PCVCommand();
-	virtual ~PCVCommand() {}
 
-	virtual bool process(ccCommandLineInterface &cmd) override;
+	~PCVCommand()
+	{
+	}
+
+	bool process(ccCommandLineInterface& cmd) override;
 };
 
 #endif

--- a/plugins/core/qPCV/PCVCommand.h
+++ b/plugins/core/qPCV/PCVCommand.h
@@ -1,0 +1,32 @@
+#ifndef PCVCOMMAND_H
+#define PCVCOMMAND_H
+
+//##########################################################################
+//#                                                                        #
+//#                      CLOUDCOMPARE PLUGIN                               #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 of the License.               #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#          COPYRIGHT: CloudCompare project                               #
+//#                                                                        #
+//##########################################################################
+
+#include "ccCommandLineInterface.h"
+
+class PCVCommand : public ccCommandLineInterface::Command
+{
+public:
+	PCVCommand();
+	virtual ~PCVCommand() {}
+
+	virtual bool process(ccCommandLineInterface &cmd) override;
+};
+
+#endif

--- a/plugins/core/qPCV/PCVCommand.h
+++ b/plugins/core/qPCV/PCVCommand.h
@@ -25,9 +25,7 @@ class PCVCommand : public ccCommandLineInterface::Command
 public:
 	PCVCommand();
 
-	~PCVCommand()
-	{
-	}
+	~PCVCommand() override = default;
 
 	bool process(ccCommandLineInterface& cmd) override;
 };

--- a/plugins/core/qPCV/qPCV.cpp
+++ b/plugins/core/qPCV/qPCV.cpp
@@ -17,7 +17,6 @@
 
 #include "qPCV.h"
 #include "ccPcvDlg.h"
-#include "PCVCommand.h"
 
 //CCLib
 #include <ScalarField.h>
@@ -46,21 +45,6 @@ qPCV::qPCV(QObject* parent/*=0*/)
 	, ccStdPluginInterface(":/CC/plugin/qPCV/info.json")
 	, m_action(nullptr)
 {
-}
-
-static const char COMMAND_PCV[] = "PCV";
-
-PCVCommand::PCVCommand() :
-	ccCommandLineInterface::Command("PCV", COMMAND_PCV ){
-}
-
-bool PCVCommand::process(ccCommandLineInterface &cmd) {
-	cmd.print("[PCV]");
-	return true;
-}
-
-void qPCV::registerCommands(ccCommandLineInterface *cmd) {
-		cmd->registerCommand(ccCommandLineInterface::Command::Shared(new PCVCommand));
 }
 
 void qPCV::onNewSelection(const ccHObject::Container& selectedEntities)

--- a/plugins/core/qPCV/qPCV.cpp
+++ b/plugins/core/qPCV/qPCV.cpp
@@ -17,6 +17,7 @@
 
 #include "qPCV.h"
 #include "ccPcvDlg.h"
+#include "PCVCommand.h"
 
 //CCLib
 #include <ScalarField.h>
@@ -45,6 +46,21 @@ qPCV::qPCV(QObject* parent/*=0*/)
 	, ccStdPluginInterface(":/CC/plugin/qPCV/info.json")
 	, m_action(nullptr)
 {
+}
+
+static const char COMMAND_PCV[] = "PCV";
+
+PCVCommand::PCVCommand() :
+	ccCommandLineInterface::Command("PCV", COMMAND_PCV ){
+}
+
+bool PCVCommand::process(ccCommandLineInterface &cmd) {
+	cmd.print("[PCV]");
+	return true;
+}
+
+void qPCV::registerCommands(ccCommandLineInterface *cmd) {
+		cmd->registerCommand(ccCommandLineInterface::Command::Shared(new PCVCommand));
 }
 
 void qPCV::onNewSelection(const ccHObject::Container& selectedEntities)

--- a/plugins/core/qPCV/qPCV.h
+++ b/plugins/core/qPCV/qPCV.h
@@ -19,6 +19,7 @@
 #define Q_PCV_PLUGIN_HEADER
 
 #include "ccStdPluginInterface.h"
+#include "PCVCommand.h"
 
 //! Wrapper to the ShadeVis algorithm for computing Ambient Occlusion on meshes and point clouds
 /** "Visibility based methods and assessment for detail-recovery", M. Tarini, P. Cignoni, R. Scopigno
@@ -41,6 +42,7 @@ public:
 	//inherited from ccStdPluginInterface
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
 	virtual QList<QAction *> getActions() override;
+	void registerCommands(ccCommandLineInterface *cmd) override;
 
 protected slots:
 


### PR DESCRIPTION
Addresses #837 . Good enough for my personal use right now. It doesn't expose options like number of rays yet, and only works for a single mesh (qPCV supports arbitrary number of meshes and point clouds). I could add those features sometime soon.