### PR TITLE
These command line options take ints, not floats

### DIFF
--- a/plugins/core/qPCV/PCVCommand.cpp
+++ b/plugins/core/qPCV/PCVCommand.cpp
@@ -49,7 +49,7 @@ bool PCVCommand::process(ccCommandLineInterface& cmd)
 		{
 			cmd.arguments().pop_front();
 			bool conversionOk = false;
-			nRays = cmd.arguments().takeFirst().toFloat(&conversionOk);
+			nRays = cmd.arguments().takeFirst().toUInt(&conversionOk);
 			if (!conversionOk)
 			{
 				return cmd.error(QObject::tr("Invalid parameter: value after \"-%1\"").arg(COMMAND_PCV_N_RAYS));
@@ -59,7 +59,7 @@ bool PCVCommand::process(ccCommandLineInterface& cmd)
 		{
 			cmd.arguments().pop_front();
 			bool conversionOk = false;
-			resolution = cmd.arguments().takeFirst().toFloat(&conversionOk);
+			resolution = cmd.arguments().takeFirst().toUInt(&conversionOk);
 			if (!conversionOk)
 			{
 				return cmd.error(QObject::tr("Invalid parameter: value after \"-%1\"").arg(COMMAND_PCV_RESOLUTION));


### PR DESCRIPTION
Avoid extra conversion and potential rounding errors