### PR TITLE
escape question marks to fix accidental trigraph

### DIFF
--- a/common/ccApplicationBase.cpp
+++ b/common/ccApplicationBase.cpp
@@ -133,7 +133,7 @@ QString ccApplicationBase::versionLongStr( bool includeOS ) const
 #elif defined(CC_ENV_32)
 	const QString arch( "32-bit" );
 #else
-	const QString arch( "??-bit" );
+	const QString arch( "\?\?-bit" );
 #endif
 
 	if ( includeOS )


### PR DESCRIPTION
Currently the literal `??-` gets interpreted as a [trigraph](https://en.wikipedia.org/wiki/Digraphs_and_trigraphs#C). My compiler `g++ (GCC) 8.2.1 20181127` emits a warning for this line.

Hence it has to be [escaped](https://stackoverflow.com/questions/1586834/escape-sequence-for-in-c), which fixes the warning and avoids `arch` being erroneously set to `~bit` rather than `??-bit`.