### PR TITLE
Reduce memory allocations in SquareMatrixTpl

### DIFF
--- a/CC/include/SquareMatrix.h
+++ b/CC/include/SquareMatrix.h
@@ -115,16 +115,12 @@ namespace CCLib
 		**/
 		void invalidate()
 		{
-			if (m_values)
-			{
-				for (unsigned i = 0; i < m_matrixSize; i++)
-					if (m_values[i])
-						delete[] m_values[i];
-				delete[] m_values;
-				m_values = nullptr;
-			}
+			delete [] m_underlyingData;
+			m_underlyingData = nullptr;
+			m_values = nullptr;
 
-			m_matrixSize = matrixSquareSize = 0;
+			m_matrixSize = 0;
+			matrixSquareSize = 0;
 		}
 
 		//! The matrix rows
@@ -651,8 +647,7 @@ namespace CCLib
 			M16d[15] = 1.0;
 		}
 
-	protected:
-
+	private:
 		//! Internal initialization
 		/** \return initilization success
 		**/
@@ -663,34 +658,23 @@ namespace CCLib
 
 			m_values = nullptr;
 
-			if (size != 0)
+			if ( size == 0 )
 			{
-				m_values = new Scalar*[m_matrixSize];
-				if (m_values)
-				{
-					memset(m_values, 0, sizeof(Scalar*) * m_matrixSize);
-					for (unsigned i = 0; i < m_matrixSize; i++)
-					{
-						m_values[i] = new Scalar[m_matrixSize];
-						if (m_values[i])
-						{
-							memset(m_values[i], 0, sizeof(Scalar)*m_matrixSize);
-						}
-						else
-						{
-							//not enough memory!
-							invalidate();
-							return false;
-						}
-					}
-				}
-				else
-				{
-					//not enough memory!
-					return false;
-				}
+				return true;
 			}
-
+			
+			m_underlyingData = new Scalar[matrixSquareSize]{};
+			
+			if ( m_underlyingData == nullptr )
+			{
+				return false;
+			}
+									
+			for (unsigned i = 0; i < m_matrixSize; i++)
+			{
+				m_values[i] = &(m_underlyingData[i * m_matrixSize]);
+			}			
+			
 			return true;
 		}
 
@@ -734,6 +718,9 @@ namespace CCLib
 
 		//! Matrix square-size
 		unsigned matrixSquareSize;
+		
+		//! Stores the actual data, indexed by m_values
+		Scalar	*m_underlyingData = nullptr;
 	};
 
 	//! Default CC square matrix type (PointCoordinateType)


### PR DESCRIPTION
For a square matrix with dimension **N**, SquareMatrixTpl was performing **N+1** memory allocations.

Reduce this to **1**.

(`m_underlyingData` stores the actual data, and `m_values` now just indexes into it.)