### PR TITLE
If LAS minor_version was 0, let PDAL choose new version when writing

### DIFF
--- a/libs/qCC_io/LASFilter.cpp
+++ b/libs/qCC_io/LASFilter.cpp
@@ -479,9 +479,9 @@ CC_FILE_ERROR LASFilter::saveToFile(ccHObject* entity, const QString& filename, 
 	{
 		bool ok = false;
 		int minor_version = minor_version_meta_data.toInt(&ok);
-		if (ok)
+		if (ok && minor_version != 0) // PDAL can read but not write LAS 1.0
 			writerOptions.add("minor_version", minor_version);
-		else
+		else if (!ok)
 			ccLog::Warning(QString("Could not convert minor_version to int"));
 	}
 	const QVariant point_format_meta_data = theCloud->getMetaData(LAS_POINT_FORMAT_META_DATA);


### PR DESCRIPTION
CloudCompare remembers the minor_version of a LAS file read to save the file in the same version.

Howerver a problem arise when reading (then saving)  a LAS 1.0 file ([see CC's forum](https://www.danielgm.net/cc/forum/viewtopic.php?f=9&t=3535&sid=2e1d57a48c982d06f4203a6718f04633)) as PDAL can read LAS 1.0 but not write it. (https://github.com/PDAL/PDAL/issues/2196)

In that case let PDAL use its default for the minor_version