### PR TITLE
{plugins} Simplify ccDefaultPluginInterface API

### DIFF
--- a/plugins/ccIOFilterPluginInterface.h
+++ b/plugins/ccIOFilterPluginInterface.h
@@ -26,10 +26,13 @@
 #include "ccDefaultPluginInterface.h"
 
 //! I/O filter plugin interface
-/** Version 1.1
+/** Version 1.2
 **/
 class ccIOFilterPluginInterface : public ccDefaultPluginInterface
 {
+public:
+	using FilterList = QVector<FileIOFilter::Shared>;
+	
 public:
 	ccIOFilterPluginInterface( const QString &resourcePath = QString() ) :
 		ccDefaultPluginInterface( resourcePath )
@@ -41,20 +44,11 @@ public:
 	//inherited from ccPluginInterface
 	CC_PLUGIN_TYPE getType() const override { return CC_IO_FILTER_PLUGIN; }
 
-	//! Returns an I/O filter instance
-	/** Either getFilter or getFilters should be reimplemented by the child class
-		(depending on the number of I/O filters managed by the plugin)
-	**/
-	virtual FileIOFilter::Shared getFilter() { return FileIOFilter::Shared(nullptr); }
-
 	//! Returns a list of I/O filter instances
-	/** Either getFilter or getFilters should be reimplemented by the child class
-		(depending on the number of I/O filters managed by the plugin)
-	**/
-	virtual QVector<FileIOFilter::Shared> getFilters() { return QVector<FileIOFilter::Shared>{ getFilter() }; }
+	virtual FilterList getFilters() { return FilterList{}; }
 };
 
 Q_DECLARE_INTERFACE(ccIOFilterPluginInterface,
-                    "edf.rd.CloudCompare.ccIOFilterPluginInterface/1.1")
+                    "edf.rd.CloudCompare.ccIOFilterPluginInterface/1.2")
 
 #endif //CC_IO_FILTER_PLUGIN_INTERFACE_HEADER

--- a/plugins/core/IO/qAdditionalIO/qAdditionalIO.cpp
+++ b/plugins/core/IO/qAdditionalIO/qAdditionalIO.cpp
@@ -40,9 +40,9 @@ void qAdditionalIO::registerCommands( ccCommandLineInterface *cmd )
 	cmd->registerCommand( ccCommandLineInterface::Command::Shared( new BundlerCommand ) );	
 }
 
-QVector<FileIOFilter::Shared> qAdditionalIO::getFilters()
+ccIOFilterPluginInterface::FilterList qAdditionalIO::getFilters()
 {
-	return QVector<FileIOFilter::Shared>{
+	return {
 		FileIOFilter::Shared( new BundlerFilter ),
 		FileIOFilter::Shared( new IcmFilter ),
 		FileIOFilter::Shared( new PNFilter ),

--- a/plugins/core/IO/qAdditionalIO/qAdditionalIO.h
+++ b/plugins/core/IO/qAdditionalIO/qAdditionalIO.h
@@ -31,12 +31,12 @@ class qAdditionalIO : public QObject, public ccIOFilterPluginInterface
 public:
 	explicit qAdditionalIO( QObject* parent = nullptr );
 	
-	virtual ~qAdditionalIO() = default;
+	~qAdditionalIO() override = default;
 
-	virtual void registerCommands(ccCommandLineInterface* cmd) override;
+	void registerCommands(ccCommandLineInterface* cmd) override;
 	
 	// inherited from ccIOFilterPluginInterface
-	QVector<FileIOFilter::Shared> getFilters() override;
+	FilterList getFilters() override;
 };
 
 #endif

--- a/plugins/core/IO/qCSVMatrixIO/qCSVMatrixIO.cpp
+++ b/plugins/core/IO/qCSVMatrixIO/qCSVMatrixIO.cpp
@@ -27,7 +27,7 @@ qCSVMatrixIO::qCSVMatrixIO(QObject *parent)
 {
 }
 
-FileIOFilter::Shared qCSVMatrixIO::getFilter()
+ccIOFilterPluginInterface::FilterList qCSVMatrixIO::getFilters()
 {
-	return FileIOFilter::Shared(new CSVMatrixFilter);
+	return { FileIOFilter::Shared( new CSVMatrixFilter ) };
 }

--- a/plugins/core/IO/qCSVMatrixIO/qCSVMatrixIO.h
+++ b/plugins/core/IO/qCSVMatrixIO/qCSVMatrixIO.h
@@ -30,10 +30,10 @@ class qCSVMatrixIO : public QObject, public ccIOFilterPluginInterface
 public:
 	qCSVMatrixIO(QObject* parent = nullptr);
 	
-	virtual ~qCSVMatrixIO() = default;
+	~qCSVMatrixIO() override = default;
 
 	//inherited from ccIOFilterPluginInterface
-	FileIOFilter::Shared getFilter() override;
+	FilterList getFilters() override;
 };
 
 #endif //Q_CSV_MATRIX_IO_PLUGIN_HEADER

--- a/plugins/core/IO/qCoreIO/qCoreIO.cpp
+++ b/plugins/core/IO/qCoreIO/qCoreIO.cpp
@@ -40,9 +40,9 @@ void qCoreIO::registerCommands( ccCommandLineInterface *inCmdLine )
 	Q_UNUSED( inCmdLine );
 }
 
-QVector<FileIOFilter::Shared> qCoreIO::getFilters()
+ccIOFilterPluginInterface::FilterList qCoreIO::getFilters()
 {
-	return QVector<FileIOFilter::Shared>{
+	return {
 		FileIOFilter::Shared( new PTXFilter ),
 		FileIOFilter::Shared( new SimpleBinFilter ),
 		FileIOFilter::Shared( new ObjFilter ),

--- a/plugins/core/IO/qCoreIO/qCoreIO.h
+++ b/plugins/core/IO/qCoreIO/qCoreIO.h
@@ -33,7 +33,7 @@ public:
 protected:
 	void registerCommands( ccCommandLineInterface *inCmdLine ) override;
 	
-	QVector<FileIOFilter::Shared> getFilters() override;
+	FilterList getFilters() override;
 };
 
 #endif //QCORE_IO_HEADER

--- a/plugins/core/IO/qE57IO/qE57IO.cpp
+++ b/plugins/core/IO/qE57IO/qE57IO.cpp
@@ -31,7 +31,7 @@ void qE57IO::registerCommands( ccCommandLineInterface *cmd )
 	Q_UNUSED( cmd );
 }
 
-QVector<FileIOFilter::Shared> qE57IO::getFilters()
+ccIOFilterPluginInterface::FilterList qE57IO::getFilters()
 {
 	return { FileIOFilter::Shared( new E57Filter ) };
 }

--- a/plugins/core/IO/qE57IO/qE57IO.h
+++ b/plugins/core/IO/qE57IO/qE57IO.h
@@ -32,7 +32,7 @@ public:
 	
 	void registerCommands( ccCommandLineInterface *cmd ) override;
 	
-	QVector<FileIOFilter::Shared> getFilters() override;
+	FilterList getFilters() override;
 };
 
 #endif

--- a/plugins/core/IO/qFBXIO/qFBXIO.cpp
+++ b/plugins/core/IO/qFBXIO/qFBXIO.cpp
@@ -32,7 +32,7 @@ void qFBXIO::registerCommands( ccCommandLineInterface *cmd )
 	cmd->registerCommand( ccCommandLineInterface::Command::Shared( new FBXCommand ) );
 }
 
-QVector<FileIOFilter::Shared> qFBXIO::getFilters()
+ccIOFilterPluginInterface::FilterList qFBXIO::getFilters()
 {
 	return { FileIOFilter::Shared( new FBXFilter ) };
 }

--- a/plugins/core/IO/qFBXIO/qFBXIO.h
+++ b/plugins/core/IO/qFBXIO/qFBXIO.h
@@ -32,7 +32,7 @@ public:
 
 	void registerCommands( ccCommandLineInterface *cmd ) override;
 
-	QVector<FileIOFilter::Shared> getFilters() override;
+	FilterList getFilters() override;
 };
 
 #endif

--- a/plugins/core/IO/qPDALIO/qPDALIO.cpp
+++ b/plugins/core/IO/qPDALIO/qPDALIO.cpp
@@ -31,7 +31,7 @@ void qPDALIO::registerCommands( ccCommandLineInterface *cmd )
 	Q_UNUSED( cmd );
 }
 
-QVector<FileIOFilter::Shared> qPDALIO::getFilters()
+ccIOFilterPluginInterface::FilterList qPDALIO::getFilters()
 {
 	return { FileIOFilter::Shared( new LASFilter ) };
 }

--- a/plugins/core/IO/qPDALIO/qPDALIO.h
+++ b/plugins/core/IO/qPDALIO/qPDALIO.h
@@ -32,7 +32,7 @@ public:
 
 	void registerCommands( ccCommandLineInterface *cmd ) override;
 
-	QVector<FileIOFilter::Shared> getFilters() override;
+	FilterList getFilters() override;
 };
 
 #endif

--- a/plugins/core/IO/qPhotoscanIO/qPhotoscanIO.cpp
+++ b/plugins/core/IO/qPhotoscanIO/qPhotoscanIO.cpp
@@ -27,7 +27,7 @@ qPhotoscanIO::qPhotoscanIO( QObject* parent )
 {
 }
 
-FileIOFilter::Shared qPhotoscanIO::getFilter()
+ccIOFilterPluginInterface::FilterList qPhotoscanIO::getFilters()
 {
-	return FileIOFilter::Shared(new PhotoScanFilter);
+	return { FileIOFilter::Shared( new PhotoScanFilter ) };
 }

--- a/plugins/core/IO/qPhotoscanIO/qPhotoscanIO.h
+++ b/plugins/core/IO/qPhotoscanIO/qPhotoscanIO.h
@@ -30,10 +30,10 @@ class qPhotoscanIO : public QObject, public ccIOFilterPluginInterface
 public:
 	explicit qPhotoscanIO( QObject *parent = nullptr );
 	
-	virtual ~qPhotoscanIO() = default;
+	~qPhotoscanIO() override = default;
 
 	//inherited from ccIOFilterPluginInterface
-	FileIOFilter::Shared getFilter() override;
+	FilterList getFilters() override;
 };
 
 #endif //Q_PHOTOSCAN_IO_PLUGIN_HEADER


### PR DESCRIPTION
- no need to complicate the API with two methods that do the same thing
- remove getFilter() in favour of getFilters()
- use a typedef ("using") for a filter list for readability