### PR TITLE
Fix incorrect handling of SF indices in command line commands 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 CloudCompare Version History
 ============================
 
-v2.10.3 (Zephyrus) - (In progress)
+v2.10.3 (Zephyrus) - (in development)
 ----------------------
 
 - Enhancements
@@ -10,6 +10,7 @@ v2.10.3 (Zephyrus) - (In progress)
 - Bug fixes
   - Command line:
     - the 'EXTRACT_VERTICES' option was actually deleting the extracted vertices right after extracting them, causing a crash when trying to access them later :| (#847)
+    - fix handling of SF indices in SF_ARITHMETIC and COMMAND_SF_OP
   - Fix loading LAS files with paths containing multi-byte characters when using PDAL (#869)
   - When saving a cloud read from LAS 1.0 let PDAL choose the default LAS version (#874)
   - Fix potential crash or use of incorrect data when comparing clouds (#871)

--- a/qCC/ccCommandLineCommands.h
+++ b/qCC/ccCommandLineCommands.h
@@ -3296,16 +3296,14 @@ struct CommandSFArithmetic : public ccCommandLineInterface::Command
 
 		//read sf index
 		int sfIndex = -1;
-		{
-			bool ok = true;
-			QString sfIndex = cmd.arguments().takeFirst();
-			if (sfIndex.toUpper() == OPTION_LAST)
-				sfIndex = -2;
-			else
-				sfIndex = sfIndex.toInt(&ok);
-			if (!ok || sfIndex < 0)
-				return cmd.error(QObject::tr("Invalid SF index! (after %1)").arg(COMMAND_SF_ARITHMETIC));
-		}
+		bool ok = true;
+		QString sfIndexStr = cmd.arguments().takeFirst();
+		if (sfIndexStr.toUpper() == OPTION_LAST)
+			sfIndex = -2;
+		else
+			sfIndex = sfIndexStr.toInt(&ok);
+		if (!ok || sfIndex < 0)
+			return cmd.error(QObject::tr("Invalid SF index! (after %1)").arg(COMMAND_SF_ARITHMETIC));
 
 		//read operation type
 		ccScalarFieldArithmeticsDlg::Operation operation = ccScalarFieldArithmeticsDlg::INVALID;
@@ -3385,18 +3383,16 @@ struct CommandSFOperation : public ccCommandLineInterface::Command
 
 		//read sf index
 		int sfIndex = -1;
-		{
-			bool ok = true;
-			QString sfIndex = cmd.arguments().takeFirst();
-			if (sfIndex.toUpper() == OPTION_LAST)
-				sfIndex = -2;
-			else
-				sfIndex = sfIndex.toInt(&ok);
+		bool ok = true;
+		QString sfIndexStr = cmd.arguments().takeFirst();
+		if (sfIndexStr.toUpper() == OPTION_LAST)
+			sfIndex = -2;
+		else
+			sfIndex = sfIndexStr.toInt(&ok);
 
-			if (!ok || sfIndex < 0)
-			{
-				return cmd.error(QObject::tr("Invalid SF index! (after %1)").arg(COMMAND_SF_OP));
-			}
+		if (!ok || sfIndex < 0)
+		{
+			return cmd.error(QObject::tr("Invalid SF index! (after %1)").arg(COMMAND_SF_OP));
 		}
 
 		//read operation type


### PR DESCRIPTION
In both CommandSFArithmetic & CommandSFOperation, the int variable was shadowed by a QString, so sfIndex (the int) would always be -1.