### PR TITLE
{plugins} Simplify the I/O plugin API 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,14 @@ v2.11 (Anoia) - (in development)
   - Plugins:
     - The I/O plugin interface has changed, so if you have your own I/O plugins, you will need to update them.
       - The interface name changed from `ccIOFilterPluginInterface` to `ccIOPluginInterface`.
-      - The `getFilter()` method was removed in favour of `getFilters()`.
+      - The `ccIOPluginInterface::getFilter()` method was removed in favour of `ccIOPluginInterface::getFilters()`.
+      - The `FileIOFilter` base class now takes a struct as an argument containing all the static info about a filter - extensions, features (import/export), etc.. See `FooFilter` in the `ExampleIOPlugin` and the comments in `FileIOFilter::FilterInfo`.
+      - The use of `FileIOFilter::FilterInfo` means that the following virtual functions in I/O filters are no longer virtual/required:
+        - importSupported
+        - exportSupported
+        - getFileFilters
+        - getDefaultExtension
+        - canLoadExtension
 
 v2.10.3 (Zephyrus) - (in development)
 ----------------------

--- a/libs/qCC_io/AsciiFilter.cpp
+++ b/libs/qCC_io/AsciiFilter.cpp
@@ -70,14 +70,17 @@ AsciiOpenDlg* AsciiFilter::GetOpenDialog(QWidget* parentWidget/*=0*/)
 	return s_openDialog;
 }
 
-bool AsciiFilter::canLoadExtension(const QString& upperCaseExt) const
+
+AsciiFilter::AsciiFilter() :
+	FileIOFilter( {
+				  "_ASCII Filter",
+				  QStringList{ "txt", "asc", "neu", "xyz", "pts", "csv" },
+				  "asc",
+				  QStringList{ "ASCII cloud (*.txt *.asc *.neu *.xyz *.pts *.csv)" },
+				  QStringList{ "ASCII cloud (*.txt *.asc *.neu *.xyz *.pts *.csv)" },
+				  Import | Export
+				  } )
 {
-	return (	upperCaseExt == "ASC"
-			||	upperCaseExt == "TXT"
-			||	upperCaseExt == "XYZ"
-			||	upperCaseExt == "NEU"
-			||	upperCaseExt == "PTS"
-			||	upperCaseExt == "CSV");
 }
 
 bool AsciiFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const

--- a/libs/qCC_io/AsciiFilter.cpp
+++ b/libs/qCC_io/AsciiFilter.cpp
@@ -76,8 +76,8 @@ AsciiFilter::AsciiFilter() :
 				  "_ASCII Filter",
 				  QStringList{ "txt", "asc", "neu", "xyz", "pts", "csv" },
 				  "asc",
-				  QStringList{ "ASCII cloud (*.txt *.asc *.neu *.xyz *.pts *.csv)" },
-				  QStringList{ "ASCII cloud (*.txt *.asc *.neu *.xyz *.pts *.csv)" },
+				  QStringList{ GetFileFilter() },
+				  QStringList{ GetFileFilter() },
 				  Import | Export
 				  } )
 {

--- a/libs/qCC_io/AsciiFilter.h
+++ b/libs/qCC_io/AsciiFilter.h
@@ -28,20 +28,16 @@
 class QCC_IO_LIB_API AsciiFilter : public FileIOFilter
 {
 public:
-
+	AsciiFilter();
+	
 	//static accessors
 	static inline QString GetFileFilter() { return "ASCII cloud (*.txt *.asc *.neu *.xyz *.pts *.csv)"; }
-	static inline QString GetDefaultExtension() { return "asc"; }
 
 	//inherited from FileIOFilter
-	bool importSupported() const override { return true; }
-	bool exportSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { return QStringList(GetFileFilter()); }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
+
 	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 
 	//! Loads an ASCII file with a predefined format
 	CC_FILE_ERROR loadCloudFromFormatedAsciiFile(	const QString& filename,
@@ -60,8 +56,7 @@ public:
 	//! Returns associated dialog (creates it if necessary)
 	static AsciiSaveDlg* GetSaveDialog(QWidget* parentWidget = nullptr);
 
-protected:
-
+private:
 	//! Internal use only
 	CC_FILE_ERROR saveFile(ccHObject* entity, FILE *theFile);
 };

--- a/libs/qCC_io/BinFilter.cpp
+++ b/libs/qCC_io/BinFilter.cpp
@@ -53,9 +53,16 @@
 #endif
 
 
-bool BinFilter::canLoadExtension(const QString& upperCaseExt) const
+BinFilter::BinFilter() :
+	FileIOFilter( {
+				  "_CloudCompare BIN Filter",
+				  QStringList{ "bin" },
+				  "bin",
+				  QStringList{ "CloudCompare entities (*.bin)" },
+				  QStringList{ "CloudCompare entities (*.bin)" },
+				  Import | Export
+				  } )	
 {
-	return (upperCaseExt == "BIN");
 }
 
 bool BinFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const

--- a/libs/qCC_io/BinFilter.cpp
+++ b/libs/qCC_io/BinFilter.cpp
@@ -58,8 +58,8 @@ BinFilter::BinFilter() :
 				  "_CloudCompare BIN Filter",
 				  QStringList{ "bin" },
 				  "bin",
-				  QStringList{ "CloudCompare entities (*.bin)" },
-				  QStringList{ "CloudCompare entities (*.bin)" },
+				  QStringList{ GetFileFilter() },
+				  QStringList{ GetFileFilter() },
 				  Import | Export
 				  } )	
 {

--- a/libs/qCC_io/BinFilter.h
+++ b/libs/qCC_io/BinFilter.h
@@ -25,20 +25,17 @@
 class QCC_IO_LIB_API BinFilter : public FileIOFilter
 {
 public:
-
+	BinFilter();
+	
 	//static accessors
 	static inline QString GetFileFilter() { return "CloudCompare entities (*.bin)"; }
 	static inline QString GetDefaultExtension() { return "bin"; }
 
 	//inherited from FileIOFilter
-	virtual bool importSupported() const override { return true; }
-	virtual bool exportSupported() const override { return true; }
-	virtual CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	virtual CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	virtual QStringList getFileFilters(bool onImport) const override { return QStringList(GetFileFilter()); }
-	virtual QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	virtual bool canLoadExtension(const QString& upperCaseExt) const override;
-	virtual bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
+	
+	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 
 	//! old style BIN loading
 	static CC_FILE_ERROR LoadFileV1(QFile& in, ccHObject& container, unsigned nbScansTotal, const LoadParameters& parameters);
@@ -48,7 +45,6 @@ public:
 
 	//! new style BIN saving
 	static CC_FILE_ERROR SaveFileV2(QFile& out, ccHObject* object);
-
 };
 
 #endif //CC_BIN_FILTER_HEADER

--- a/libs/qCC_io/DepthMapFileFilter.cpp
+++ b/libs/qCC_io/DepthMapFileFilter.cpp
@@ -31,10 +31,17 @@
 //system
 #include <cassert>
 
-bool DepthMapFileFilter::canLoadExtension(const QString& upperCaseExt) const
+
+DepthMapFileFilter::DepthMapFileFilter() :
+	FileIOFilter( {
+				  "_Depth Map Filter",
+				  QStringList(),
+				  "txt",
+				  QStringList(),
+				  QStringList{ "Depth Map [ascii] (*.txt *.asc)" },
+				  Export
+				  } )
 {
-	//import not supported
-	return false;
 }
 
 bool DepthMapFileFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const

--- a/libs/qCC_io/DepthMapFileFilter.cpp
+++ b/libs/qCC_io/DepthMapFileFilter.cpp
@@ -38,7 +38,7 @@ DepthMapFileFilter::DepthMapFileFilter() :
 				  QStringList(),
 				  "txt",
 				  QStringList(),
-				  QStringList{ "Depth Map [ascii] (*.txt *.asc)" },
+				  QStringList{ GetFileFilter() },
 				  Export
 				  } )
 {

--- a/libs/qCC_io/DepthMapFileFilter.h
+++ b/libs/qCC_io/DepthMapFileFilter.h
@@ -26,22 +26,17 @@ class ccGBLSensor;
 class QCC_IO_LIB_API DepthMapFileFilter : public FileIOFilter
 {
 public:
-
+	DepthMapFileFilter();
+	
 	//static accessors
 	static inline QString GetFileFilter() { return "Depth Map [ascii] (*.txt *.asc)"; }
-	static inline QString GetDefaultExtension() { return "txt"; }
 
 	//inherited from FileIOFilter
-	virtual bool exportSupported() const override { return true; }
-	virtual CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	virtual QStringList getFileFilters(bool onImport) const override { return QStringList(GetFileFilter()); }
-	virtual QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	virtual bool canLoadExtension(const QString& upperCaseExt) const override;
-	virtual bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 
 	//direct method to save a sensor (depth map)
 	CC_FILE_ERROR saveToFile(const QString& filename, ccGBLSensor* sensor);
-
 };
 
 #endif //CC_DEPTH_MAP_FILE_FILTER_HEADER

--- a/libs/qCC_io/DxfFilter.cpp
+++ b/libs/qCC_io/DxfFilter.cpp
@@ -37,9 +37,17 @@
 //system
 #include <cassert>
 
-bool DxfFilter::canLoadExtension(const QString& upperCaseExt) const
+
+DxfFilter::DxfFilter() :
+	FileIOFilter( {
+				  "_DXF Filter",
+				  QStringList{ "dxf" },
+				  "dxf",
+				  QStringList{ "DXF geometry (*.dxf)" },
+				  QStringList{ "DXF geometry (*.dxf)" },
+				  Import | Export
+				  } )
 {
-	return (upperCaseExt == "DXF");
 }
 
 bool DxfFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const

--- a/libs/qCC_io/DxfFilter.h
+++ b/libs/qCC_io/DxfFilter.h
@@ -24,21 +24,13 @@
 class QCC_IO_LIB_API DxfFilter : public FileIOFilter
 {
 public:
-
-	//static accessors
-	static inline QString GetFileFilter() { return "DXF geometry (*.dxf)"; }
-	static inline QString GetDefaultExtension() { return "dxf"; }
+	DxfFilter();
 
 	//inherited from FileIOFilter
-	virtual bool importSupported() const override { return true; }
-	virtual bool exportSupported() const override { return true; }
-	virtual CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	virtual CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	virtual QStringList getFileFilters(bool onImport) const override { return QStringList(GetFileFilter()); }
-	virtual QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	virtual bool canLoadExtension(const QString& upperCaseExt) const override;
-	virtual bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
 
+	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;	
 };
 
 #endif //CC_DXF_FILTER_HEADER

--- a/libs/qCC_io/FileIOFilter.cpp
+++ b/libs/qCC_io/FileIOFilter.cpp
@@ -53,10 +53,10 @@ static unsigned s_sessionCounter = 0;
 
 
 FileIOFilter::FileIOFilter( const FileIOFilter::FilterInfo &info ) :
-	mFilterInfo( info )
+	m_filterInfo( info )
 {
 #ifdef QT_DEBUG	
-	if ( !(mFilterInfo.mFeatures & DynamicInfo) )
+	if ( !(m_filterInfo.features & DynamicInfo) )
 	{
 		checkFilterInfo();
 	}
@@ -65,42 +65,42 @@ FileIOFilter::FileIOFilter( const FileIOFilter::FilterInfo &info ) :
 
 bool FileIOFilter::importSupported() const
 {
-	return mFilterInfo.mFeatures & Import;
+	return m_filterInfo.features & Import;
 }
 
 bool FileIOFilter::exportSupported() const
 {
-	return mFilterInfo.mFeatures & Export;
+	return m_filterInfo.features & Export;
 }
 
 QStringList FileIOFilter::getFileFilters( bool onImport ) const
 {
 	if ( onImport )
 	{
-		return mFilterInfo.mImportFileFilterStrings;
+		return m_filterInfo.importFileFilterStrings;
 	}
 	
-	return mFilterInfo.mExportFileFilterStrings;
+	return m_filterInfo.exportFileFilterStrings;
 }
 
 QString FileIOFilter::getDefaultExtension() const
 {
-	return mFilterInfo.mDefaultExtension;
+	return m_filterInfo.defaultExtension;
 }
 
 void FileIOFilter::setImportExtensions( const QStringList &extensions )
 {
-	mFilterInfo.mImportExtensions = extensions;
+	m_filterInfo.importExtensions = extensions;
 }
 
 void FileIOFilter::setImportFileFilterStrings( const QStringList &filterStrings )
 {
-	mFilterInfo.mImportFileFilterStrings = filterStrings;
+	m_filterInfo.importFileFilterStrings = filterStrings;
 }
 
 void FileIOFilter::setExportFileFilterStrings(const QStringList &filterStrings)
 {
-	mFilterInfo.mExportFileFilterStrings = filterStrings;
+	m_filterInfo.exportFileFilterStrings = filterStrings;
 }
 
 void FileIOFilter::checkFilterInfo() const
@@ -108,43 +108,43 @@ void FileIOFilter::checkFilterInfo() const
 #ifdef QT_DEBUG
 	// Check info for consistency
 	
-	if ( mFilterInfo.mFeatures & Import )
+	if ( m_filterInfo.features & Import )
 	{
-		if ( mFilterInfo.mImportFileFilterStrings.isEmpty() )
+		if ( m_filterInfo.importFileFilterStrings.isEmpty() )
 		{
-			ccLog::Warning( QStringLiteral( "I/O filter marked as import, but no filter strings set: %1" ).arg( mFilterInfo.mID ) );
+			ccLog::Warning( QStringLiteral( "I/O filter marked as import, but no filter strings set: %1" ).arg( m_filterInfo.id ) );
 		}
 		
-		if ( mFilterInfo.mImportExtensions.isEmpty() )
+		if ( m_filterInfo.importExtensions.isEmpty() )
 		{
-			ccLog::Warning( QStringLiteral( "I/O filter marked as import, but no extensions set: %1" ).arg( mFilterInfo.mID ) );
+			ccLog::Warning( QStringLiteral( "I/O filter marked as import, but no extensions set: %1" ).arg( m_filterInfo.id ) );
 		}
 	}
 	else
 	{
-		if ( !mFilterInfo.mImportFileFilterStrings.isEmpty() )
+		if ( !m_filterInfo.importFileFilterStrings.isEmpty() )
 		{
-			ccLog::Warning( QStringLiteral( "I/O filter not marked as import, but filter strings are set: %1" ).arg( mFilterInfo.mID ) );
+			ccLog::Warning( QStringLiteral( "I/O filter not marked as import, but filter strings are set: %1" ).arg( m_filterInfo.id ) );
 		}
 		
-		if ( !mFilterInfo.mImportExtensions.isEmpty() )
+		if ( !m_filterInfo.importExtensions.isEmpty() )
 		{
-			ccLog::Warning( QStringLiteral( "I/O filter not marked as import, but extensions are set: %1" ).arg( mFilterInfo.mID ) );
+			ccLog::Warning( QStringLiteral( "I/O filter not marked as import, but extensions are set: %1" ).arg( m_filterInfo.id ) );
 		}
 	}
 	
-	if ( mFilterInfo.mFeatures & Export )
+	if ( m_filterInfo.features & Export )
 	{
-		if ( mFilterInfo.mExportFileFilterStrings.isEmpty() )
+		if ( m_filterInfo.exportFileFilterStrings.isEmpty() )
 		{
-			ccLog::Warning( QStringLiteral( "I/O filter marked as export, but no filter strings set: %1" ).arg( mFilterInfo.mID ) );
+			ccLog::Warning( QStringLiteral( "I/O filter marked as export, but no filter strings set: %1" ).arg( m_filterInfo.id ) );
 		}
 	}
 	else
 	{
-		if ( !mFilterInfo.mExportFileFilterStrings.isEmpty() )
+		if ( !m_filterInfo.exportFileFilterStrings.isEmpty() )
 		{
-			ccLog::Warning( QStringLiteral( "I/O filter not marked as export, but filter strings are set: %1" ).arg( mFilterInfo.mID ) );
+			ccLog::Warning( QStringLiteral( "I/O filter not marked as export, but filter strings are set: %1" ).arg( m_filterInfo.id ) );
 		}		
 	}
 #endif
@@ -259,7 +259,7 @@ FileIOFilter::Shared FileIOFilter::FindBestFilterForExtension(const QString& ext
 	
 	for ( const auto &filter : s_ioFilters )
 	{
-		if ( filter->mFilterInfo.mImportExtensions.contains( lowerExt ) )
+		if ( filter->m_filterInfo.importExtensions.contains( lowerExt ) )
 		{
 			return filter;
 		}

--- a/libs/qCC_io/FileIOFilter.h
+++ b/libs/qCC_io/FileIOFilter.h
@@ -315,24 +315,24 @@ protected:
 	struct FilterInfo
 	{
 		//! ID used to uniquely identify the filter (not user-visible)
-		QString mID;
+		QString id;
 		
 		//! List of extensions this filter can read (lowercase)
 		//! e.g. "txt", "foo", "bin"
 		//! This is used in FindBestFilterForExtension()
-		QStringList mImportExtensions;
+		QStringList importExtensions;
 		
 		//! The default file extension (for both import & export as applicable)
-		QString mDefaultExtension;
+		QString defaultExtension;
 		
 		//! List of file filters for import (e.g. "Test (*.txt)", "Foo (*.foo))
-		QStringList	mImportFileFilterStrings;
+		QStringList	importFileFilterStrings;
 		
 		//! List of file filters for export (e.g. "Test (*.txt)", "Foo (*.foo))
-		QStringList	mExportFileFilterStrings;
+		QStringList	exportFileFilterStrings;
 		
 		//! Supported features \see FilterFeature
-		FilterFeatures mFeatures;
+		FilterFeatures features;
 	};
 	
 	QCC_IO_LIB_API explicit FileIOFilter( const FilterInfo &info );
@@ -352,7 +352,7 @@ protected:
 private:
 	void checkFilterInfo() const;
 	
-	FilterInfo mFilterInfo;
+	FilterInfo m_filterInfo;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( FileIOFilter::FilterFeatures )

--- a/libs/qCC_io/FileIOFilter.h
+++ b/libs/qCC_io/FileIOFilter.h
@@ -21,7 +21,7 @@
 //qCC_db
 #include <ccHObject.h>
 
-//Local
+//local
 #include "ccGlobalShiftManager.h"
 
 class QWidget;
@@ -110,20 +110,20 @@ public:
 public: //public interface
 	
 	//! Returns whether this I/O filter can import files
-	bool importSupported() const;
+	QCC_IO_LIB_API bool importSupported() const;
 	
 	//! Returns whether this I/O filter can export files
-	bool exportSupported() const;
+	QCC_IO_LIB_API bool exportSupported() const;
 	
 	//! Returns the file filter(s) for this I/O filter
 	/** E.g. 'ASCII file (*.asc)'
 		\param onImport whether the requested filters are for import or export
 		\return list of filters
 	**/
-	QStringList getFileFilters(bool onImport) const;
+	QCC_IO_LIB_API QStringList getFileFilters(bool onImport) const;
 	
 	//! Returns the default file extension
-	QString getDefaultExtension() const;
+	QCC_IO_LIB_API QString getDefaultExtension() const;
 	
 public: //public interface (to be reimplemented by each I/O filter)
 	
@@ -335,7 +335,7 @@ protected:
 		FilterFeatures mFeatures;
 	};
 	
-	explicit FileIOFilter( const FilterInfo &info );
+	QCC_IO_LIB_API explicit FileIOFilter( const FilterInfo &info );
 	
 	//! Allow import extensions to be set after construction
 	//! (e.g. for ImageFileFilter & QImageReader::supportedImageFormats())

--- a/libs/qCC_io/ImageFileFilter.cpp
+++ b/libs/qCC_io/ImageFileFilter.cpp
@@ -33,33 +33,51 @@
 #include <cassert>
 
 ImageFileFilter::ImageFileFilter()
-	: FileIOFilter()
+	: FileIOFilter( {
+					"_Image Filter",
+					QStringList(),	// set below
+					"png",
+					QStringList(),	// set below
+					QStringList(),	// set below
+					Import | Export | DynamicInfo
+					} )
 {
 	//output filters
 	{
 		//we grab the list of supported image file formats (for writing)
 		QList<QByteArray> formats = QImageWriter::supportedImageFormats();
+		
 		//we convert this list into a proper "filters" string
-		for (int i = 0; i < formats.size(); ++i)
+		for (auto &format : formats)
 		{
-			m_outputFilters.append(QString("%1 image (*.%2)").arg(QString(formats[i].data()).toUpper(),formats[i].data()));
+			m_outputFilters.append( QStringLiteral("%1 image (*.%2)")
+									.arg( QString( format.data() ).toUpper(), format.data() ) );
 		}
+		
+		setExportFileFilterStrings( m_outputFilters );
 	}
 
 	//input filters
 	{
 		//we grab the list of supported image file formats (for reading)
 		QList<QByteArray> formats = QImageReader::supportedImageFormats();
+		
 		QStringList imageExts;
-		for (int i = 0; i < formats.size(); ++i)
+		
+		for (auto &format : formats)
 		{
-			imageExts.append(QString("*.%1").arg(formats[i].data()));
+			imageExts.append( QStringLiteral("*.%1").arg(format.data()) );
 		}
+		
+		setImportExtensions( imageExts );
+		
 		//we convert this list into a proper "filters" string
 		if (!imageExts.empty())
 		{
 			m_inputFilter = QString("Image (%1)").arg(imageExts.join(" "));
 		}
+		
+		setImportFileFilterStrings( { m_inputFilter } );
 	}
 }
 
@@ -95,7 +113,7 @@ QString ImageFileFilter::GetSaveFilename(const QString& dialogTitle, const QStri
 															dialogTitle,
 															imageSavePath + QString("/%1.%2").arg(baseName, pngFilter.isEmpty() ? QString(formats[0].data()) : QString("png")),
 															filters,
-															pngFilter.isEmpty() ? static_cast<QString*>(0) : &pngFilter);
+															pngFilter.isEmpty() ? nullptr : &pngFilter);
 
 	return outputFilename;
 }
@@ -116,23 +134,6 @@ QString ImageFileFilter::GetLoadFilename(const QString& dialogTitle, const QStri
 											dialogTitle,
 											imageLoadPath,
 											imageFilter);
-}
-
-QStringList ImageFileFilter::getFileFilters(bool onImport) const
-{
-	return onImport ? QStringList(m_inputFilter) : m_outputFilters;
-}
-
-bool ImageFileFilter::canLoadExtension(const QString& upperCaseExt) const
-{
-	//we grab the list of supported image file formats (for reading)
-	QList<QByteArray> formats = QImageReader::supportedImageFormats();
-	//we convert this list into a proper "filters" string
-	for (int i=0; i<formats.size(); ++i)
-		if (QString(formats[i].data()).toUpper() == upperCaseExt)
-			return true;
-
-	return false;
 }
 
 bool ImageFileFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const

--- a/libs/qCC_io/ImageFileFilter.h
+++ b/libs/qCC_io/ImageFileFilter.h
@@ -24,41 +24,30 @@
 class QCC_IO_LIB_API ImageFileFilter : public FileIOFilter
 {
 public:
-
-	//! Default constructor
 	ImageFileFilter();
 
-	//static accessors
-	static inline QString GetDefaultExtension() { return "png"; }
-
 	//inherited from FileIOFilter
-	virtual bool importSupported() const override { return true; }
-	virtual bool exportSupported() const override { return true; }
-	virtual CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	virtual CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	virtual QStringList getFileFilters(bool onImport) const override;
-	virtual QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	virtual bool canLoadExtension(const QString& upperCaseExt) const override;
-	virtual bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
+
+	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 
 	//! Helper: select an input image filename
 	static QString GetLoadFilename(	const QString& dialogTitle,
 									const QString& imageLoadPath,
-									QWidget* parentWidget = 0);
+									QWidget* parentWidget = nullptr);
 
 	//! Helper: select an output image filename
 	static QString GetSaveFilename(	const QString& dialogTitle,
 									const QString& baseName,
 									const QString& imageSavePath,
-									QWidget* parentWidget = 0);
+									QWidget* parentWidget = nullptr);
 
-protected:
-
+private:
 	//! Supported (output) filters
 	QStringList m_outputFilters;
 	//! Supported (input) filters
 	QString m_inputFilter;
-
 };
 
 #endif //CC_IMAGE_FILE_FILTER_HEADER

--- a/libs/qCC_io/PlyFilter.cpp
+++ b/libs/qCC_io/PlyFilter.cpp
@@ -49,9 +49,17 @@
 
 using namespace CCLib;
 
-bool PlyFilter::canLoadExtension(const QString& upperCaseExt) const
-{
-	return (upperCaseExt == "PLY");
+
+PlyFilter::PlyFilter() :
+	FileIOFilter( {
+				  "_PLY Filter",
+				  QStringList{ "ply" },
+				  "ply",
+				  QStringList{ "PLY mesh (*.ply)" },
+				  QStringList{ "PLY mesh (*.ply)" },
+				  Import | Export
+				  } )
+{	
 }
 
 bool PlyFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const
@@ -67,6 +75,7 @@ bool PlyFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) con
 }
 
 static e_ply_storage_mode s_defaultOutputFormat = PLY_DEFAULT;
+
 void PlyFilter::SetDefaultOutputFormat(e_ply_storage_mode format)
 {
 	s_defaultOutputFormat = format;

--- a/libs/qCC_io/PlyFilter.h
+++ b/libs/qCC_io/PlyFilter.h
@@ -60,27 +60,21 @@ struct plyElement
 class QCC_IO_LIB_API PlyFilter : public FileIOFilter
 {
 public:
-
+	PlyFilter();
+	
 	//static accessors
-	static inline QString GetFileFilter() { return "PLY mesh (*.ply)"; }
-	static inline QString GetDefaultExtension() { return "ply"; }
 	static void SetDefaultOutputFormat(e_ply_storage_mode format);
 
 	//inherited from FileIOFilter
-	virtual bool importSupported() const override { return true; }
-	virtual bool exportSupported() const override { return true; }
-	virtual CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	virtual CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	virtual QStringList getFileFilters(bool onImport) const override { return QStringList(GetFileFilter()); }
-	virtual QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	virtual bool canLoadExtension(const QString& upperCaseExt) const override;
-	virtual bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
+	
+	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 
 	//! Custom loading method
 	CC_FILE_ERROR loadFile(const QString& filename, const QString& textureFilename, ccHObject& container, LoadParameters& parameters);
 
-protected:
-
+private:
 	//! Internal method
 	CC_FILE_ERROR saveToFile(ccHObject* entity, QString filename, e_ply_storage_mode storageType);
 };

--- a/libs/qCC_io/RasterGridFilter.cpp
+++ b/libs/qCC_io/RasterGridFilter.cpp
@@ -20,32 +20,31 @@
 #include "RasterGridFilter.h"
 
 //qCC_db
-#include <ccPointCloud.h>
-#include <ccScalarField.h>
 #include <ccMesh.h>
 #include <ccPlane.h>
+#include <ccPointCloud.h>
+#include <ccScalarField.h>
 
 //GDAL
-#include <gdal_priv.h>
 #include <cpl_conv.h> // for CPLMalloc()
+#include <gdal_priv.h>
 
 //Qt
 #include <QMessageBox>
 
 //System
-#include <string.h> //for memset
+#include <cstring> //for memset
 
-bool RasterGridFilter::canLoadExtension(const QString& upperCaseExt) const
+RasterGridFilter::RasterGridFilter() :
+	FileIOFilter( {
+				  "_Raster Grid Filter",
+				  QStringList{ "tif", "tiff", "adf" },
+				  "tif",
+				  QStringList{ "RASTER grid (*.*)" },
+				  QStringList(),
+				  Import
+				  } )
 {
-	return (	upperCaseExt == "TIF"
-			||	upperCaseExt == "TIFF"
-			||	upperCaseExt == "ADF");
-}
-
-bool RasterGridFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const
-{
-	//not supported yet
-	return false;
 }
 
 CC_FILE_ERROR RasterGridFilter::loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters)

--- a/libs/qCC_io/RasterGridFilter.h
+++ b/libs/qCC_io/RasterGridFilter.h
@@ -28,19 +28,10 @@
 class QCC_IO_LIB_API RasterGridFilter : public FileIOFilter
 {
 public:
-
-	//static accessors
-	static inline QString GetFileFilter() { return "RASTER grid (*.*)"; }
-	static inline QString GetDefaultExtension() { return "tif"; }
+	RasterGridFilter();
 
 	//inherited from FileIOFilter
-	virtual bool importSupported() const override { return true; }
-	virtual CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	virtual QStringList getFileFilters(bool onImport) const override { return QStringList(GetFileFilter()); }
-	virtual QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	virtual bool canLoadExtension(const QString& upperCaseExt) const override;
-	virtual bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
-
+	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
 };
 
 #endif //CC_GDAL_SUPPORT

--- a/libs/qCC_io/ShpFilter.cpp
+++ b/libs/qCC_io/ShpFilter.cpp
@@ -504,9 +504,16 @@ public:
 	}
 };
 
-bool ShpFilter::canLoadExtension(const QString& upperCaseExt) const
+ShpFilter::ShpFilter() :
+	FileIOFilter( {
+				  "_Shape Filter",
+				  QStringList{ "shp" },
+				  "shp",
+				  QStringList{ "SHP entity (*.shp)" },
+				  QStringList{ "SHP entity (*.shp)" },
+				  Import | Export
+				  } )
 {
-	return (upperCaseExt == "SHP");
 }
 
 bool ShpFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const

--- a/libs/qCC_io/ShpFilter.h
+++ b/libs/qCC_io/ShpFilter.h
@@ -37,25 +37,16 @@ class GenericDBFField;
 class QCC_IO_LIB_API ShpFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "SHP entity (*.shp)"; }
-	static inline QString GetDefaultExtension() { return "shp"; }
-
+	ShpFilter();
+	
 	//inherited from FileIOFilter
-	virtual bool importSupported() const override { return true; }
-	virtual bool exportSupported() const override { return true; }
-	virtual CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	virtual CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	virtual QStringList getFileFilters(bool onImport) const override { return QStringList(GetFileFilter()); }
-	virtual QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	virtual bool canLoadExtension(const QString& upperCaseExt) const override;
-	virtual bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
 
-	//! Default constructor
-	ShpFilter() : FileIOFilter() {}
+	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 
 	//! Special method to save multiple entities with attributes
-	virtual CC_FILE_ERROR saveToFile(ccHObject* entity, const std::vector<GenericDBFField*>& fields, const QString& filename, const SaveParameters& parameters);
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const std::vector<GenericDBFField*>& fields, const QString& filename, const SaveParameters& parameters);
 
 	//! Sets whether to consider closed polylines as polygons or not
 	void treatClosedPolylinesAsPolygons(bool state) { m_closedPolylinesAsPolygons = state; }
@@ -68,7 +59,7 @@ public:
 	//! Sets whether to save polyline's height in .dbf
 	void save3DPolyHeightInDBF(bool state) { m_save3DPolyHeightInDBF = state; }
 
-protected:
+private:
 	//! Whether to consider closed polylines as polygons or not
 	bool m_closedPolylinesAsPolygons = true;
 

--- a/plugins/core/IO/qAdditionalIO/src/BundlerFilter.cpp
+++ b/plugins/core/IO/qAdditionalIO/src/BundlerFilter.cpp
@@ -71,19 +71,16 @@ struct BundlerCamera
 	bool isValid;
 };
 
-bool BundlerFilter::canLoadExtension(const QString& upperCaseExt) const
+BundlerFilter::BundlerFilter() :
+	FileIOFilter( {
+				  "+Bundler Filter",
+				  QStringList{ "out" },
+				  "out",
+				  QStringList{ "Snavely's Bundler output (*.out)" },
+				  QStringList(),
+				  Import | FromPlugin
+				  } )
 {
-	return (upperCaseExt == "OUT");
-}
-
-bool BundlerFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const
-{
-	Q_UNUSED( type );
-	Q_UNUSED( multiple );
-	Q_UNUSED( exclusive );
-	
-	//no output yet
-	return false;
 }
 
 CC_FILE_ERROR BundlerFilter::loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters)

--- a/plugins/core/IO/qAdditionalIO/src/BundlerFilter.h
+++ b/plugins/core/IO/qAdditionalIO/src/BundlerFilter.h
@@ -26,17 +26,10 @@
 class BundlerFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "Snavely's Bundler output (*.out)"; }
-	static inline QString GetDefaultExtension() { return "out"; }
+	BundlerFilter();
 
 	//inherited from FileIOFilter
-	bool importSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
-	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
 
 	//! Specific load method
 	CC_FILE_ERROR loadFileExtended(	const QString& filename,

--- a/plugins/core/IO/qAdditionalIO/src/IcmFilter.cpp
+++ b/plugins/core/IO/qAdditionalIO/src/IcmFilter.cpp
@@ -33,19 +33,17 @@
 //TODO: use QFile instead!
 const int MAX_ASCII_FILE_LINE_LENGTH = 4096;
 
-bool IcmFilter::canLoadExtension(const QString& upperCaseExt) const
-{
-	return (upperCaseExt == "ICM");
-}
 
-bool IcmFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const
+IcmFilter::IcmFilter() :
+	FileIOFilter( {
+				  "+ICM Filter",
+				  QStringList{ "icm" },
+				  "icm",
+				  QStringList{ "Clouds + calibrated images [meta][ascii] (*.icm)" },
+				  QStringList(),
+				  Import | FromPlugin
+				  } )
 {
-	Q_UNUSED( type );
-	Q_UNUSED( multiple );
-	Q_UNUSED( exclusive );
-	
-	//export not supported
-	return false;
 }
 
 CC_FILE_ERROR IcmFilter::loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters)

--- a/plugins/core/IO/qAdditionalIO/src/IcmFilter.h
+++ b/plugins/core/IO/qAdditionalIO/src/IcmFilter.h
@@ -24,17 +24,10 @@
 class IcmFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "Clouds + calibrated images [meta][ascii] (*.icm)"; }
-	static inline QString GetDefaultExtension() { return "icm"; }
+	IcmFilter();
 
 	//inherited from FileIOFilter
-	bool importSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
-	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
 
 private:
 	static int LoadCalibratedImages(ccHObject* entities, const QString& path, const QString& imageDescFilename, const ccBBox& globalBBox);

--- a/plugins/core/IO/qAdditionalIO/src/PNFilter.cpp
+++ b/plugins/core/IO/qAdditionalIO/src/PNFilter.cpp
@@ -29,9 +29,17 @@
 //default normal value
 static const CCVector3 s_defaultNorm(0,0,1);
 
-bool PNFilter::canLoadExtension(const QString& upperCaseExt) const
+
+PNFilter::PNFilter() :
+	FileIOFilter( {
+				  "+Point+Normal Filter",
+				  QStringList{ "pn" },
+				  "pn",
+				  QStringList{ "Point+Normal cloud (*.pn)" },
+				  QStringList{ "Point+Normal cloud (*.pn)" },
+				  Import | Export | FromPlugin
+				  } )
 {
-	return (upperCaseExt == "PN");
 }
 
 bool PNFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const

--- a/plugins/core/IO/qAdditionalIO/src/PNFilter.h
+++ b/plugins/core/IO/qAdditionalIO/src/PNFilter.h
@@ -24,19 +24,13 @@
 class PNFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "Point+Normal cloud (*.pn)"; }
-	static inline QString GetDefaultExtension() { return "pn"; }
+	PNFilter();
 
 	//inherited from FileIOFilter
-	bool importSupported() const override { return true; }
-	bool exportSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
+
 	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 };
 
 #endif //CC_PN_FILTER_HEADER

--- a/plugins/core/IO/qAdditionalIO/src/PVFilter.cpp
+++ b/plugins/core/IO/qAdditionalIO/src/PVFilter.cpp
@@ -27,9 +27,17 @@
 //Qt
 #include <QFile>
 
-bool PVFilter::canLoadExtension(const QString& upperCaseExt) const
+
+PVFilter::PVFilter() :
+	FileIOFilter( {
+				  "+Point+Value Filter",
+				  QStringList{ "pv" },
+				  "pv",
+				  QStringList{ "Point+Value cloud (*.pv)" },
+				  QStringList{ "Point+Value cloud (*.pv)" },
+				  Import | Export | FromPlugin
+				  } )
 {
-	return (upperCaseExt == "PV");
 }
 
 bool PVFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const

--- a/plugins/core/IO/qAdditionalIO/src/PVFilter.h
+++ b/plugins/core/IO/qAdditionalIO/src/PVFilter.h
@@ -24,19 +24,13 @@
 class PVFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "Point+Value cloud (*.pv)"; }
-	static inline QString GetDefaultExtension() { return "pv"; }
+	PVFilter();
 
 	//inherited from FileIOFilter
-	bool importSupported() const override { return true; }
-	bool exportSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
+
 	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 };
 
 #endif //CC_PV_FILTER_HEADER

--- a/plugins/core/IO/qAdditionalIO/src/PovFilter.cpp
+++ b/plugins/core/IO/qAdditionalIO/src/PovFilter.cpp
@@ -47,11 +47,18 @@ const char CC_SENSOR_ROTATION_ORDER_OLD_NAMES[][10] = {	"THETA_PHI",		//Rotation
 														"PHI_THETA"			//Rotation: mirror then body
 };
 
-bool PovFilter::canLoadExtension(const QString& upperCaseExt) const
-{
-	return (upperCaseExt == "POV");
-}
 
+PovFilter::PovFilter() :
+	FileIOFilter( {
+				  "+POV Filter",
+				  QStringList{ "pov" },
+				  "pov",
+				  QStringList{ "Clouds + sensor info. [meta][ascii] (*.pov)" },
+				  QStringList{ "Clouds + sensor info. [meta][ascii] (*.pov)" },
+				  Import | Export | FromPlugin
+				  } )
+{
+}
 bool PovFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const
 {
 	if (type == CC_TYPES::POINT_CLOUD)

--- a/plugins/core/IO/qAdditionalIO/src/PovFilter.h
+++ b/plugins/core/IO/qAdditionalIO/src/PovFilter.h
@@ -24,19 +24,13 @@
 class PovFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "Clouds + sensor info. [meta][ascii] (*.pov)"; }
-	static inline QString GetDefaultExtension() { return "pov"; }
+	PovFilter();
 
 	//inherited from FileIOFilter
-	bool importSupported() const override { return true; }
-	bool exportSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
+
 	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 };
 
 #endif //POV_FILTER_HEADER

--- a/plugins/core/IO/qAdditionalIO/src/SalomeHydroFilter.cpp
+++ b/plugins/core/IO/qAdditionalIO/src/SalomeHydroFilter.cpp
@@ -27,6 +27,19 @@
 #include <QStringList>
 #include <QTextStream>
 
+
+SalomeHydroFilter::SalomeHydroFilter() :
+	FileIOFilter( {
+				  "+SalomeHydro Filter",
+				  QStringList{ "poly" },
+				  "poly",
+				  QStringList{ "Salome Hydro polylines (*.poly)" },
+				  QStringList{ "Salome Hydro polylines (*.poly)" },
+				  Import | Export | FromPlugin
+				  } )
+{	
+}
+
 bool SalomeHydroFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const
 {
 	if (type == CC_TYPES::POLY_LINE)
@@ -36,11 +49,6 @@ bool SalomeHydroFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclus
 		return true;
 	}
 	return false;
-}
-
-bool SalomeHydroFilter::canLoadExtension(const QString& upperCaseExt) const
-{
-	return (upperCaseExt == "POLY");
 }
 
 CC_FILE_ERROR SalomeHydroFilter::saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters)

--- a/plugins/core/IO/qAdditionalIO/src/SalomeHydroFilter.h
+++ b/plugins/core/IO/qAdditionalIO/src/SalomeHydroFilter.h
@@ -26,19 +26,13 @@
 class SalomeHydroFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "Salome Hydro polylines (*.poly)"; }
-	static inline QString GetDefaultExtension() { return "poly"; }
+	SalomeHydroFilter();
 
 	//inherited from FileIOFilter
-	bool importSupported() const override { return true; }
-	bool exportSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
+
 	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 };
 
 #endif //CC_SALOME_HYDRO_HEADER

--- a/plugins/core/IO/qAdditionalIO/src/SinusxFilter.cpp
+++ b/plugins/core/IO/qAdditionalIO/src/SinusxFilter.cpp
@@ -30,6 +30,19 @@
 //System
 #include <cstring>
 
+
+SinusxFilter::SinusxFilter() :
+	FileIOFilter( {
+				  "+Sinusx Filter",
+				  QStringList{ "sx", "sinusx" },
+				  "sx",
+				  QStringList{ "Sinusx curve (*.sx)" },
+				  QStringList{ "Sinusx curve (*.sx)" },
+				  Import | Export | FromPlugin
+				  } )
+{
+}
+
 bool SinusxFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const
 {
 	if (type == CC_TYPES::POLY_LINE)
@@ -39,12 +52,6 @@ bool SinusxFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) 
 		return true;
 	}
 	return false;
-}
-
-bool SinusxFilter::canLoadExtension(const QString& upperCaseExt) const
-{
-	return (	upperCaseExt == "SX"
-			||	upperCaseExt == "SINUSX" );
 }
 
 QString MakeSinusxName(QString name)

--- a/plugins/core/IO/qAdditionalIO/src/SinusxFilter.h
+++ b/plugins/core/IO/qAdditionalIO/src/SinusxFilter.h
@@ -24,19 +24,13 @@
 class SinusxFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "Sinusx curve (*.sx)"; }
-	static inline QString GetDefaultExtension() { return QString("sx"); }
+	SinusxFilter();
 
 	//inherited from FileIOFilter
-	bool exportSupported() const override { return true; }
-	bool importSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
+
 	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 };
 
 #endif //CC_SINUSX_FILTER_HEADER

--- a/plugins/core/IO/qAdditionalIO/src/SoiFilter.cpp
+++ b/plugins/core/IO/qAdditionalIO/src/SoiFilter.cpp
@@ -26,19 +26,17 @@
 //TODO: use QFile instead!
 const int MAX_ASCII_FILE_LINE_LENGTH = 4096;
 
-bool SoiFilter::canLoadExtension(const QString& upperCaseExt) const
-{
-	return (upperCaseExt == "SOI");
-}
 
-bool SoiFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const
+SoiFilter::SoiFilter() :
+	FileIOFilter( {
+				  "+Soisic Filter",
+				  QStringList{ "soi" },
+				  "soi",
+				  QStringList{ "Mensi Soisic cloud (*.soi)" },
+				  QStringList(),
+				  Import | FromPlugin
+				  } )
 {
-	Q_UNUSED( type );
-	Q_UNUSED( multiple );
-	Q_UNUSED( exclusive );
-	
-	//not supported
-	return false;
 }
 
 CC_FILE_ERROR SoiFilter::loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters)

--- a/plugins/core/IO/qAdditionalIO/src/SoiFilter.h
+++ b/plugins/core/IO/qAdditionalIO/src/SoiFilter.h
@@ -24,17 +24,10 @@
 class SoiFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "Mensi Soisic cloud (*.soi)"; }
-	static inline QString GetDefaultExtension() { return "soi"; }
+	SoiFilter();
 
 	//inherited from FileIOFilter
-	bool importSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
-	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
 };
 
 #endif //CC_SOI_FILTER_HEADER

--- a/plugins/core/IO/qCSVMatrixIO/src/CSVMatrixFilter.cpp
+++ b/plugins/core/IO/qCSVMatrixIO/src/CSVMatrixFilter.cpp
@@ -37,11 +37,6 @@
 #include <string.h>
 #include <assert.h>
 
-bool CSVMatrixFilter::canLoadExtension(const QString& upperCaseExt) const
-{
-	return (upperCaseExt == "CSV");
-}
-
 //semi-persistent parameters
 static QChar s_separator(',');
 static double s_xSpacing = 1.0;
@@ -49,6 +44,19 @@ static double s_ySpacing = 1.0;
 static bool s_inverseRows = false;
 static bool s_loadAsMesh = false;
 static bool s_useTexture = false;
+
+CSVMatrixFilter::CSVMatrixFilter() :
+	FileIOFilter( {
+				  "+CSV Matrix Filter",
+				  QStringList{ "csv" },
+				  "csv",
+				  QStringList{ "CSV matrix cloud (*.csv)" },
+				  QStringList(),
+				  Import
+				  } )
+{
+}
+
 CC_FILE_ERROR CSVMatrixFilter::loadFile(const QString& filename,
 									ccHObject& container,
 									LoadParameters& parameters)

--- a/plugins/core/IO/qCSVMatrixIO/src/CSVMatrixFilter.cpp
+++ b/plugins/core/IO/qCSVMatrixIO/src/CSVMatrixFilter.cpp
@@ -52,7 +52,7 @@ CSVMatrixFilter::CSVMatrixFilter() :
 				  "csv",
 				  QStringList{ "CSV matrix cloud (*.csv)" },
 				  QStringList(),
-				  Import
+				  Import | FromPlugin
 				  } )
 {
 }

--- a/plugins/core/IO/qCSVMatrixIO/src/CSVMatrixFilter.h
+++ b/plugins/core/IO/qCSVMatrixIO/src/CSVMatrixFilter.h
@@ -22,22 +22,13 @@
 #include <FileIOFilter.h>
 
 //! CSV matrix I/O filter
-class /*QCC_IO_LIB_API*/ CSVMatrixFilter : public FileIOFilter
+class CSVMatrixFilter : public FileIOFilter
 {
 public:
-
-	//static accessors
-	static inline QString GetFileFilter() { return "CSV matrix cloud (*.csv)"; }
-	static inline QString GetDefaultExtension() { return "csv"; }
+	CSVMatrixFilter();
 
 	//inherited from FileIOFilter
-	virtual bool importSupported() const { return true; }
-	virtual CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters);
-	virtual QStringList getFileFilters(bool onImport) const { return QStringList(GetFileFilter()); }
-	virtual QString getDefaultExtension() const { return GetDefaultExtension(); }
-	virtual bool canLoadExtension(const QString& upperCaseExt) const;
-	virtual bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const { return false; }
-
+	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
 };
 
 #endif //CC_CSV_MATRIX_FILTER_HEADER

--- a/plugins/core/IO/qCoreIO/src/HeightProfileFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/HeightProfileFilter.cpp
@@ -24,6 +24,19 @@
 #include <QFile>
 #include <QTextStream>
 
+
+HeightProfileFilter::HeightProfileFilter() :
+	FileIOFilter( {
+				  "+Height profile Filter",
+				  QStringList(),
+				  "",
+				  QStringList(),
+				  QStringList{ "Height profile (*.csv)" },
+				  Export | FromPlugin
+				  } )
+{
+}
+
 bool HeightProfileFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const
 {
 	if (type == CC_TYPES::POLY_LINE)

--- a/plugins/core/IO/qCoreIO/src/HeightProfileFilter.h
+++ b/plugins/core/IO/qCoreIO/src/HeightProfileFilter.h
@@ -26,17 +26,11 @@
 class HeightProfileFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "Height profile (*.csv)"; }
-	static inline QString GetDefaultExtension() { return QString(); }
+	HeightProfileFilter();
 
 	//inherited from FileIOFilter
-	bool exportSupported() const override { return true; }
-	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override { Q_UNUSED( upperCaseExt ); return false; }
 	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 };
 
 #endif //CC_HEIGHT_PROFILE_HEADER

--- a/plugins/core/IO/qCoreIO/src/MAFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/MAFilter.cpp
@@ -75,12 +75,17 @@ namespace
 	};	
 }
 
-bool MAFilter::canLoadExtension(const QString& upperCaseExt) const
-{
-	Q_UNUSED( upperCaseExt );
-	
-	//import not supported
-	return false;
+
+MAFilter::MAFilter() :
+	FileIOFilter( {
+				  "+Height profile Filter",
+				  QStringList(),
+				  "ma",
+				  QStringList(),
+				  QStringList{ "Maya ASCII mesh (*.ma)" },
+				  Export | FromPlugin
+				  } )
+{	
 }
 
 bool MAFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const

--- a/plugins/core/IO/qCoreIO/src/MAFilter.h
+++ b/plugins/core/IO/qCoreIO/src/MAFilter.h
@@ -24,17 +24,11 @@
 class MAFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "Maya ASCII mesh (*.ma)"; }
-	static inline QString GetDefaultExtension() { return "ma"; }
+	MAFilter();
 
 	//inherited from FileIOFilter
-	bool exportSupported() const override { return true; }
-	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
 	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 };
 
 #endif //CC_MA_FILTER_HEADER

--- a/plugins/core/IO/qCoreIO/src/MascaretFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/MascaretFilter.cpp
@@ -47,6 +47,19 @@ public:
 	}
 };
 
+
+MascaretFilter::MascaretFilter() :
+	FileIOFilter( {
+				  "+Mascaret Filter",
+				  QStringList(),
+				  "georef",
+				  QStringList(),
+				  QStringList{ "(Geo-)Mascaret profile (*.georef)" },
+				  Export | FromPlugin
+				  } )
+{
+}
+
 bool MascaretFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const
 {
 	if (type == CC_TYPES::POLY_LINE)

--- a/plugins/core/IO/qCoreIO/src/MascaretFilter.h
+++ b/plugins/core/IO/qCoreIO/src/MascaretFilter.h
@@ -26,18 +26,11 @@
 class MascaretFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "(Geo-)Mascaret profile (*.georef)"; }
-	static inline QString GetDefaultExtension() { return "georef"; }
-
+	MascaretFilter();
+	
 	//inherited from FileIOFilter
-	bool importSupported() const override { return false; }
-	bool exportSupported() const override { return true; }
-	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override { Q_UNUSED( upperCaseExt ); return false; }
 	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 };
 
 #endif //CC_MASCARET_FILTER_HEADER

--- a/plugins/core/IO/qCoreIO/src/OFFFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/OFFFilter.cpp
@@ -28,9 +28,17 @@
 //System
 #include <string>
 
-bool OFFFilter::canLoadExtension(const QString& upperCaseExt) const
+
+OFFFilter::OFFFilter() :
+	FileIOFilter( {
+				  "+OFF Filter",
+				  QStringList{ "off" },
+				  "off",
+				  QStringList{ "OFF mesh (*.off)" },
+				  QStringList{ "OFF mesh (*.off)" },
+				  Import | Export | FromPlugin
+				  } )
 {
-	return (upperCaseExt == "OFF");
 }
 
 bool OFFFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const

--- a/plugins/core/IO/qCoreIO/src/OFFFilter.h
+++ b/plugins/core/IO/qCoreIO/src/OFFFilter.h
@@ -26,19 +26,13 @@
 class OFFFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "OFF mesh (*.off)"; }
-	static inline QString GetDefaultExtension() { return "off"; }
-	
+	OFFFilter();
+
 	//inherited from FileIOFilter
-	bool importSupported() const override { return true; }
-	bool exportSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
+
 	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 };
 
 #endif //CC_OFF_FILTER_HEADER

--- a/plugins/core/IO/qCoreIO/src/ObjFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/ObjFilter.cpp
@@ -43,9 +43,17 @@
 //System
 #include <cstring>
 
-bool ObjFilter::canLoadExtension(const QString& upperCaseExt) const
+
+ObjFilter::ObjFilter() :
+	FileIOFilter( {
+				  "+OBJ Filter",
+				  QStringList{ "obj" },
+				  "obj",
+				  QStringList{ "OBJ mesh (*.obj)" },
+				  QStringList{ "OBJ mesh (*.obj)" },
+				  Import | Export | FromPlugin
+				  } )
 {
-	return (upperCaseExt == "OBJ");
 }
 
 bool ObjFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const

--- a/plugins/core/IO/qCoreIO/src/ObjFilter.h
+++ b/plugins/core/IO/qCoreIO/src/ObjFilter.h
@@ -24,19 +24,13 @@
 class ObjFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "OBJ mesh (*.obj)"; }
-	static inline QString GetDefaultExtension() { return "obj"; }
+	ObjFilter();
 
 	//inherited from FileIOFilter
-	bool importSupported() const override { return true; }
-	bool exportSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
+
 	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 };
 
 #endif //CC_OBJ_FILTER_HEADER

--- a/plugins/core/IO/qCoreIO/src/PDMS/PDMSFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/PDMS/PDMSFilter.cpp
@@ -33,24 +33,19 @@
 
 using namespace CCLib;
 
-bool PDMSFilter::canLoadExtension(const QString& upperCaseExt) const
-{
-	return (	upperCaseExt == "MAC"
-			||	upperCaseExt == "PDMS"
-			||	upperCaseExt == "PDMSMAC" );
-}
-
-bool PDMSFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const
-{
-	Q_UNUSED( type );
-	Q_UNUSED( multiple );
-	Q_UNUSED( exclusive );
-	
-	//not supported yet
-	return false;
-}
-
 using PdmsAndCCPair = std::pair<PdmsTools::PdmsObjects::GenericItem*, ccHObject*>;
+
+PDMSFilter::PDMSFilter() :
+	FileIOFilter( {
+				  "+PDMS Filter",
+				  QStringList{ "pdms", "pdmsmac", "mac" },
+				  "pdms",
+				  QStringList{ "PDMS primitives (*.pdms *.pdmsmac *.mac)" },
+				  QStringList(),
+				  Import | FromPlugin
+				  } )
+{
+}
 
 CC_FILE_ERROR PDMSFilter::loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters)
 {

--- a/plugins/core/IO/qCoreIO/src/PDMS/PDMSFilter.h
+++ b/plugins/core/IO/qCoreIO/src/PDMS/PDMSFilter.h
@@ -24,17 +24,10 @@
 class PDMSFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "PDMS primitives (*.pdms *.pdmsmac *.mac)"; }
-	static inline QString GetDefaultExtension() { return "pdms"; }
-
+	PDMSFilter();
+	
 	//inherited from FileIOFilter
-	bool importSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
-	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
 };
 
 #endif //CC_PDMS_FILTER_HEADER

--- a/plugins/core/IO/qCoreIO/src/PTXFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/PTXFilter.cpp
@@ -36,18 +36,17 @@
 
 const char CC_PTX_INTENSITY_FIELD_NAME[] = "Intensity";
 
-bool PTXFilter::canLoadExtension(const QString& upperCaseExt) const
-{
-	return (upperCaseExt == "PTX");
-}
 
-bool PTXFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const
+PTXFilter::PTXFilter() :
+	FileIOFilter( {
+				  "+PTX Filter",
+				  QStringList{ "ptx" },
+				  "ptx",
+				  QStringList{ "PTX cloud (*.ptx)" },
+				  QStringList(),
+				  Import | FromPlugin
+				  } )
 {
-	Q_UNUSED( multiple );
-	Q_UNUSED( exclusive );
-	
-	//not supported yet
-	return false;
 }
 
 static void CleanMatrix(ccGLMatrixd& mat)

--- a/plugins/core/IO/qCoreIO/src/PTXFilter.h
+++ b/plugins/core/IO/qCoreIO/src/PTXFilter.h
@@ -25,17 +25,10 @@
 class PTXFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "PTX cloud (*.ptx)"; }
-	static inline QString GetDefaultExtension() { return "ptx"; }
+	PTXFilter();
 
 	//inherited from FileIOFilter
-	bool importSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
-	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
 };
 
 #endif //CC_PTX_FILTER_HEADER

--- a/plugins/core/IO/qCoreIO/src/STLFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/STLFilter.cpp
@@ -39,9 +39,17 @@
 //System
 #include <cstring>
 
-bool STLFilter::canLoadExtension(const QString& upperCaseExt) const
-{
-	return (upperCaseExt == "STL");
+
+STLFilter::STLFilter() :
+	FileIOFilter( {
+				  "+STL Filter",
+				  QStringList{ "stl" },
+				  "stl",
+				  QStringList{ "STL mesh (*.stl)" },
+				  QStringList{ "STL mesh (*.stl)" },
+				  Import | Export | FromPlugin
+				  } )
+{	
 }
 
 bool STLFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const

--- a/plugins/core/IO/qCoreIO/src/STLFilter.h
+++ b/plugins/core/IO/qCoreIO/src/STLFilter.h
@@ -30,19 +30,13 @@ class ccPointCloud;
 class STLFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "STL mesh (*.stl)"; }
-	static inline QString GetDefaultExtension() { return "stl"; }
-
+	STLFilter();
+	
 	//inherited from FileIOFilter
-	bool importSupported() const override { return true; }
-	bool exportSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
+
 	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 
 private:
 	//! Custom save method

--- a/plugins/core/IO/qCoreIO/src/SimpleBinFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/SimpleBinFilter.cpp
@@ -35,9 +35,17 @@ constexpr size_t c_headerSize = 64;
 //header flag
 constexpr quint16 s_headerFlagSBF = (static_cast<quint16>(42) | static_cast<quint16>(42 << 8));
 
-bool SimpleBinFilter::canLoadExtension(const QString& upperCaseExt) const
+
+SimpleBinFilter::SimpleBinFilter() :
+	FileIOFilter( {
+				  "+Simple binary Filter",
+				  QStringList{ "sbf", "data" },
+				  "sbf",
+				  QStringList{ "Simple binary file (*.sbf)" },
+				  QStringList{ "Simple binary file (*.sbf)" },
+				  Import | Export | FromPlugin
+				  } )
 {
-	return (upperCaseExt == "SBF" || upperCaseExt == "DATA");
 }
 
 bool SimpleBinFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const

--- a/plugins/core/IO/qCoreIO/src/SimpleBinFilter.h
+++ b/plugins/core/IO/qCoreIO/src/SimpleBinFilter.h
@@ -24,19 +24,13 @@
 class SimpleBinFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "Simple binary file (*.sbf)"; }
-	static inline QString GetDefaultExtension() { return "sbf"; }
+	SimpleBinFilter();
 
 	//inherited from FileIOFilter
-	bool importSupported() const override { return true; }
-	bool exportSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
+
 	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 };
 
 #endif //CC_SIMPLE_BIN_FILTER_HEADER

--- a/plugins/core/IO/qCoreIO/src/VTKFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/VTKFilter.cpp
@@ -31,9 +31,17 @@
 //System
 #include <cstring>
 
-bool VTKFilter::canLoadExtension(const QString& upperCaseExt) const
+
+VTKFilter::VTKFilter() :
+	FileIOFilter( {
+				  "+VTK Filter",
+				  QStringList{ "vtk" },
+				  "vtk",
+				  QStringList{ "VTK cloud or mesh (*.vtk)" },
+				  QStringList{ "VTK cloud or mesh (*.vtk)" },
+				  Import | Export | FromPlugin
+				  } )
 {
-	return (upperCaseExt == "VTK");
 }
 
 bool VTKFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const

--- a/plugins/core/IO/qCoreIO/src/VTKFilter.h
+++ b/plugins/core/IO/qCoreIO/src/VTKFilter.h
@@ -24,19 +24,13 @@
 class VTKFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "VTK cloud or mesh (*.vtk)"; }
-	static inline QString GetDefaultExtension() { return "vtk"; }
+	VTKFilter();
 
 	//inherited from FileIOFilter
-	bool importSupported() const override { return true; }
-	bool exportSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
+
 	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 };
 
 #endif //CC_VTK_FILTER_HEADER

--- a/plugins/core/IO/qE57IO/src/E57Filter.cpp
+++ b/plugins/core/IO/qE57IO/src/E57Filter.cpp
@@ -53,9 +53,17 @@ using colorFieldType = double;
 const char CC_E57_INTENSITY_FIELD_NAME[] = "Intensity";
 const char CC_E57_RETURN_INDEX_FIELD_NAME[] = "Return index";
 
-bool E57Filter::canLoadExtension(const QString& upperCaseExt) const
+
+E57Filter::E57Filter() :
+	FileIOFilter( {
+				  "+E57 Filter",
+				  QStringList{ "e57" },
+				  "e57",
+				  QStringList{ "E57 cloud (*.e57)" },
+				  QStringList{ "E57 cloud (*.e57)" },
+				  Import | Export | FromPlugin
+				  } )
 {
-	return (upperCaseExt == "E57");
 }
 
 bool E57Filter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const

--- a/plugins/core/IO/qE57IO/src/E57Filter.h
+++ b/plugins/core/IO/qE57IO/src/E57Filter.h
@@ -25,19 +25,13 @@
 class E57Filter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "E57 cloud (*.e57)"; }
-	static inline QString GetDefaultExtension() { return "e57"; }
-
+	E57Filter();
+	
 	//inherited from FileIOFilter
-	bool importSupported() const override { return true; }
-	bool exportSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
+
 	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 };
 
 #endif //CC_E57_FILTER_HEADER

--- a/plugins/core/IO/qFBXIO/src/FBXFilter.cpp
+++ b/plugins/core/IO/qFBXIO/src/FBXFilter.cpp
@@ -39,9 +39,17 @@
 
 static const char FBX_SCALE_METADATA_KEY[] = "FBX:ScaleToCM";
 
-bool FBXFilter::canLoadExtension(const QString& upperCaseExt) const
+
+FBXFilter::FBXFilter() :
+	FileIOFilter( {
+				  "+FBX Filter",
+				  QStringList{ "fbx" },
+				  "fbx",
+				  QStringList{ "FBX mesh (*.fbx)" },
+				  QStringList{ "FBX mesh (*.fbx)" },
+				  Import | Export | FromPlugin
+				  } )
 {
-	return (upperCaseExt == "FBX");
 }
 
 bool FBXFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const
@@ -1302,7 +1310,6 @@ static ccMesh* FromFbxMesh(FbxMesh* fbxMesh, FileIOFilter::LoadParameters& param
 	return mesh;
 }
 
-
 CC_FILE_ERROR FBXFilter::loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters)
 {
 	CC_FILE_ERROR result = CC_FERR_NO_ERROR;
@@ -1317,7 +1324,7 @@ CC_FILE_ERROR FBXFilter::loadFile(const QString& filename, ccHObject& container,
 		lSdkManager->SetIOSettings(ios);
 
 		// Import options determine what kind of data is to be imported.
-		// True is the default, but here we’ll set some to true explicitly, and others to false.
+		// True is the default, but here we'll set some to true explicitly, and others to false.
 		//(*(lSdkManager->GetIOSettings())).SetBoolProp(IMP_FBX_MATERIAL,	true);
 		//(*(lSdkManager->GetIOSettings())).SetBoolProp(IMP_FBX_TEXTURE,	true);
 

--- a/plugins/core/IO/qFBXIO/src/FBXFilter.h
+++ b/plugins/core/IO/qFBXIO/src/FBXFilter.h
@@ -26,19 +26,13 @@
 class FBXFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "FBX mesh (*.fbx)"; }
-	static inline QString GetDefaultExtension() { return "fbx"; }
+	FBXFilter();
 
 	//inherited from FileIOFilter
-	bool importSupported() const override { return true; }
-	bool exportSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
+
 	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 
 	//! Sets default output format (will prevent the dialog to appear when saving FBX files)
 	static void SetDefaultOutputFormat(QString format);

--- a/plugins/core/IO/qLASFWFIO/Filter/LASFWFFilter.cpp
+++ b/plugins/core/IO/qLASFWFIO/Filter/LASFWFFilter.cpp
@@ -68,8 +68,8 @@ LASFWFFilter::LASFWFFilter() :
 				  "+LASFW Filter",
 				  QStringList{ "las", "laz" },
 				  "las",
-				  QStringList{ "LAS 1.3 or 1.4 (*.las *.laz)" },
-				  QStringList{ "LAS 1.3 or 1.4 (*.las *.laz)" },
+				  QStringList{ GetFileFilter() },
+				  QStringList{ GetFileFilter() },
 				  Import | Export | FromPlugin
 				  } )
 {

--- a/plugins/core/IO/qLASFWFIO/Filter/LASFWFFilter.cpp
+++ b/plugins/core/IO/qLASFWFIO/Filter/LASFWFFilter.cpp
@@ -62,10 +62,17 @@ public:
 //! Semi persistent save dialog
 QSharedPointer<LASSaveDlg> s_saveDlg(0);
 
-bool LASFWFFilter::canLoadExtension(const QString& upperCaseExt) const
+
+LASFWFFilter::LASFWFFilter() :
+	FileIOFilter( {
+				  "+LASFW Filter",
+				  QStringList{ "las", "laz" },
+				  "las",
+				  QStringList{ "LAS 1.3 or 1.4 (*.las *.laz)" },
+				  QStringList{ "LAS 1.3 or 1.4 (*.las *.laz)" },
+				  Import | Export | FromPlugin
+				  } )
 {
-	return (	upperCaseExt == "LAS"
-			||	upperCaseExt == "LAZ" );
 }
 
 bool LASFWFFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const

--- a/plugins/core/IO/qLASFWFIO/Filter/LASFWFFilter.h
+++ b/plugins/core/IO/qLASFWFIO/Filter/LASFWFFilter.h
@@ -25,20 +25,16 @@
 class LASFWFFilter : public FileIOFilter
 {
 public:
-
+	LASFWFFilter();
+	
 	//static accessors
 	static inline QString GetFileFilter() { return "LAS 1.3 or 1.4 (*.las *.laz)"; }
-	static inline QString GetDefaultExtension() { return "las"; }
 
 	//inherited from FileIOFilter
-	virtual bool importSupported() const override { return true; }
-	virtual bool exportSupported() const override { return true; }
-	virtual CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	virtual CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	virtual QStringList getFileFilters(bool onImport) const override { return QStringList(GetFileFilter()); }
-	virtual QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	virtual bool canLoadExtension(const QString& upperCaseExt) const override;
-	virtual bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
+
+	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 };
 
 #endif //CC_LAS_FWF_FILTER_HEADER

--- a/plugins/core/IO/qLASFWFIO/qLASFWFIO.cpp
+++ b/plugins/core/IO/qLASFWFIO/qLASFWFIO.cpp
@@ -26,7 +26,7 @@
 
 qLASFWFIO::qLASFWFIO(QObject *parent)
     : QObject(parent)
-    , ccIOFilterPluginInterface(":/CC/plugin/qLASFWFIO/info.json")
+    , ccIOPluginInterface(":/CC/plugin/qLASFWFIO/info.json")
 {
 }
 

--- a/plugins/core/IO/qPDALIO/src/LASFilter.cpp
+++ b/plugins/core/IO/qPDALIO/src/LASFilter.cpp
@@ -106,10 +106,17 @@ public:
 	}
 };
 
-bool LASFilter::canLoadExtension(const QString& upperCaseExt) const
+
+LASFilter::LASFilter() :
+	FileIOFilter( {
+				  "+PDAL LAS Filter",
+				  QStringList{ "las" },
+				  "las",
+				  QStringList{ "LAS cloud (*.las *.laz)" },
+				  QStringList{ "LAS cloud (*.las *.laz)" },
+				  Import | Export | FromPlugin
+				  } )
 {
-	return (upperCaseExt == "LAS" ||
-	        upperCaseExt == "LAZ");
 }
 
 bool LASFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const

--- a/plugins/core/IO/qPDALIO/src/LASFilter.h
+++ b/plugins/core/IO/qPDALIO/src/LASFilter.h
@@ -24,19 +24,13 @@
 class LASFilter : public FileIOFilter
 {
 public:
-	//static accessors
-	static inline QString GetFileFilter() { return "LAS cloud (*.las *.laz)"; }
-	static inline QString GetDefaultExtension() { return "las"; }
+	LASFilter();
 
 	//inherited from FileIOFilter
-	bool importSupported() const override { return true; }
-	bool exportSupported() const override { return true; }
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
-	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
-	QStringList getFileFilters(bool onImport) const override { Q_UNUSED( onImport ); return { GetFileFilter() }; }
-	QString getDefaultExtension() const override { return GetDefaultExtension(); }
-	bool canLoadExtension(const QString& upperCaseExt) const override;
+
 	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 };
 
 #endif //CC_LAS_FILTER_HEADER

--- a/plugins/core/IO/qPhotoscanIO/src/PhotoScanFilter.cpp
+++ b/plugins/core/IO/qPhotoscanIO/src/PhotoScanFilter.cpp
@@ -68,11 +68,6 @@ struct MeshDesc
 	QString texture;
 };
 
-bool PhotoScanFilter::canLoadExtension(const QString& upperCaseExt) const
-{
-	return (upperCaseExt == "PSZ");
-}
-
 enum Sections { DOCUMENT, CHUNKS, CHUNK, SENSORS, CAMERAS, FRAMES, FRAME, TRANSFORM };
 
 QString ToName(Sections section)
@@ -387,6 +382,18 @@ static QString CreateTempFile(QuaZip& zip, QString zipFilename)
 	return tempFilename;
 }
 
+
+PhotoScanFilter::PhotoScanFilter() :
+	FileIOFilter( {
+				  "+PhotoScan Filter",
+				  QStringList{ "psz" },
+				  "psz",
+				  QStringList{ "Photoscan project (*.psz)" },
+				  QStringList(),
+				  Import | FromPlugin
+				  } )
+{
+}
 
 CC_FILE_ERROR PhotoScanFilter::loadFile(const QString& filename,
 										ccHObject& container,

--- a/plugins/core/IO/qPhotoscanIO/src/PhotoScanFilter.h
+++ b/plugins/core/IO/qPhotoscanIO/src/PhotoScanFilter.h
@@ -22,22 +22,13 @@
 #include <FileIOFilter.h>
 
 //! Photoscan (PSZ) file I/O filter
-class /*QCC_IO_LIB_API*/ PhotoScanFilter : public FileIOFilter
+class PhotoScanFilter : public FileIOFilter
 {
 public:
-
-	//static accessors
-	static inline QString GetFileFilter() { return "Photoscan project (*.psz)"; }
-	static inline QString GetDefaultExtension() { return "psz"; }
+	PhotoScanFilter();
 
 	//inherited from FileIOFilter
-	virtual bool importSupported() const { return true; }
 	virtual CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters);
-	virtual QStringList getFileFilters(bool onImport) const { return QStringList(GetFileFilter()); }
-	virtual QString getDefaultExtension() const { return GetDefaultExtension(); }
-	virtual bool canLoadExtension(const QString& upperCaseExt) const;
-	virtual bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const { return false; }
-
 };
 
 #endif //CC_PHOTOSCAN_FILTER_HEADER

--- a/plugins/core/Standard/qPCL/PclIO/PcdFilter.cpp
+++ b/plugins/core/Standard/qPCL/PclIO/PcdFilter.cpp
@@ -40,9 +40,17 @@
 #include <pcl/filters/passthrough.h>
 #include <pcl/io/pcd_io.h>
 
-bool PcdFilter::canLoadExtension(const QString& upperCaseExt) const
+
+PcdFilter::PcdFilter() :
+    FileIOFilter( {
+                  "+Point Cloud Library Filter",
+                  QStringList{ "pcd" },
+                  "pcd",
+                  QStringList{ "Point Cloud Library cloud (*.pcd)" },
+                  QStringList(),
+                  Import | FromPlugin
+                  } )
 {
-	return (upperCaseExt == "PCD");
 }
 
 bool PcdFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const
@@ -195,9 +203,9 @@ CC_FILE_ERROR PcdFilter::loadFile(const QString& filename, ccHObject& container,
 		//Compute parameters
 		ccGenericPointCloud* pc = ccHObjectCaster::ToGenericPointCloud(ccCloud);
 		sensor->computeAutoParameters(pc);
-	
+
 		sensor->setEnabled(false);
-		
+
 		ccCloud->addChild(sensor);
 	}
 

--- a/plugins/core/Standard/qPCL/PclIO/PcdFilter.cpp
+++ b/plugins/core/Standard/qPCL/PclIO/PcdFilter.cpp
@@ -40,9 +40,8 @@
 #include <pcl/filters/passthrough.h>
 #include <pcl/io/pcd_io.h>
 
-
-PcdFilter::PcdFilter() :
-    FileIOFilter( {
+PcdFilter::PcdFilter()
+	: FileIOFilter( {
                   "+Point Cloud Library Filter",
                   QStringList{ "pcd" },
                   "pcd",

--- a/plugins/core/Standard/qPCL/PclIO/PcdFilter.h
+++ b/plugins/core/Standard/qPCL/PclIO/PcdFilter.h
@@ -25,20 +25,13 @@
 class PcdFilter : public FileIOFilter
 {
 public:
-
-	//static accessors
-	static inline QString GetFileFilter() { return "Point Cloud Library cloud (*.pcd)"; }
-	static inline QString GetDefaultExtension() { return "pcd"; }
+	PcdFilter();
 
 	//inherited from FileIOFilter
-	virtual bool importSupported() const { return true; }
-	virtual CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters);
-	virtual CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters);
-	virtual QStringList getFileFilters(bool onImport) const { return QStringList(GetFileFilter()); }
-	virtual QString getDefaultExtension() const { return GetDefaultExtension(); }
-	virtual bool canLoadExtension(const QString& upperCaseExt) const;
-	virtual bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const;
+	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;
 
+	bool canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) const override;
+	CC_FILE_ERROR saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters) override;
 };
 
 #endif //CC_PCD_FILTER_HEADER

--- a/plugins/core/Standard/qPCL/PclIO/qPclIO.cpp
+++ b/plugins/core/Standard/qPCL/PclIO/qPclIO.cpp
@@ -25,7 +25,7 @@
 
 qPclIO::qPclIO(QObject *parent)
     : QObject(parent)
-    , ccIOFilterPluginInterface(":/CC/plugin/qPclIO/info.json")
+    , ccIOPluginInterface(":/CC/plugin/qPclIO/info.json")
 {
 }
 

--- a/plugins/core/Standard/qPCL/PclIO/qPclIO.cpp
+++ b/plugins/core/Standard/qPCL/PclIO/qPclIO.cpp
@@ -29,7 +29,7 @@ qPclIO::qPclIO(QObject *parent)
 {
 }
 
-ccIOPluginInterface::FilterList qPclIO::getFilter()
+ccIOPluginInterface::FilterList qPclIO::getFilters()
 {
     return { FileIOFilter::Shared( new PcdFilter ) };
 }

--- a/plugins/example/ExampleIOPlugin/src/FooFilter.cpp
+++ b/plugins/example/ExampleIOPlugin/src/FooFilter.cpp
@@ -20,18 +20,23 @@
 #include "FooFilter.h"
 
 
-bool FooFilter::importSupported() const
+FooFilter::FooFilter() :
+	FileIOFilter( {
+				  "Foo Filter",
+				  QStringList{ "foo", "txt" },
+				  "foo",
+				  QStringList{ "Foo file (*.foo)", "Text file (*.txt)" },
+				  QStringList(),
+				  Import
+				  } )
 {
-	return true;
-}
-
-bool FooFilter::exportSupported() const
-{
-	return false;
 }
 
 CC_FILE_ERROR FooFilter::loadFile( const QString &fileName, ccHObject &container, LoadParameters &parameters )
 {	
+	Q_UNUSED( container );
+	Q_UNUSED( parameters );
+	
 	QFile file( fileName );
 	
 	if ( !file.open( QIODevice::ReadOnly ) )
@@ -60,40 +65,12 @@ CC_FILE_ERROR FooFilter::loadFile( const QString &fileName, ccHObject &container
 	return CC_FERR_NO_ERROR;
 }
 
-QStringList FooFilter::getFileFilters( bool onImport ) const
-{
-	if ( onImport )
-	{
-		// import
-		return QStringList{
-			QStringLiteral( "Foo file (*.foo)" ),
-			QStringLiteral( "Text file (*.txt)" )
-		};
-	}
-	else
-	{
-		// export
-		return {};
-	}
-}
-
-QString FooFilter::getDefaultExtension() const
-{
-	return QStringLiteral( "foo" );
-}
-
-bool FooFilter::canLoadExtension( const QString &upperCaseExt ) const
-{
-	const QStringList extensions{
-		"FOO",
-		"TXT"
-	};
-	
-	return extensions.contains( upperCaseExt );
-}
-
 bool FooFilter::canSave( CC_CLASS_ENUM type, bool &multiple, bool &exclusive ) const
 {
+	Q_UNUSED( type );
+	Q_UNUSED( multiple );
+	Q_UNUSED( exclusive );
+
 	// ... can we save this?
 	return false;
 }

--- a/plugins/example/ExampleIOPlugin/src/FooFilter.h
+++ b/plugins/example/ExampleIOPlugin/src/FooFilter.h
@@ -24,16 +24,11 @@
 class FooFilter : public FileIOFilter
 {
 public:
-	// inherited from FileIOFilter
-	bool importSupported() const override;
-	bool exportSupported() const override;
+	FooFilter();
 	
+	// inherited from FileIOFilter
 	CC_FILE_ERROR loadFile( const QString &fileName, ccHObject &container, LoadParameters &parameters ) override;
 	
-	QStringList getFileFilters( bool onImport ) const override;
-	QString getDefaultExtension() const override;
-	
-	bool canLoadExtension( const QString &upperCaseExt ) const override;
 	bool canSave( CC_CLASS_ENUM type, bool &multiple, bool &exclusive ) const override;
 };
 


### PR DESCRIPTION
- The `FileIOFilter` base class now takes a struct as an argument containing all the static info about a filter - extensions, features (import/export), etc.. See `FooFilter` in the `ExampleIOPlugin` and the comments in `FileIOFilter::FilterInfo`.
- The use of `FileIOFilter::FilterInfo` means that the following virtual functions in I/O filters are no longer virtual/required:
   - importSupported
   - exportSupported
   - getFileFilters
   - getDefaultExtension
   - canLoadExtension
- Removes a lot of boilerplate code and makes it easier to add properties/features to I/O plugins
- Because it changes every single I/O plugin, this PR is unavoidably large...