### PR TITLE
Add "priority" to FileIOFilter::FilterInfo

### DIFF
--- a/libs/qCC_io/AsciiFilter.cpp
+++ b/libs/qCC_io/AsciiFilter.cpp
@@ -74,6 +74,7 @@ AsciiOpenDlg* AsciiFilter::GetOpenDialog(QWidget* parentWidget/*=0*/)
 AsciiFilter::AsciiFilter()
 	: FileIOFilter( {
 					"_ASCII Filter",
+					2.0f,	// priority
 					QStringList{ "txt", "asc", "neu", "xyz", "pts", "csv" },
 					"asc",
 					QStringList{ GetFileFilter() },

--- a/libs/qCC_io/BinFilter.cpp
+++ b/libs/qCC_io/BinFilter.cpp
@@ -56,6 +56,7 @@
 BinFilter::BinFilter()
 	: FileIOFilter( {
 					"_CloudCompare BIN Filter",
+					1.0f,	// priority
 					QStringList{ "bin" },
 					"bin",
 					QStringList{ GetFileFilter() },

--- a/libs/qCC_io/DepthMapFileFilter.cpp
+++ b/libs/qCC_io/DepthMapFileFilter.cpp
@@ -35,7 +35,7 @@
 DepthMapFileFilter::DepthMapFileFilter()
 	: FileIOFilter( {
 					"_Depth Map Filter",
-					19.0f,	// priority
+					DEFAULT_PRIORITY,	// priority
 					QStringList(),
 					"txt",
 					QStringList(),

--- a/libs/qCC_io/DepthMapFileFilter.cpp
+++ b/libs/qCC_io/DepthMapFileFilter.cpp
@@ -35,6 +35,7 @@
 DepthMapFileFilter::DepthMapFileFilter()
 	: FileIOFilter( {
 					"_Depth Map Filter",
+					19.0f,	// priority
 					QStringList(),
 					"txt",
 					QStringList(),

--- a/libs/qCC_io/DxfFilter.cpp
+++ b/libs/qCC_io/DxfFilter.cpp
@@ -41,6 +41,7 @@
 DxfFilter::DxfFilter()
 	: FileIOFilter( {
 					"_DXF Filter",
+					13.0f,	// priority
 					QStringList{ "dxf" },
 					"dxf",
 					QStringList{ "DXF geometry (*.dxf)" },

--- a/libs/qCC_io/FileIOFilter.h
+++ b/libs/qCC_io/FileIOFilter.h
@@ -179,6 +179,9 @@ public: //public interface (to be reimplemented by each I/O filter)
 	}
 	
 public: //static methods
+	//! Get a list of all the available importer filter strings for use in a drop down menu.
+	//! Includes "All (*.)" as the first item in the list.
+	QCC_IO_LIB_API static QStringList ImportFilterList();
 	
 	//! Loads one or more entities from a file with a known filter
 	/** Shortcut to FileIOFilter::loadFile
@@ -317,6 +320,11 @@ protected:
 		//! ID used to uniquely identify the filter (not user-visible)
 		QString id;
 		
+		//! Priority used to determine sort order and which one is the default in the
+		//! case of multiple FileIOFilters registering the same extension.
+		//! Default is 25.0 /see DEFAULT_PRIORITY.
+		float priority;
+		
 		//! List of extensions this filter can read (lowercase)
 		//! e.g. "txt", "foo", "bin"
 		//! This is used in FindBestFilterForExtension()
@@ -334,6 +342,8 @@ protected:
 		//! Supported features \see FilterFeature
 		FilterFeatures features;
 	};
+	
+	static constexpr float DEFAULT_PRIORITY = 25.0f;
 	
 	QCC_IO_LIB_API explicit FileIOFilter( const FilterInfo &info );
 	

--- a/libs/qCC_io/ImageFileFilter.cpp
+++ b/libs/qCC_io/ImageFileFilter.cpp
@@ -35,6 +35,7 @@
 ImageFileFilter::ImageFileFilter()
 	: FileIOFilter( {
 					"_Image Filter",
+					17.0f,	// priority
 					QStringList(),	// set below
 					"png",
 					QStringList(),	// set below

--- a/libs/qCC_io/PlyFilter.cpp
+++ b/libs/qCC_io/PlyFilter.cpp
@@ -53,6 +53,7 @@ using namespace CCLib;
 PlyFilter::PlyFilter()
 	: FileIOFilter( {
 					"_PLY Filter",
+					7.0f,	// priority
 					QStringList{ "ply" },
 					"ply",
 					QStringList{ "PLY mesh (*.ply)" },

--- a/libs/qCC_io/RasterGridFilter.cpp
+++ b/libs/qCC_io/RasterGridFilter.cpp
@@ -37,13 +37,14 @@
 
 RasterGridFilter::RasterGridFilter()
 	: FileIOFilter( {
-				  "_Raster Grid Filter",
-				  QStringList{ "tif", "tiff", "adf" },
-				  "tif",
-				  QStringList{ "RASTER grid (*.*)" },
-				  QStringList(),
-				  Import | BuiltIn
-				  } )
+					"_Raster Grid Filter",
+					16.0f,	// priority
+					QStringList{ "tif", "tiff", "adf" },
+					"tif",
+					QStringList{ "RASTER grid (*.*)" },
+					QStringList(),
+					Import | BuiltIn
+					} )
 {
 }
 

--- a/libs/qCC_io/ShpFilter.cpp
+++ b/libs/qCC_io/ShpFilter.cpp
@@ -507,6 +507,7 @@ public:
 ShpFilter::ShpFilter()
 	: FileIOFilter( {
 					"_Shape Filter",
+					14.0f,	// priority
 					QStringList{ "shp" },
 					"shp",
 					QStringList{ "SHP entity (*.shp)" },

--- a/plugins/core/IO/qAdditionalIO/src/BundlerFilter.cpp
+++ b/plugins/core/IO/qAdditionalIO/src/BundlerFilter.cpp
@@ -73,7 +73,8 @@ struct BundlerCamera
 
 BundlerFilter::BundlerFilter()
 	: FileIOFilter( {
-					"+Bundler Filter",
+					"_Snavely Bundler Filter",
+					DEFAULT_PRIORITY,	// priority
 					QStringList{ "out" },
 					"out",
 					QStringList{ "Snavely's Bundler output (*.out)" },

--- a/plugins/core/IO/qAdditionalIO/src/IcmFilter.cpp
+++ b/plugins/core/IO/qAdditionalIO/src/IcmFilter.cpp
@@ -36,7 +36,8 @@ const int MAX_ASCII_FILE_LINE_LENGTH = 4096;
 
 IcmFilter::IcmFilter()
 	: FileIOFilter( {
-					"+ICM Filter",
+					"_ICM Filter",
+					DEFAULT_PRIORITY,	// priority
 					QStringList{ "icm" },
 					"icm",
 					QStringList{ "Clouds + calibrated images [meta][ascii] (*.icm)" },

--- a/plugins/core/IO/qAdditionalIO/src/PNFilter.cpp
+++ b/plugins/core/IO/qAdditionalIO/src/PNFilter.cpp
@@ -32,7 +32,8 @@ static const CCVector3 s_defaultNorm(0,0,1);
 
 PNFilter::PNFilter()
 	: FileIOFilter( {
-					"+Point+Normal Filter",
+					"_Point+Normal Filter",
+					DEFAULT_PRIORITY,	// priority
 					QStringList{ "pn" },
 					"pn",
 					QStringList{ "Point+Normal cloud (*.pn)" },

--- a/plugins/core/IO/qAdditionalIO/src/PVFilter.cpp
+++ b/plugins/core/IO/qAdditionalIO/src/PVFilter.cpp
@@ -30,7 +30,8 @@
 
 PVFilter::PVFilter()
 	: FileIOFilter( {
-					"+Point+Value Filter",
+					"_Point+Value Filter",
+					DEFAULT_PRIORITY,	// priority
 					QStringList{ "pv" },
 					"pv",
 					QStringList{ "Point+Value cloud (*.pv)" },

--- a/plugins/core/IO/qAdditionalIO/src/PovFilter.cpp
+++ b/plugins/core/IO/qAdditionalIO/src/PovFilter.cpp
@@ -50,7 +50,8 @@ const char CC_SENSOR_ROTATION_ORDER_OLD_NAMES[][10] = {	"THETA_PHI",		//Rotation
 
 PovFilter::PovFilter()
 	: FileIOFilter( {
-					"+POV Filter",
+					"_POV Filter",
+					DEFAULT_PRIORITY,	// priority
 					QStringList{ "pov" },
 					"pov",
 					QStringList{ "Clouds + sensor info. [meta][ascii] (*.pov)" },

--- a/plugins/core/IO/qAdditionalIO/src/SalomeHydroFilter.cpp
+++ b/plugins/core/IO/qAdditionalIO/src/SalomeHydroFilter.cpp
@@ -30,7 +30,8 @@
 
 SalomeHydroFilter::SalomeHydroFilter()
 	: FileIOFilter( {
-					"+SalomeHydro Filter",
+					"_SalomeHydro Filter",
+					DEFAULT_PRIORITY,	// priority
 					QStringList{ "poly" },
 					"poly",
 					QStringList{ "Salome Hydro polylines (*.poly)" },

--- a/plugins/core/IO/qAdditionalIO/src/SinusxFilter.cpp
+++ b/plugins/core/IO/qAdditionalIO/src/SinusxFilter.cpp
@@ -33,7 +33,8 @@
 
 SinusxFilter::SinusxFilter()
 	: FileIOFilter( {
-					"+Sinusx Filter",
+					"_Sinusx Filter",
+					DEFAULT_PRIORITY,	// priority
 					QStringList{ "sx", "sinusx" },
 					"sx",
 					QStringList{ "Sinusx curve (*.sx)" },

--- a/plugins/core/IO/qAdditionalIO/src/SoiFilter.cpp
+++ b/plugins/core/IO/qAdditionalIO/src/SoiFilter.cpp
@@ -29,7 +29,8 @@ const int MAX_ASCII_FILE_LINE_LENGTH = 4096;
 
 SoiFilter::SoiFilter()
 	: FileIOFilter( {
-					"+Soisic Filter",
+					"_Soisic Filter",
+					DEFAULT_PRIORITY,	// priority
 					QStringList{ "soi" },
 					"soi",
 					QStringList{ "Mensi Soisic cloud (*.soi)" },

--- a/plugins/core/IO/qCSVMatrixIO/src/CSVMatrixFilter.cpp
+++ b/plugins/core/IO/qCSVMatrixIO/src/CSVMatrixFilter.cpp
@@ -47,7 +47,8 @@ static bool s_useTexture = false;
 
 CSVMatrixFilter::CSVMatrixFilter()
     : FileIOFilter( {
-                    "+CSV Matrix Filter",
+                    "_CSV Matrix Filter",
+					DEFAULT_PRIORITY,	// priority
                     QStringList{ "csv" },
                     "csv",
                     QStringList{ "CSV matrix cloud (*.csv)" },

--- a/plugins/core/IO/qCoreIO/src/HeightProfileFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/HeightProfileFilter.cpp
@@ -27,7 +27,8 @@
 
 HeightProfileFilter::HeightProfileFilter()
 	: FileIOFilter( {
-					"+Height profile Filter",
+					"_Height profile Filter",
+					21.0f,	// priority
 					QStringList(),
 					"",
 					QStringList(),

--- a/plugins/core/IO/qCoreIO/src/MAFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/MAFilter.cpp
@@ -78,7 +78,8 @@ namespace
 
 MAFilter::MAFilter()
 	: FileIOFilter( {
-					"+Maya ASCII Filter",
+					"_Maya ASCII Filter",
+					18.0f,	// priority
 					QStringList(),
 					"ma",
 					QStringList(),

--- a/plugins/core/IO/qCoreIO/src/MAFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/MAFilter.cpp
@@ -79,7 +79,7 @@ namespace
 MAFilter::MAFilter()
 	: FileIOFilter( {
 					"_Maya ASCII Filter",
-					18.0f,	// priority
+					DEFAULT_PRIORITY,	// priority
 					QStringList(),
 					"ma",
 					QStringList(),

--- a/plugins/core/IO/qCoreIO/src/MascaretFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/MascaretFilter.cpp
@@ -51,7 +51,7 @@ public:
 MascaretFilter::MascaretFilter()
 	: FileIOFilter( {
 					"_Mascaret Filter",
-					20.0f,	// priority
+					DEFAULT_PRIORITY,	// priority
 					QStringList(),
 					"georef",
 					QStringList(),

--- a/plugins/core/IO/qCoreIO/src/MascaretFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/MascaretFilter.cpp
@@ -50,7 +50,8 @@ public:
 
 MascaretFilter::MascaretFilter()
 	: FileIOFilter( {
-					"+Mascaret Filter",
+					"_Mascaret Filter",
+					20.0f,	// priority
 					QStringList(),
 					"georef",
 					QStringList(),

--- a/plugins/core/IO/qCoreIO/src/OFFFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/OFFFilter.cpp
@@ -31,7 +31,8 @@
 
 OFFFilter::OFFFilter()
 	: FileIOFilter( {
-					"+OFF Filter",
+					"_OFF Filter",
+					11.0f,	// priority
 					QStringList{ "off" },
 					"off",
 					QStringList{ "OFF mesh (*.off)" },

--- a/plugins/core/IO/qCoreIO/src/ObjFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/ObjFilter.cpp
@@ -46,7 +46,8 @@
 
 ObjFilter::ObjFilter()
 	: FileIOFilter( {
-					"+OBJ Filter",
+					"_OBJ Filter",
+					8.0f,	// priority
 					QStringList{ "obj" },
 					"obj",
 					QStringList{ "OBJ mesh (*.obj)" },

--- a/plugins/core/IO/qCoreIO/src/PDMS/PDMSFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/PDMS/PDMSFilter.cpp
@@ -38,7 +38,7 @@ using PdmsAndCCPair = std::pair<PdmsTools::PdmsObjects::GenericItem*, ccHObject*
 PDMSFilter::PDMSFilter()
 	: FileIOFilter( {
 					"_PDMS Filter",
-					15.0f,	// priority
+					DEFAULT_PRIORITY,	// priority
 					QStringList{ "pdms", "pdmsmac", "mac" },
 					"pdms",
 					QStringList{ "PDMS primitives (*.pdms *.pdmsmac *.mac)" },

--- a/plugins/core/IO/qCoreIO/src/PDMS/PDMSFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/PDMS/PDMSFilter.cpp
@@ -37,7 +37,8 @@ using PdmsAndCCPair = std::pair<PdmsTools::PdmsObjects::GenericItem*, ccHObject*
 
 PDMSFilter::PDMSFilter()
 	: FileIOFilter( {
-					"+PDMS Filter",
+					"_PDMS Filter",
+					15.0f,	// priority
 					QStringList{ "pdms", "pdmsmac", "mac" },
 					"pdms",
 					QStringList{ "PDMS primitives (*.pdms *.pdmsmac *.mac)" },

--- a/plugins/core/IO/qCoreIO/src/PTXFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/PTXFilter.cpp
@@ -39,7 +39,8 @@ const char CC_PTX_INTENSITY_FIELD_NAME[] = "Intensity";
 
 PTXFilter::PTXFilter()
 	: FileIOFilter( {
-					"+PTX Filter",
+					"_PTX Filter",
+					5.0f,	// priority
 					QStringList{ "ptx" },
 					"ptx",
 					QStringList{ "PTX cloud (*.ptx)" },

--- a/plugins/core/IO/qCoreIO/src/STLFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/STLFilter.cpp
@@ -42,7 +42,8 @@
 
 STLFilter::STLFilter()
 	: FileIOFilter( {
-					"+STL Filter",
+					"_STL Filter",
+					10.0f,	// priority
 					QStringList{ "stl" },
 					"stl",
 					QStringList{ "STL mesh (*.stl)" },

--- a/plugins/core/IO/qCoreIO/src/SimpleBinFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/SimpleBinFilter.cpp
@@ -38,7 +38,8 @@ constexpr quint16 s_headerFlagSBF = (static_cast<quint16>(42) | static_cast<quin
 
 SimpleBinFilter::SimpleBinFilter()
 	: FileIOFilter( {
-					"+Simple binary Filter",
+					"_Simple binary Filter",
+					6.0f,	// priority
 					QStringList{ "sbf", "data" },
 					"sbf",
 					QStringList{ "Simple binary file (*.sbf)" },

--- a/plugins/core/IO/qCoreIO/src/VTKFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/VTKFilter.cpp
@@ -34,7 +34,8 @@
 
 VTKFilter::VTKFilter()
 	: FileIOFilter( {
-					"+VTK Filter",
+					"_VTK Filter",
+					9.0f,	// priority
 					QStringList{ "vtk" },
 					"vtk",
 					QStringList{ "VTK cloud or mesh (*.vtk)" },

--- a/plugins/core/IO/qE57IO/src/E57Filter.cpp
+++ b/plugins/core/IO/qE57IO/src/E57Filter.cpp
@@ -56,7 +56,8 @@ const char CC_E57_RETURN_INDEX_FIELD_NAME[] = "Return index";
 
 E57Filter::E57Filter()
     : FileIOFilter( {
-                    "+E57 Filter",
+                    "_E57 Filter",
+					4.0f,	// priority
                     QStringList{ "e57" },
                     "e57",
                     QStringList{ "E57 cloud (*.e57)" },

--- a/plugins/core/IO/qFBXIO/src/FBXFilter.cpp
+++ b/plugins/core/IO/qFBXIO/src/FBXFilter.cpp
@@ -42,7 +42,8 @@ static const char FBX_SCALE_METADATA_KEY[] = "FBX:ScaleToCM";
 
 FBXFilter::FBXFilter()
     : FileIOFilter( {
-                    "+FBX Filter",
+                    "_FBX Filter",
+                    12.0f,	// priority
                     QStringList{ "fbx" },
                     "fbx",
                     QStringList{ "FBX mesh (*.fbx)" },

--- a/plugins/core/IO/qLASFWFIO/Filter/LASFWFFilter.cpp
+++ b/plugins/core/IO/qLASFWFIO/Filter/LASFWFFilter.cpp
@@ -65,7 +65,8 @@ QSharedPointer<LASSaveDlg> s_saveDlg(0);
 
 LASFWFFilter::LASFWFFilter()
     : FileIOFilter( {
-                    "+LASFW Filter",
+                    "_LASFW Filter",
+                    DEFAULT_PRIORITY,	// priority
                     QStringList{ "las", "laz" },
                     "las",
                     QStringList{ GetFileFilter() },

--- a/plugins/core/IO/qLASFWFIO/Filter/LASFWFFilter.cpp
+++ b/plugins/core/IO/qLASFWFIO/Filter/LASFWFFilter.cpp
@@ -66,7 +66,7 @@ QSharedPointer<LASSaveDlg> s_saveDlg(0);
 LASFWFFilter::LASFWFFilter()
     : FileIOFilter( {
                     "_LASFW Filter",
-                    DEFAULT_PRIORITY,	// priority
+                    3.5f,	// priority
                     QStringList{ "las", "laz" },
                     "las",
                     QStringList{ GetFileFilter() },

--- a/plugins/core/IO/qPDALIO/src/LASFilter.cpp
+++ b/plugins/core/IO/qPDALIO/src/LASFilter.cpp
@@ -109,7 +109,8 @@ public:
 
 LASFilter::LASFilter()
     : FileIOFilter( {
-                    "+PDAL LAS Filter",
+                    "_PDAL LAS Filter",
+                    3.0f,	// priority
                     QStringList{ "las" },
                     "las",
                     QStringList{ "LAS cloud (*.las *.laz)" },

--- a/plugins/core/IO/qPhotoscanIO/src/PhotoScanFilter.cpp
+++ b/plugins/core/IO/qPhotoscanIO/src/PhotoScanFilter.cpp
@@ -385,7 +385,8 @@ static QString CreateTempFile(QuaZip& zip, QString zipFilename)
 
 PhotoScanFilter::PhotoScanFilter()
     : FileIOFilter( {
-                    "+PhotoScan Filter",
+                    "_PhotoScan Filter",
+					DEFAULT_PRIORITY,	// priority
                     QStringList{ "psz" },
                     "psz",
                     QStringList{ "Photoscan project (*.psz)" },

--- a/plugins/core/IO/qPhotoscanIO/src/PhotoScanFilter.cpp
+++ b/plugins/core/IO/qPhotoscanIO/src/PhotoScanFilter.cpp
@@ -386,7 +386,7 @@ static QString CreateTempFile(QuaZip& zip, QString zipFilename)
 PhotoScanFilter::PhotoScanFilter()
     : FileIOFilter( {
                     "_PhotoScan Filter",
-					DEFAULT_PRIORITY,	// priority
+					18.0f,	// priority
                     QStringList{ "psz" },
                     "psz",
                     QStringList{ "Photoscan project (*.psz)" },

--- a/plugins/core/Standard/qPCL/PclIO/PcdFilter.cpp
+++ b/plugins/core/Standard/qPCL/PclIO/PcdFilter.cpp
@@ -42,7 +42,8 @@
 
 PcdFilter::PcdFilter()
     : FileIOFilter( {
-                    "+Point Cloud Library Filter",
+                    "_Point Cloud Library Filter",
+                    DEFAULT_PRIORITY,	// priority
                     QStringList{ "pcd" },
                     "pcd",
                     QStringList{ "Point Cloud Library cloud (*.pcd)" },

--- a/plugins/core/Standard/qPCL/PclIO/PcdFilter.cpp
+++ b/plugins/core/Standard/qPCL/PclIO/PcdFilter.cpp
@@ -43,7 +43,7 @@
 PcdFilter::PcdFilter()
     : FileIOFilter( {
                     "_Point Cloud Library Filter",
-                    DEFAULT_PRIORITY,	// priority
+                    13.0f,	// priority
                     QStringList{ "pcd" },
                     "pcd",
                     QStringList{ "Point Cloud Library cloud (*.pcd)" },

--- a/plugins/example/ExampleIOPlugin/src/FooFilter.cpp
+++ b/plugins/example/ExampleIOPlugin/src/FooFilter.cpp
@@ -20,15 +20,16 @@
 #include "FooFilter.h"
 
 
-FooFilter::FooFilter() :
-	FileIOFilter( {
-				  "Foo Filter",
-				  QStringList{ "foo", "txt" },
-				  "foo",
-				  QStringList{ "Foo file (*.foo)", "Text file (*.txt)" },
-				  QStringList(),
-				  Import
-				  } )
+FooFilter::FooFilter()
+	: FileIOFilter( {
+					"Foo Filter",
+					DEFAULT_PRIORITY,	// priority
+					QStringList{ "foo", "txt" },
+					"foo",
+					QStringList{ "Foo file (*.foo)", "Text file (*.txt)" },
+					QStringList(),
+					Import
+					} )
 {
 }
 


### PR DESCRIPTION
The order of the menu items used to be determined by the order FileIOFilters were registered. This meant that plugins couldn't set the order and items would end up in different places depending on the plugin load order. This order is now controlled by the priority so it is deterministic.

- any items with the same priority will be sorted by id
- also changed plugin-based filter ids from "+" to "_"

The order of the menu items should now be the same as it was before I started messing with FileIOFilters.