### PR TITLE
Remove problematic disconnect in ccSectionExtractionTool

### DIFF
--- a/qCC/ccSectionExtractionTool.cpp
+++ b/qCC/ccSectionExtractionTool.cpp
@@ -162,8 +162,6 @@ bool ccSectionExtractionTool::linkWith(ccGLWindow* win)
 
 	if (oldWin)
 	{
-		m_associatedWin->disconnect(this);
-
 		//restore sections original display
 		{
 			for (SectionPool::iterator it = m_sections.begin(); it != m_sections.end(); ++it)


### PR DESCRIPTION
In _ccSectionExtractionTool::linkWith()_:

1) If the parameter "win" is nullptr, then _ccOverlayDialog::linkWith()_ will set m_associatedWin to nullptr which we dereference

2) If it isn't, then we are disconnecting "win" because m_associatedWin is assigned it (or equal to it) in _ccOverlayDialog::linkWith()_

3) It should probably have read `oldWin->disconnect( this )`, but this case is handled in _ccOverlayDialog::linkWith()_