### PR TITLE
Fix operator precedence

### DIFF
--- a/libs/qCC_db/ccGenericMesh.cpp
+++ b/libs/qCC_db/ccGenericMesh.cpp
@@ -1049,7 +1049,7 @@ bool ccGenericMesh::computePointPosition(unsigned triIndex, const CCVector2d& uv
 	getTriangleVertices(triIndex, A, B, C);
 
 	double z = 1.0 - uv.x - uv.y;
-	if (warningIfOutside && z < -1.0e-6 || z > 1.0 + 1.0e-6)
+	if (warningIfOutside && ((z < -1.0e-6) || (z > 1.0 + 1.0e-6)))
 	{
 		ccLog::Warning("Point falls outside of the triangle");
 	}


### PR DESCRIPTION
```c++
(warningIfOutside && z < -1.0e-6 || z > 1.0 + 1.0e-6)
```

is parsed as:
```c++
((warningIfOutside && z < -1.0e-6) || z > 1.0 + 1.0e-6)
```
since `&&` has a higher precedence than `||`. I don't think this is the intent.

It's always best to include parentheses to avoid this problem - and as a bonus it makes it more human-compatible!