### PR TITLE
check the size m_pointsVisibility instead of capacity

### DIFF
--- a/libs/qCC_db/ccPointCloud.cpp
+++ b/libs/qCC_db/ccPointCloud.cpp
@@ -2717,7 +2717,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 			//if some points are hidden (= visibility table instantiated), we can't use display arrays :(
 			if (isVisibilityTableInstantiated())
 			{
-				assert(m_pointsVisibility.capacity() == m_points.size());
+				assert(m_pointsVisibility.size() == m_points.size());
 				//compressed normals set
 				const ccNormalVectors* compressedNormals = ccNormalVectors::GetUniqueInstance();
 				assert(compressedNormals);


### PR DESCRIPTION
I think the m_pointsVisibility should be checked by size rather than capacity since I didn't see any function like shrink_to_fit called. When we segment the segmented point cloud again (i.e. click segment button at “xx - Cloud.remained”), this assert triggered!