### PR TITLE
{plugins} Save IID in ccDefaultPluginInterface

### DIFF
--- a/plugins/ccDefaultPluginInterface.cpp
+++ b/plugins/ccDefaultPluginInterface.cpp
@@ -73,6 +73,7 @@ public:
 		return list;
 	}
 	
+	QString	m_IID;
 	QJsonDocument	doc;
 };
 
@@ -112,6 +113,11 @@ ccDefaultPluginInterface::~ccDefaultPluginInterface()
 	delete m_data;
 }
 
+const QString &ccDefaultPluginInterface::IID() const
+{
+	return m_data->m_IID;
+}
+
 bool ccDefaultPluginInterface::isCore() const
 {	
 	return m_data->doc.object().value( "core" ).toBool();
@@ -145,4 +151,9 @@ ccPluginInterface::ContactList ccDefaultPluginInterface::getAuthors() const
 ccPluginInterface::ContactList ccDefaultPluginInterface::getMaintainers() const
 {
 	return m_data->contacts( "maintainers" );
+}
+
+void ccDefaultPluginInterface::setIID(const QString &iid)
+{
+	m_data->m_IID = iid;
 }

--- a/plugins/ccDefaultPluginInterface.h
+++ b/plugins/ccDefaultPluginInterface.h
@@ -29,10 +29,8 @@ class ccDefaultPluginData;
 class ccDefaultPluginInterface : public ccPluginInterface
 {
 public:
-	ccDefaultPluginInterface( const QString &resourcePath = QString() );
-
 	~ccDefaultPluginInterface() override;
-	
+		
 	bool isCore() const override;
 
 	QString getName() const override;
@@ -43,8 +41,14 @@ public:
 	ReferenceList getReferences() const override;
 	ContactList getAuthors() const override;
 	ContactList getMaintainers() const override;
+
+protected:
+	ccDefaultPluginInterface( const QString &resourcePath = QString() );
 	
 private:
+	void setIID( const QString& iid ) override;
+	const QString& IID() const override;
+		
 	ccDefaultPluginData	*m_data;
 };
 

--- a/plugins/ccPluginInterface.h
+++ b/plugins/ccPluginInterface.h
@@ -67,7 +67,7 @@ public:
 public:
 	//! Virtual destructor
 	virtual ~ccPluginInterface() = default;
-
+	
 	//! Returns plugin type (standard or OpenGL filter)
 	virtual CC_PLUGIN_TYPE getType() const = 0;
 
@@ -130,6 +130,16 @@ public:
 			(use a unique prefix for all commands if possible)
 	**/
 	virtual void registerCommands(ccCommandLineInterface* cmd) { Q_UNUSED( cmd ); }
+	
+protected:	
+	friend class ccPluginManager;
+
+	//! Set the IID of the plugin (which comes from Q_PLUGIN_METADATA).
+	//! It is used to uniquely identify the plugin.
+	virtual void setIID( const QString& iid ) = 0;
+	
+	//! Get the IID of the plugin.
+	virtual const QString& IID() const = 0;
 };
 
 Q_DECLARE_METATYPE(const ccPluginInterface *);


### PR DESCRIPTION
Set up so plugin manager can save and access the IID from the QPluginLoader as part of the ccPluginInterface.

The IID is going to be used to track which plugins are disabled.