### PR TITLE
Track if we are running on the command line in ccApplicationBase

### DIFF
--- a/ccViewer/ccViewerApplication.cpp
+++ b/ccViewer/ccViewerApplication.cpp
@@ -25,8 +25,8 @@
 #include "ccViewerApplication.h"
 
 
-ccViewerApplication::ccViewerApplication(int &argc, char **argv)
-	: ccApplicationBase( argc, argv, QStringLiteral( "1.38" ) )
+ccViewerApplication::ccViewerApplication( int &argc, char **argv, bool isCommandLine )
+	: ccApplicationBase( argc, argv, isCommandLine, QStringLiteral( "1.38" ) )
 {
 	setApplicationName( "CloudCompareViewer" );
 }

--- a/ccViewer/ccViewerApplication.h
+++ b/ccViewer/ccViewerApplication.h
@@ -28,7 +28,7 @@ class ccViewerApplication : public ccApplicationBase
 	Q_OBJECT
 	
 public:
-	ccViewerApplication( int &argc, char **argv );
+	ccViewerApplication( int &argc, char **argv, bool isCommandLine );
 
 	void  setViewer( ccViewer *inViewer );
 	

--- a/ccViewer/main.cpp
+++ b/ccViewer/main.cpp
@@ -44,9 +44,9 @@
 
 int main(int argc, char *argv[])
 {
-	ccViewerApplication::init(false);
+	ccViewerApplication::initOpenGL();
 	
-	ccViewerApplication a(argc, argv);
+	ccViewerApplication a(argc, argv, false);
 
 #ifdef USE_VLD
 	VLDEnable();

--- a/common/ccApplicationBase.cpp
+++ b/common/ccApplicationBase.cpp
@@ -45,47 +45,45 @@
 #endif
 
 
-void ccApplicationBase::init(bool noOpenGLSupport)
+void ccApplicationBase::initOpenGL()
 {
-	if (!noOpenGLSupport)
+	//See http://doc.qt.io/qt-5/qopenglwidget.html#opengl-function-calls-headers-and-qopenglfunctions
+	/** Calling QSurfaceFormat::setDefaultFormat() before constructing the QApplication instance is mandatory
+		on some platforms (for example, OS X) when an OpenGL core profile context is requested. This is to
+		ensure that resource sharing between contexts stays functional as all internal contexts are created
+		using the correct version and profile.
+	**/
 	{
-		//See http://doc.qt.io/qt-5/qopenglwidget.html#opengl-function-calls-headers-and-qopenglfunctions
-		/** Calling QSurfaceFormat::setDefaultFormat() before constructing the QApplication instance is mandatory
-			on some platforms (for example, OS X) when an OpenGL core profile context is requested. This is to
-			ensure that resource sharing between contexts stays functional as all internal contexts are created
-			using the correct version and profile.
-		**/
-		{
-			QSurfaceFormat format = QSurfaceFormat::defaultFormat();
+		QSurfaceFormat format = QSurfaceFormat::defaultFormat();
 
-			format.setSwapBehavior(QSurfaceFormat::DoubleBuffer);
-			format.setStencilBufferSize(0);
+		format.setSwapBehavior(QSurfaceFormat::DoubleBuffer);
+		format.setStencilBufferSize(0);
 
 #ifdef CC_GL_WINDOW_USE_QWINDOW
-			format.setStereo(true);
+		format.setStereo(true);
 #endif
 
 #ifdef Q_OS_MAC
-			format.setVersion(2, 1);	// must be 2.1 - see ccGLWindow::functions()
-			format.setProfile(QSurfaceFormat::CoreProfile);
+		format.setVersion(2, 1);	// must be 2.1 - see ccGLWindow::functions()
+		format.setProfile(QSurfaceFormat::CoreProfile);
 #endif
 
 #ifdef QT_DEBUG
-			format.setOption(QSurfaceFormat::DebugContext, true);
+		format.setOption(QSurfaceFormat::DebugContext, true);
 #endif
 
-			QSurfaceFormat::setDefaultFormat(format);
-		}
-
-		// The 'AA_ShareOpenGLContexts' attribute must be defined BEFORE the creation of the Q(Gui)Application
-		// DGM: this is mandatory to enable exclusive full screen for ccGLWidget (at least on Windows)
-		QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+		QSurfaceFormat::setDefaultFormat(format);
 	}
+
+	// The 'AA_ShareOpenGLContexts' attribute must be defined BEFORE the creation of the Q(Gui)Application
+	// DGM: this is mandatory to enable exclusive full screen for ccGLWidget (at least on Windows)
+	QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
 }
 
-ccApplicationBase::ccApplicationBase(int &argc, char **argv, const QString &version)
+ccApplicationBase::ccApplicationBase(int &argc, char **argv, bool isCommandLine, const QString &version)
     : QApplication( argc, argv )
     , c_VersionStr( version )
+	, c_CommandLine( isCommandLine )
 {
 	setOrganizationName( "CCCorp" );
 

--- a/common/ccApplicationBase.h
+++ b/common/ccApplicationBase.h
@@ -29,9 +29,11 @@ class ccApplicationBase : public QApplication
 public:
 	//! This must be called before instantiating the application class so it
 	//! can setup OpenGL first.
-	static void	init(bool noOpenGLSupport);
+	static void	initOpenGL();
 	
-	ccApplicationBase( int &argc, char **argv, const QString &version );
+	ccApplicationBase( int &argc, char **argv, bool isCommandLine, const QString &version );
+	
+	bool isCommandLine() const { return c_CommandLine; }
 	
 	QString versionStr() const;
 	QString versionLongStr( bool includeOS ) const;
@@ -46,6 +48,8 @@ private:
 	QString	m_ShaderPath;
 	QString	m_TranslationPath;
 	QStringList m_PluginPaths;
+	
+	const bool c_CommandLine;
 };
 
 #endif

--- a/qCC/ccApplication.cpp
+++ b/qCC/ccApplication.cpp
@@ -27,8 +27,8 @@
 #include "ccApplication.h"
 #include "mainwindow.h"
 
-ccApplication::ccApplication(int &argc, char **argv)
-	: ccApplicationBase( argc, argv, QStringLiteral( "2.11 alpha (Anoia)" ) )
+ccApplication::ccApplication( int &argc, char **argv, bool isCommandLine )
+	: ccApplicationBase( argc, argv, isCommandLine, QStringLiteral( "2.11 alpha (Anoia)" ) )
 {
 	setApplicationName( "CloudCompare" );
 	

--- a/qCC/ccApplication.h
+++ b/qCC/ccApplication.h
@@ -26,7 +26,7 @@ class ccApplication : public ccApplicationBase
 	Q_OBJECT
 
 public:
-	ccApplication( int &argc, char **argv );
+	ccApplication( int &argc, char **argv, bool isCommandLine );
 	
 protected:
 	bool event( QEvent *inEvent ) override;

--- a/qCC/main.cpp
+++ b/qCC/main.cpp
@@ -64,9 +64,12 @@ int main(int argc, char **argv)
 	bool commandLine = (argc > 1) && (argv[1][0] == '-');
 #endif
    
-	ccApplication::init(commandLine);
+	if ( !commandLine )
+	{
+		ccApplication::initOpenGL();
+	}
 	
-	ccApplication app(argc, argv);
+	ccApplication app(argc, argv, commandLine);
 
 	//store the log message until a valid logging instance is registered
 	ccLog::EnableMessageBackup(true);


### PR DESCRIPTION
The plugin manager is going to need to know if we are running on the command line so we don't disable plugins in that case. Otherwise the user would need to run the GUI to enable/disable them.

Also rename `ccApplicationBase::init()` to `ccApplicationBase::initOpenGL()` to better reflect what it's doing and to remove inverted "!noOpenGLSupport" logic.