### PR TITLE
{plugins} Add a way to track disabled plugins and skip them on load

### DIFF
--- a/common/ccPluginManager.h
+++ b/common/ccPluginManager.h
@@ -43,11 +43,16 @@ public:
 	
 	ccPluginInterfaceList& pluginList();
 	
+	void setPluginEnabled( const ccPluginInterface* plugin, bool enabled );
+	bool isEnabled( const ccPluginInterface* plugin ) const;
+	
 protected:
 	explicit ccPluginManager( QObject* parent = nullptr );
 
 private:
 	void loadFromPathsAndAddToList();
+	
+	QStringList disabledPluginIIDs() const;
 	
 	QStringList m_pluginPaths;
 	ccPluginInterfaceList m_pluginList;

--- a/qCC/pluginManager/ccPluginUIManager.cpp
+++ b/qCC/pluginManager/ccPluginUIManager.cpp
@@ -72,6 +72,13 @@ void ccPluginUIManager::init()
 			continue;
 		}
 		
+		if ( !ccPluginManager::get().isEnabled( plugin ) )
+		{
+			m_plugins.push_back( plugin );
+			
+			continue;	
+		}
+		
 		const QString pluginName = plugin->getName();
 		
 		Q_ASSERT( !pluginName.isEmpty() );


### PR DESCRIPTION
Store a list of disabled plugin IIDs in the preferences and check it before activating them.