### PR TITLE
Ensure that RPATH is absolute

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,10 +28,8 @@ set( INSTALL_DESTINATIONS CloudCompare )
 # RPATH Linux/Unix: (dynamic) libs are put in a subdir of prefix/lib,
 # since they are only used by qCC/ccViewer
 if( UNIX AND NOT APPLE )
-	if( NOT CMAKE_INSTALL_LIBDIR )
-		set( CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib CACHE PATH "CloudCompare lib dir" )
-	endif( NOT CMAKE_INSTALL_LIBDIR )
-	set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}/cloudcompare")
+	include( GNUInstallDirs )
+	set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}/cloudcompare")
 endif()
 
 # CCViewer


### PR DESCRIPTION
GNUInstallDirs provides a default value for CMAKE_INSTALL_LIBDIR
and allows a user to override it as either absolute or relative
(eg. -DCMAKE_INSTALL_LIBDIR=/usr/lib64 or -DCMAKE_INSTALL_LIBDIR=lib64).
CMAKE_INSTALL_FULL_LIBDIR is the absolute calculated from it.

This popped up in Debian [#928986](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=928986): the RPATH incorrectly being a relative path caused libQCC_IO_LIB.so not to be found.