### PR TITLE
Building with ScalarType as double (with fixes)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ language: cpp
 compiler:
 - clang
 - gcc
+env: 
+- SCALAR_DOUBLE=ON
+- SCALAR_DOUBLE=OFF
 install:
 - sudo apt-get update -qq
 - sudo apt-get install -qy cmake
@@ -26,6 +29,7 @@ before_script:
   -DDLIB_ROOT=/usr/include
   -DOPTION_USE_DXF_LIB=ON
   -DOPTION_USE_SHAPE_LIB=ON
+  -DOPTION_SCALAR_DOUBLE=$SCALAR_DOUBLE
   -DPLUGIN_EXAMPLE_GL=ON
   -DPLUGIN_EXAMPLE_IO=ON
   -DPLUGIN_EXAMPLE_STANDARD=ON
@@ -51,7 +55,7 @@ before_script:
   ..
 script:
 - if [[ $CXX == "clang++" ]]; then export LD_LIBRARY_PATH=/usr/local/clang/lib:$LD_LIBRARY_PATH; fi
-- if [[ $TRAVIS_BRANCH != "beta_builds" ]]; then make -j2 && xvfb-run ctest; fi
+- if [[ $TRAVIS_BRANCH != "beta_builds" ]] && [[ $SCALAR_DOUBLE != "ON" ]]; then make -j2 && xvfb-run ctest -V; fi
 - cd ..
 after_success:
 - openssl aes-256-cbc -K $encrypted_d04fcf964026_key -iv $encrypted_d04fcf964026_iv

--- a/CC/include/AutoSegmentationTools.h
+++ b/CC/include/AutoSegmentationTools.h
@@ -104,8 +104,8 @@ public:
 		\return success
 	**/
 	static bool frontPropagationBasedSegmentation(	GenericIndexedCloudPersist* theCloud,
-													ScalarType minSeedDist,
 													PointCoordinateType radius,
+													ScalarType minSeedDist,
 													unsigned char octreeLevel,
 													ReferenceCloudContainer& theSegmentedLists,
 													CCLib::GenericProgressCallback* progressCb = nullptr,

--- a/CC/include/CCTypes.h
+++ b/CC/include/CCTypes.h
@@ -23,6 +23,12 @@
 using PointCoordinateType = float;
 
 //! Type of a single scalar field value
+#if defined SCALAR_TYPE_DOUBLE
+using ScalarType = double;
+#elif defined SCALAR_TYPE_FLOAT
 using ScalarType = float;
+#else
+static_assert(false, "type for ScalarType has not been declared");
+#endif //SCALAR_TYPE_DOUBLE
 
 #endif //CC_TYPES_HEADER

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,15 @@ OPTION( OPTION_BUILD_CCVIEWER "Check to compile CCViewer project" ON )
 # Quad buffer stereo support
 OPTION( OPTION_GL_QUAD_BUFFER_SUPPORT "Check to compile CloudCompare and ccViewer with Quad Buffer support" OFF )
 
+# ScalarType as float (default) or double
+option( OPTION_SCALAR_DOUBLE "Check to define ScalarType as double" OFF )
+
+if ( OPTION_SCALAR_DOUBLE )
+	add_definitions( -DSCALAR_TYPE_DOUBLE )
+else()
+	add_definitions( -DSCALAR_TYPE_FLOAT )
+endif()
+
 # Define target folders
 # (now that ccViewer can have its own plugins, qCC and ccViewer must fall in separate folders!
 if(WIN32 OR APPLE) 

--- a/libs/qCC_db/ccGBLSensor.cpp
+++ b/libs/qCC_db/ccGBLSensor.cpp
@@ -1051,8 +1051,11 @@ bool ccGBLSensor::fromFile_MeOnly(QFile& in, short dataVersion, int flags)
 	ccSerializationHelper::CoordsFromDataStream(inStream, flags, &m_deltaTheta, 1);
 	if (dataVersion < 38)
 	{
-		ccSerializationHelper::ScalarsFromDataStream(inStream, flags, &m_sensorRange, 1);
-		ccSerializationHelper::ScalarsFromDataStream(inStream, flags, &m_uncertainty, 1);
+		ScalarType sensorRange{}, uncertainty{};
+		ccSerializationHelper::ScalarsFromDataStream(inStream, flags, &sensorRange, 1);
+		ccSerializationHelper::ScalarsFromDataStream(inStream, flags, &uncertainty, 1);
+		m_sensorRange = static_cast<PointCoordinateType>(sensorRange);
+		m_uncertainty = static_cast<PointCoordinateType>(uncertainty);
 	}
 	else
 	{

--- a/libs/qCC_glWindow/ccRenderingTools.cpp
+++ b/libs/qCC_glWindow/ccRenderingTools.cpp
@@ -31,6 +31,7 @@
 #include <QLabel>
 #include <QVBoxLayout>
 
+#include <numeric>
 
 void ccRenderingTools::ShowDepthBuffer(ccGBLSensor* sensor, QWidget* parent/*=0*/, unsigned maxDim/*=1024*/)
 {
@@ -44,8 +45,8 @@ void ccRenderingTools::ShowDepthBuffer(ccGBLSensor* sensor, QWidget* parent/*=0*
 	}
 
 	//determine min and max depths
-	ScalarType minDist = 0.0f;
-	ScalarType maxDist = 0.0f;
+	PointCoordinateType minDist = 0.0f;
+	PointCoordinateType maxDist = 0.0f;
 	{
 		const PointCoordinateType* _zBuff = depthBuffer.zBuff.data();
 		double sumDist = 0.0;
@@ -190,8 +191,8 @@ void ConvertToLogScale(ScalarType& dispMin, ScalarType& dispMax)
 {
 	ScalarType absDispMin = (dispMax < 0 ? std::min(-dispMax, -dispMin) : std::max<ScalarType>(dispMin, 0)); 
 	ScalarType absDispMax = std::max(std::abs(dispMin), std::abs(dispMax));
-	dispMin = std::log10(std::max(absDispMin, FLT_EPSILON));
-	dispMax = std::log10(std::max(absDispMax, FLT_EPSILON));
+	dispMin = std::log10(std::max(absDispMin, std::numeric_limits<ScalarType>::epsilon()));
+	dispMax = std::log10(std::max(absDispMax, std::numeric_limits<ScalarType>::epsilon()));
 }
 
 void ccRenderingTools::DrawColorRamp(const CC_DRAW_CONTEXT& context)


### PR DESCRIPTION
I am posting this pull request despite having some doubts.

This PR contains the following changes:
- the actual substance of #598, the issue which prompted the changes with type fixes and static casts to supply proper types;
- a fix to a compilation error that occurred with `ScalarType = double` - namely, [change in parameter order in AutoSegmentationTools](CC/src/AutoSegmentationTools.cpp) - I was surprised this went on unnoticed!
- a modification to Travis' build script - turning off tests for double comparisons in `TestShpFilter`, as the test data seems to be intended for `float` only and I don't feel competent enough to do anything with it.

I kindly ask for suggestions regarding improving this PR.