### PR TITLE
GLWindow: handle middle mouse button press, use for zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ v2.11 (Anoia) - (in development)
     - Tools > Registration > Move bounding-box center to origin
     - Tools > Registration > Move bounding-box min corner to origin
     - Tools > Registration > Move bounding-box max corner to origin
+  - Add smooth zoom when middle mouse button is pressed
 
 - Improvements
   - Clipping box tool:

--- a/libs/qCC_glWindow/ccGLWindow.cpp
+++ b/libs/qCC_glWindow/ccGLWindow.cpp
@@ -3846,6 +3846,14 @@ void ccGLWindow::mousePressEvent(QMouseEvent *event)
 			emit leftButtonClicked(event->x(), event->y());
 		}
 	}
+	if (event->buttons() & Qt::MiddleButton)
+	{
+		//middle click = zooming
+		if (m_interactionFlags & INTERACT_SIG_MB_CLICKED)
+		{
+			emit middleButtonClicked(event->x(), event->y());
+		}
+	}
 	else
 	{
 		event->ignore();
@@ -4248,6 +4256,14 @@ void ccGLWindow::mouseMoveEvent(QMouseEvent *event)
 			}
 		}
 	}
+	else if ((event->buttons() & Qt::MiddleButton)) // zoom
+	{
+		//middle button = zooming
+		float pseudo_wheelDelta_deg = static_cast<float>(-dy);
+		onWheelEvent(pseudo_wheelDelta_deg);
+
+		emit mouseWheelRotated(pseudo_wheelDelta_deg);
+	}
 
 	m_mouseMoved = true;
 	m_lastMousePos = event->pos();
@@ -4448,6 +4464,14 @@ void ccGLWindow::mouseReleaseEvent(QMouseEvent *event)
 		}
 
 		m_activeItems.clear();
+	}
+	else if (event->button() == Qt::MiddleButton)
+	{
+		if (mouseHasMoved)
+		{
+			event->accept();
+			toBeRefreshed();
+		}
 	}
 
 	refresh(false);

--- a/libs/qCC_glWindow/ccGLWindow.h
+++ b/libs/qCC_glWindow/ccGLWindow.h
@@ -104,7 +104,8 @@ public:
 		INTERACT_SIG_LB_CLICKED  = 256,      //left button clicked
 		INTERACT_SIG_MOUSE_MOVED = 512,      //mouse moved (only if a button is clicked)
 		INTERACT_SIG_BUTTON_RELEASED = 1024, //mouse button released
-		INTERACT_SEND_ALL_SIGNALS = INTERACT_SIG_RB_CLICKED | INTERACT_SIG_LB_CLICKED | INTERACT_SIG_MOUSE_MOVED | INTERACT_SIG_BUTTON_RELEASED,
+		INTERACT_SIG_MB_CLICKED  = 2048,     //middle button clicked
+		INTERACT_SEND_ALL_SIGNALS = INTERACT_SIG_RB_CLICKED | INTERACT_SIG_LB_CLICKED | INTERACT_SIG_MB_CLICKED| INTERACT_SIG_MOUSE_MOVED | INTERACT_SIG_BUTTON_RELEASED,
 	};
 	Q_DECLARE_FLAGS(INTERACTION_FLAGS, INTERACTION_FLAG)
 
@@ -773,6 +774,13 @@ signals:
 
 	//! Signal emitted when the exclusive fullscreen is toggled
 	void exclusiveFullScreenToggled(bool exclusive);
+
+	//! Signal emitted when the middle mouse button is clicked on the window
+	/** See INTERACT_SIG_MB_CLICKED.
+		Arguments correspond to the clicked point coordinates (x,y) in
+		pixels relative to the window corner!
+	**/
+	void middleButtonClicked(int x, int y);
 
 protected: //rendering
 


### PR DESCRIPTION
- handle the middle mouse button press
- when the middle mouse button is pressed use the delta along the y axis
  to zoom the view (like the mouse wheel)

fixes https://github.com/CloudCompare/CloudCompare/issues/382