### PR TITLE
GLWindow: on Shift+LeftMB roll view instead of free rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v2.11 (Anoia) - (in development)
     - Tools > Registration > Move bounding-box min corner to origin
     - Tools > Registration > Move bounding-box max corner to origin
   - Add smooth zoom when middle mouse button is pressed
+  - Roll view around view-vector when pressing SHIFT and left mouse button
 
 - Improvements
   - Clipping box tool:

--- a/libs/qCC_glWindow/ccGLWindow.cpp
+++ b/libs/qCC_glWindow/ccGLWindow.cpp
@@ -4130,14 +4130,24 @@ void ccGLWindow::mouseMoveEvent(QMouseEvent *event)
 				//case LockedAxisMode:
 				{
 					static CCVector3d s_lastMouseOrientation;
-					if (!m_mouseMoved)
-					{
-						//on the first time, we must compute the previous orientation (the camera hasn't moved yet)
-						s_lastMouseOrientation = convertMousePositionToOrientation(m_lastMousePos.x(), m_lastMousePos.y());
-					}
-
 					CCVector3d currentMouseOrientation = convertMousePositionToOrientation(x, y);
-					rotMat = ccGLMatrixd::FromToRotation(s_lastMouseOrientation, currentMouseOrientation);
+
+					if (QApplication::keyboardModifiers() & Qt::ShiftModifier)
+					{
+						//rotate around the current viewport (roll camera)
+						double angle_rad = 2.0 * M_PI * dx/width();
+						rotMat.initFromParameters(angle_rad, CCVector3d(0, 0, 1), CCVector3d(0, 0, 0));
+					}
+					else
+					{
+						if (!m_mouseMoved)
+						{
+							//on the first time, we must compute the previous orientation (the camera hasn't moved yet)
+							s_lastMouseOrientation = convertMousePositionToOrientation(m_lastMousePos.x(), m_lastMousePos.y());
+						}
+						// unconstrained rotation following mouse position
+						rotMat = ccGLMatrixd::FromToRotation(s_lastMouseOrientation, currentMouseOrientation);
+					}
 
 					//if (rotationMode == LockedAxisMode)
 					//{


### PR DESCRIPTION
fixes: https://github.com/CloudCompare/CloudCompare/issues/54