### PR TITLE
riegl: add rdbio plugin

### DIFF
--- a/plugins/3rdParty/qRDBIO/CMakeLists.txt
+++ b/plugins/3rdParty/qRDBIO/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.0)
+
+option( PLUGIN_IO_QRDB "Check to install RDB 2 I/O plugin" OFF )
+
+# CloudCompare RDB 2 I/O plugin
+if (PLUGIN_IO_QRDB)
+	project( QRDB_IO_PLUGIN )
+
+	# find rdb
+	# if not defined globally define path to rdb-config.cmake by settin the
+	# cmake variable rdb_DIR
+	find_package(rdb REQUIRED)
+
+	# Set to include this I/O plugin in ccViewer
+	set( CC_IS_IO_PLUGIN 1 )
+
+	include( ../../CMakePluginTpl.cmake )
+	target_link_libraries(${PROJECT_NAME} rdbcpp)
+endif()

--- a/plugins/3rdParty/qRDBIO/RDBFilter.cpp
+++ b/plugins/3rdParty/qRDBIO/RDBFilter.cpp
@@ -1,0 +1,549 @@
+//##########################################################################
+//#                                                                        #
+//#                       CLOUDCOMPARE PLUGIN: qRDBIO                      #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 of the License.               #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#          COPYRIGHT: RIEGL Laser Measurement Systems GmbH               #
+//#                                                                        #
+//##########################################################################
+
+#include "RDBFilter.h"
+
+//Local
+#include "RDBOpenDialog.h"
+
+//Qt
+#include <QFile>
+#include <QFileInfo>
+#include <QTextStream>
+#include <QIcon>
+#include <QComboBox>
+
+//CClib
+#include <ScalarField.h>
+
+//qCC_db
+#include <ccPlane.h>
+#include <ccPointCloud.h>
+#include <ccProgressDialog.h>
+#include <ccMesh.h>
+#include <ccHObject.h>
+#include <ccMaterial.h>
+#include <ccMaterialSet.h>
+#include <ccLog.h>
+#include <ccScalarField.h>
+
+//RDB
+#include <riegl/rdb.hpp>
+
+//System
+#include <string.h>
+#include <assert.h>
+#include <sstream>
+#include <array>
+
+
+RDBFilter::RDBFilter()
+	: FileIOFilter( {
+					"RDB 2.0 Filter",
+					DEFAULT_PRIORITY,	//priority
+					QStringList{ "rdbx", "vxls", "ptch", "mtch" },
+					"RDB2",
+					QStringList{ "RDB Pointcloud file (*.rdbx)",
+						"RDB Voxelfile (*.vxls)",
+						"RDB Plane Patch file (*.ptch)",
+						"RDB Match file (*.mtch)" },
+					QStringList(),
+					Import
+					} )
+{
+}
+
+namespace //local helper
+{
+
+void updateTable(RDBOpenDialog &openDlg, riegl::rdb::Pointcloud &rdb)
+{
+	static const QIcon xIcon		(QString::fromUtf8(":/CC/images/typeXCoordinate.png"));
+	static const QIcon yIcon		(QString::fromUtf8(":/CC/images/typeYCoordinate.png"));
+	static const QIcon zIcon		(QString::fromUtf8(":/CC/images/typeZCoordinate.png"));
+	static const QIcon NormIcon		(QString::fromUtf8(":/CC/images/typeNormal.png"));
+	static const QIcon RGBIcon		(QString::fromUtf8(":/CC/images/typeRgbCcolor.png"));
+	static const QIcon GreyIcon		(QString::fromUtf8(":/CC/images/typeGrayColor.png"));
+	static const QIcon ScalarIcon	(QString::fromUtf8(":/CC/images/typeSF.png"));
+
+	//checks if fields are available
+	bool rdb_hasRGBA = false;
+	bool rdb_hasNormals = false;
+	bool rdb_has_pca_axis_min = false;
+
+	{
+		int idx = 0;
+		//Get list of point attributes
+		std::vector<std::string> attributes = rdb.pointAttribute().list();
+		openDlg.rdbTableWidget->setColumnCount(2);
+		openDlg.rdbTableWidget->setRowCount(attributes.size());
+		openDlg.rdbTableWidget->setColumnWidth(0,200);
+		openDlg.rdbTableWidget->setEditTriggers(QAbstractItemView::NoEditTriggers);
+
+		QStringList headerLabels;
+		headerLabels << "Name" << "Load as";
+		openDlg.rdbTableWidget->setHorizontalHeaderLabels(headerLabels);
+
+		ccLog::Print(QString("set row count to: %1").arg(attributes.size()));
+
+		//check for existance of attribute and add it to qList
+		auto list_known_attribute = [] (RDBOpenDialog &openDlg,
+				int &idx, std::vector<std::string> &attributes, const char *att, bool &rdb_has_flag)
+		{
+			if (std::find(attributes.begin(),attributes.end(), att) != attributes.end())
+			{
+				rdb_has_flag = true;
+				openDlg.rdbTableWidget->setItem(idx, 0, new QTableWidgetItem(att));
+				//openDlg.rdbTableWidget->cellWidget(idx,0)->setEnabled(false);
+				idx++;
+				attributes.erase(std::remove(attributes.begin(), attributes.end(), att), attributes.end());
+			}
+		};
+		auto add_qcombobox_scalar = [] (RDBOpenDialog &openDlg,
+				int &idx, std::vector<std::string> &attributes, const std::string &att, bool active)
+		{
+			if (std::find(attributes.begin(),attributes.end(), att) != attributes.end())
+			{
+				openDlg.rdbTableWidget->setItem(idx, 0, new QTableWidgetItem(att.c_str()));
+				//openDlg.rdbTableWidget->cellWidget(idx,0)->setEnabled(false);
+				attributes.erase(std::remove(attributes.begin(), attributes.end(), att), attributes.end());
+
+				QComboBox* columnHeaderWidget = new QComboBox();
+				columnHeaderWidget->addItem(RDB_OPEN_DLG_TYPES_NAMES[RDB_OPEN_DLG_None]);
+				columnHeaderWidget->addItem(RDB_OPEN_DLG_TYPES_NAMES[RDB_OPEN_DLG_Scalar]);
+				columnHeaderWidget->setMaxVisibleItems(2);
+				columnHeaderWidget->setItemIcon(1, ScalarIcon);
+				if (active)
+					columnHeaderWidget->setCurrentIndex(1);
+				else
+					columnHeaderWidget->setCurrentIndex(0);
+
+				openDlg.rdbTableWidget->setCellWidget(idx,1, columnHeaderWidget);
+				idx++;
+			}
+		};
+
+		bool dummy = false;
+
+		list_known_attribute(openDlg, idx, attributes, "riegl.xyz",           dummy);
+		list_known_attribute(openDlg, idx, attributes, "riegl.rgba",          rdb_hasRGBA);
+		list_known_attribute(openDlg, idx, attributes, "riegl.surface_normal",rdb_hasNormals);
+		list_known_attribute(openDlg, idx, attributes, "riegl.pca_axis_min",  rdb_has_pca_axis_min);
+
+		idx = 0;
+		{ //XYZ
+			QComboBox* columnHeaderWidget = new QComboBox();
+			columnHeaderWidget->addItem(RDB_OPEN_DLG_TYPES_NAMES[RDB_OPEN_DLG_XYZ]);
+			columnHeaderWidget->setMaxVisibleItems(1);
+			columnHeaderWidget->setCurrentIndex(0);
+			columnHeaderWidget->setItemIcon(0, xIcon);
+			openDlg.rdbTableWidget->setCellWidget(idx,1, columnHeaderWidget);
+			idx++;
+		}
+		if (rdb_hasRGBA)
+		{ //RGB
+			QComboBox* columnHeaderWidget = new QComboBox();
+			columnHeaderWidget->addItem(RDB_OPEN_DLG_TYPES_NAMES[RDB_OPEN_DLG_RGB]);
+			columnHeaderWidget->setMaxVisibleItems(1);
+			columnHeaderWidget->setCurrentIndex(0);
+			columnHeaderWidget->setItemIcon(0, RGBIcon);
+			openDlg.rdbTableWidget->setCellWidget(idx,1, columnHeaderWidget);
+			idx++;
+		}
+		if (rdb_hasNormals)
+		{ //normals
+			QComboBox* columnHeaderWidget = new QComboBox();
+			columnHeaderWidget->addItem(RDB_OPEN_DLG_TYPES_NAMES[RDB_OPEN_DLG_NORM]);
+			columnHeaderWidget->setMaxVisibleItems(1);
+			columnHeaderWidget->setCurrentIndex(0);
+			columnHeaderWidget->setItemIcon(0, NormIcon);
+			openDlg.rdbTableWidget->setCellWidget(idx,1, columnHeaderWidget);
+			idx++;
+		}
+		if (rdb_has_pca_axis_min)
+		{ //normals
+			QComboBox* columnHeaderWidget = new QComboBox();
+			columnHeaderWidget->addItem(RDB_OPEN_DLG_TYPES_NAMES[RDB_OPEN_DLG_NORM]);
+			columnHeaderWidget->setMaxVisibleItems(1);
+			columnHeaderWidget->setCurrentIndex(0);
+			columnHeaderWidget->setItemIcon(0, NormIcon);
+			openDlg.rdbTableWidget->setCellWidget(idx,1, columnHeaderWidget);
+			idx++;
+		}
+		add_qcombobox_scalar(openDlg, idx, attributes, "riegl.id",            false);
+		add_qcombobox_scalar(openDlg, idx, attributes, "riegl.reflectance",   true);
+		add_qcombobox_scalar(openDlg, idx, attributes, "riegl.amplitude",     true);
+		add_qcombobox_scalar(openDlg, idx, attributes, "riegl.deviation",     true);
+
+		ccLog::Print(QString("unknown attributes: %1").arg(attributes.size()));
+		//openDlg.rdbAttributesList->insertItem(idx, "--- unknown attributes ---");
+		std::vector<std::string> attr_copy(attributes);
+		for (std::string &att : attr_copy)
+		{
+			add_qcombobox_scalar(openDlg, idx, attributes, att, false);
+		}
+	}
+}
+
+} //end namespace local helper
+
+
+CC_FILE_ERROR RDBFilter::loadFile( const QString &filename, ccHObject &container, LoadParameters &parameters )
+{	
+	RDBOpenDialog openDlg(nullptr);
+
+	//New RDB library context
+	riegl::rdb::Context context;
+
+	//check for known rdb vector attributes
+	bool rdb_hasRGBA = false;
+	bool rdb_hasNormals = false;
+	bool rdb_has_pca_axis_min = false;
+
+	//needed for plane patch
+	//bool rdb_hasNormals = false;
+	bool rdb_has_plane_up     = false;
+	bool rdb_has_plane_width  = false;
+	bool rdb_has_plane_height = false;
+
+	{
+		//Access existing database
+		riegl::rdb::Pointcloud rdb(context);
+		riegl::rdb::pointcloud::OpenSettings settings(context);
+		rdb.open(filename.toStdString(), settings);
+
+		//Fill the table with attributes
+		updateTable(openDlg, rdb);
+
+		//Get index graph root node
+		riegl::rdb::pointcloud::QueryStat stat = rdb.stat();
+		riegl::rdb::pointcloud::GraphNode root = stat.index();
+		openDlg.rdbPointsNumber->setText(QString("%1").arg(root.pointCountTotal));
+
+		{
+			//Get list of point attributes
+			std::vector<std::string> attributes = rdb.pointAttribute().list();
+
+			//check for existance of specific rdb attribute
+			auto listContains = [] (std::vector<std::string> &attributes, const char *att)
+			{
+				return std::find(attributes.begin(),attributes.end(), att) != attributes.end();
+			};
+
+			rdb_hasRGBA         = listContains(attributes, "riegl.rgba"          );
+			rdb_hasNormals      = listContains(attributes, "riegl.surface_normal");
+			rdb_has_pca_axis_min= listContains(attributes, "riegl.pca_axis_min"  );
+			rdb_has_plane_up    = listContains(attributes, "riegl.plane_up"      );
+			rdb_has_plane_width = listContains(attributes, "riegl.plane_width"   );
+			rdb_has_plane_height= listContains(attributes, "riegl.plane_height"  );
+
+			if (rdb_hasNormals && rdb_has_pca_axis_min)
+			{
+				//prefer plane normals
+				rdb_has_pca_axis_min = false;
+			}
+		}
+	}
+
+	//open dialog and wait for user to configure
+	if (!openDlg.exec())
+	{
+		return CC_FERR_CANCELED_BY_USER;
+	}
+
+	//define needed parameter for scalar fields
+	struct Conversion
+	{
+		//name of the attribute
+		std::string att;
+		//pointer to scalar field
+		ccScalarField *sf;
+		//buffer for rdb select
+		std::vector<float> buffer;
+	};
+
+	//Load the file
+	const size_t BUFFER_SIZE = 100000;
+	size_t total = 0;
+
+	//point cloud from CC to fill with points from rdb file
+	ccPointCloud* cloud = new ccPointCloud();
+	CC_FILE_ERROR result = CC_FERR_NO_ERROR;
+	//if plane patch attributes are present create plane patch objects
+	bool create_planes = false;
+	ccHObject *plane_set = nullptr;
+	if (rdb_hasNormals && rdb_has_plane_up && rdb_has_plane_width && rdb_has_plane_height)
+	{
+		create_planes = true;
+		cloud->setName("Plane Centers");
+		plane_set = new ccHObject();
+	}
+
+	//create a list of the scalars
+	std::vector<std::string> scalars2load;
+	for (int i=0; i<openDlg.rdbTableWidget->rowCount(); ++i)
+	{
+		QComboBox* cbox = static_cast<QComboBox*>(openDlg.rdbTableWidget->cellWidget(i, 1));
+		if (cbox->currentText() == RDB_OPEN_DLG_TYPES_NAMES[RDB_OPEN_DLG_Scalar])
+		{
+			QString att = openDlg.rdbTableWidget->item(i,0)->text();
+			scalars2load.push_back(att.toStdString());
+			ccLog::Print(QString("load scalar: %1").arg(att));
+		}
+	}
+
+	//initialize scalar fields and rdb buffers
+	std::vector<Conversion> conversions;
+	for (std::string &att : scalars2load)
+	{
+		Conversion conv;
+		conv.att = att;
+		conv.sf = new ccScalarField(att.c_str());
+		conv.sf->link();
+		conv.buffer.resize(BUFFER_SIZE);
+		cloud->addScalarField(conv.sf);
+		conversions.push_back(conv);
+	}
+
+	//if there are rgb values load and show them
+	if (rdb_hasRGBA)
+	{
+		cloud->showColors(true);
+	}
+	//if there are surface normals load and show them
+	if (rdb_hasNormals || rdb_has_pca_axis_min)
+	{
+		cloud->showNormals(true);
+	}
+	if (conversions.size() > 0)
+	{
+		cloud->setCurrentDisplayedScalarField(0);
+		cloud->showSF(true);
+	}
+	{
+		//Access existing database
+		riegl::rdb::Pointcloud rdb(context);
+		riegl::rdb::pointcloud::OpenSettings settings(context);
+		rdb.open(filename.toStdString(), settings);
+		//Get index graph root node
+		riegl::rdb::pointcloud::QueryStat stat = rdb.stat();
+		riegl::rdb::pointcloud::GraphNode root = stat.index();
+
+		//progress dialog
+		ccProgressDialog pdlg(true, parameters.parentWidget);
+		CCLib::NormalizedProgress nprogress(&pdlg, root.pointCountTotal/BUFFER_SIZE);
+		{
+			std::stringstream ss;
+			ss << "Loading RDB file [" << filename.toStdString().c_str()<< "]";
+			pdlg.setMethodTitle(ss.str().c_str());
+			pdlg.setInfo("Points loaded: 0");
+			pdlg.start();
+		}
+
+		//prepare point attribute buffers
+		std::vector< std::array<float, 3> >   buffer_xyz(BUFFER_SIZE);
+		std::vector< std::array<float, 3> >   buffer_normals;
+		std::vector< std::array<uint8_t, 4> > buffer_rgba;
+		std::vector< std::array<float, 3> >   buffer_plane_up;
+		std::vector< float >                  buffer_plane_width;
+		std::vector< float >                  buffer_plane_height;
+		//reserve memory for optional entries
+		if (rdb_hasNormals)
+			buffer_normals.resize(BUFFER_SIZE);
+		if (rdb_hasRGBA)
+			buffer_rgba.resize(BUFFER_SIZE);
+		if (rdb_has_plane_up)
+			buffer_plane_up.resize(BUFFER_SIZE);
+		if (rdb_has_plane_width)
+			buffer_plane_width.resize(BUFFER_SIZE);
+		if (rdb_has_plane_height)
+			buffer_plane_height.resize(BUFFER_SIZE);
+
+		//Start new select query to read all points
+		riegl::rdb::pointcloud::QuerySelect select = rdb.select();
+
+		//Bind target data buffers to query
+		select.bindBuffer("riegl.xyz",                buffer_xyz);
+		if (rdb_hasRGBA)
+			select.bindBuffer("riegl.rgba",           buffer_rgba);
+		if (rdb_hasNormals)
+			select.bindBuffer("riegl.surface_normal", buffer_normals);
+		if (rdb_has_pca_axis_min)
+			select.bindBuffer("riegl.pca_axis_min",   buffer_normals);
+		if (rdb_has_plane_up)
+			select.bindBuffer("riegl.plane_up",       buffer_plane_up);
+		if (rdb_has_plane_width)
+			select.bindBuffer("riegl.plane_width",    buffer_plane_width);
+		if (rdb_has_plane_height)
+			select.bindBuffer("riegl.plane_height",   buffer_plane_height);
+		for (Conversion &conv : conversions)
+		{
+			select.bindBuffer(conv.att,       conv.buffer);
+		}
+
+		{ //pre allocate memory for cloud to load
+			unsigned total_entries = 0;
+			//Start new select query to read all points
+			riegl::rdb::pointcloud::QuerySelect count_select = rdb.select();
+			while (const uint32_t count = count_select.next(BUFFER_SIZE))
+			{
+				total_entries += count;
+			}
+			if (cloud->reserve(total_entries))
+			{
+				if (rdb_hasRGBA && !cloud->reserveTheRGBTable())
+				{
+					ccLog::Print(QString("[RDBFilter] Not enough memory to reserve RGB table for points. Try to load as many as possible. Total: %1").arg(total_entries));
+					result = CC_FERR_NOT_ENOUGH_MEMORY;
+				}
+				if ((rdb_hasNormals || rdb_has_pca_axis_min) && !cloud->reserveTheNormsTable())
+				{
+					ccLog::Print(QString("[RDBFilter] Not enough memory to reserve normal table for points. Try to load as many as possible. Total: %1").arg(total_entries));
+					result = CC_FERR_NOT_ENOUGH_MEMORY;
+				}
+			}
+			else //not enough memory for all points
+			{
+				ccLog::Print(QString("[RDBFilter] Not enough memory to load all points. Try to load as many as possible. Total: %1").arg(total_entries));
+				result = CC_FERR_NOT_ENOUGH_MEMORY;
+			}
+		}
+
+		//Read and process all points block-wise
+		while (const uint32_t count = select.next(BUFFER_SIZE))
+		{
+			//reserve memory for next block (only if we don't have enough memory
+			//to hold the complete pointcloud)
+			if (result == CC_FERR_NOT_ENOUGH_MEMORY)
+			{
+				if (!cloud->reserve(cloud->size() + count))
+				{
+					//can't load more points, exiting
+					result = CC_FERR_NOT_ENOUGH_MEMORY;
+					break;
+				}
+				if (rdb_hasRGBA && !cloud->reserveTheRGBTable())
+				{
+					result = CC_FERR_NOT_ENOUGH_MEMORY;
+					break;
+				}
+				if ((rdb_hasNormals || rdb_has_pca_axis_min) && !cloud->reserveTheNormsTable())
+				{
+					result = CC_FERR_NOT_ENOUGH_MEMORY;
+					break;
+				}
+			}
+
+			//buffers to hold the CC vectors
+			ccColor::Rgb col;
+			for (uint32_t i=0; i<count; ++i)
+			{
+				//read XYZ
+				cloud->addPoint(CCVector3::fromArray(buffer_xyz[i].data()));
+				//read RGB
+				if (rdb_hasRGBA)
+				{
+					col.r = static_cast<unsigned char>(buffer_rgba[i][0]);
+					col.g = static_cast<unsigned char>(buffer_rgba[i][1]);
+					col.b = static_cast<unsigned char>(buffer_rgba[i][2]);
+					cloud->addRGBColor(col);
+				}
+				//read normals
+				if (rdb_hasNormals || rdb_has_pca_axis_min)
+				{
+					cloud->addNorm(CCVector3::fromArray(buffer_normals[i].data()));
+				}
+				//read selected scalars
+				for (Conversion &conv : conversions)
+				{
+					conv.sf->addElement(conv.buffer[i]);
+				}
+
+				if (create_planes)
+				{
+					//calculate tranformation matrix from norm and up vector
+					//to define the position and orientation of the plane patch
+					CCVector3 plane_norm = CCVector3::fromArray(buffer_normals[i].data());
+					CCVector3 plane_up   = CCVector3::fromArray(buffer_plane_up[i].data());
+					CCVector3 plane_side = plane_norm.cross(-plane_up);
+					Vector3Tpl<float> X(plane_side);
+					Vector3Tpl<float> Y(plane_up);
+					Vector3Tpl<float> Z(plane_norm);
+					Vector3Tpl<float> t(
+								static_cast<float>(buffer_xyz[i][0]),
+								static_cast<float>(buffer_xyz[i][1]),
+								static_cast<float>(buffer_xyz[i][2]));
+					ccGLMatrix mat(X, Y, Z, t);
+					//create plane patch
+					ccPlane *plane = new ccPlane(
+								static_cast<PointCoordinateType>(buffer_plane_width[i]),
+								static_cast<PointCoordinateType>(buffer_plane_height[i]),
+								&mat);
+					if (rdb_hasRGBA)
+					{
+						col.r = static_cast<unsigned char>(buffer_rgba[i][0]);
+						col.g = static_cast<unsigned char>(buffer_rgba[i][1]);
+						col.b = static_cast<unsigned char>(buffer_rgba[i][2]);
+						plane->setColor(col);
+					}
+					plane->showNormalVector(true); //per default show the normal vector
+					plane_set->addChild(plane);
+				}
+			}
+			total += count;
+
+			{
+				//update the progress info
+				pdlg.setInfo(QString("Points loaded: %1").arg(total));
+			}
+
+			if (!nprogress.oneStep())
+			{
+				//cancel requested
+				result = CC_FERR_CANCELED_BY_USER;
+				break;
+			}
+		}
+	}
+
+	ccLog::Print(QString("[RDBFilter] Number of points: %1").arg(total));
+
+	//compute min and max of scalars
+	for (Conversion &conv : conversions)
+	{
+		conv.sf->computeMinAndMax();
+		conv.sf->release();
+	}
+	cloud->setVisible(true);
+	container.addChild(static_cast<ccHObject*>(cloud));
+	if (create_planes)
+	{
+		container.addChild(plane_set);
+	}
+
+	return result;
+}
+
+bool RDBFilter::canSave( CC_CLASS_ENUM type, bool &multiple, bool &exclusive ) const
+{
+	Q_UNUSED( type );
+	Q_UNUSED( multiple );
+	Q_UNUSED( exclusive );
+
+	//... can we save this?
+	return false;
+}

--- a/plugins/3rdParty/qRDBIO/RDBFilter.h
+++ b/plugins/3rdParty/qRDBIO/RDBFilter.h
@@ -1,0 +1,34 @@
+#ifndef CC_RDB_FILTER_HEADER
+#define CC_RDB_FILTER_HEADER
+
+//##########################################################################
+//#                                                                        #
+//#                       CLOUDCOMPARE PLUGIN: qRDBIO                      #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 of the License.               #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#          COPYRIGHT: RIEGL Laser Measurement Systems GmbH               #
+//#                                                                        #
+//##########################################################################
+
+#include <FileIOFilter.h>
+
+class RDBFilter : public FileIOFilter
+{
+public:
+	RDBFilter();
+	
+	// inherited from FileIOFilter
+	CC_FILE_ERROR loadFile( const QString &fileName, ccHObject &container, LoadParameters &parameters ) override;
+	
+	bool canSave( CC_CLASS_ENUM type, bool &multiple, bool &exclusive ) const override;
+};
+
+#endif //CC_RDB_FILTER_HEADER

--- a/plugins/3rdParty/qRDBIO/RDBOpenDialog.cpp
+++ b/plugins/3rdParty/qRDBIO/RDBOpenDialog.cpp
@@ -1,0 +1,31 @@
+//##########################################################################
+//#                                                                        #
+//#                       CLOUDCOMPARE PLUGIN: qRDBIO                      #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 of the License.               #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#          COPYRIGHT: RIEGL Laser Measurement Systems GmbH               #
+//#                                                                        #
+//##########################################################################
+
+#include "RDBOpenDialog.h"
+
+//Qt
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QSettings>
+
+RDBOpenDialog::RDBOpenDialog(QWidget* parent/*=0*/)
+	: QDialog(parent)
+	, Ui::RDBOpenDlg()
+{
+	setupUi(this);
+}
+

--- a/plugins/3rdParty/qRDBIO/RDBOpenDialog.h
+++ b/plugins/3rdParty/qRDBIO/RDBOpenDialog.h
@@ -1,0 +1,53 @@
+//##########################################################################
+//#                                                                        #
+//#                       CLOUDCOMPARE PLUGIN: qRDBIO                      #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 of the License.               #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#          COPYRIGHT: RIEGL Laser Measurement Systems GmbH               #
+//#                                                                        #
+//##########################################################################
+
+#ifndef RDB_OPEN_DIALOG_HEADER
+#define RDB_OPEN_DIALOG_HEADER
+
+//Qt
+#include <QDialog>
+
+//GUI
+#include "ui_openRDBDlg.h"
+
+enum CC_RDB_OPEN_DLG_TYPES {	RDB_OPEN_DLG_None		= 0,
+								RDB_OPEN_DLG_XYZ		= 1,
+								RDB_OPEN_DLG_NORM		= 2,
+								RDB_OPEN_DLG_RGB		= 3,
+								RDB_OPEN_DLG_Grey		= 4,
+								RDB_OPEN_DLG_Scalar		= 5,
+						   };
+const unsigned RDB_OPEN_DLG_TYPES_NUMBER = 6;
+const char RDB_OPEN_DLG_TYPES_NAMES[RDB_OPEN_DLG_TYPES_NUMBER][24] = {	"Ignore",
+																		"XYZ",
+																		"Normals",
+																		"RGB",
+																		"Grey",
+																		"Scalar",
+																	 };
+//! RDB Open dialog
+class RDBOpenDialog : public QDialog, public Ui::RDBOpenDlg
+{
+	Q_OBJECT
+
+public:
+
+	//! Default constructor
+	explicit RDBOpenDialog(QWidget* parent = nullptr);
+};
+
+#endif

--- a/plugins/3rdParty/qRDBIO/README.md
+++ b/plugins/3rdParty/qRDBIO/README.md
@@ -1,0 +1,35 @@
+# RDB IO Plugin
+
+This plugin adds support to load Riegl DataBase 2 files.
+
+To compile this plugin the RDB library is needed. To get the library go to the
+[Riegl Members Area](http://www.riegl.com/members-area/) and create an account.
+The account will be validated by an administrator. After validation download
+the RDB library for your platform and extract it.
+
+
+## Build the Plugin
+To build and install the plugin enable the plugin with the `PLUGIN_IO_QRDB` flag
+and pass the location of the RDB library with `rdb_DIR` (the path to the
+`rdb-config.cmake` file located in `interface/cpp`)
+
+### Build on Linux and Unix like
+In the CloudCompare root folder execute the following commands to configure,
+build and install
+
+```
+cmake -H. -B_build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${PWD}/_install" -DPLUGIN_IO_QRDB=ON -Drdb_DIR=/path/to/rdblib-2.2.1/interface/cpp
+cmake --build _build -- -j
+cmake --build _build --target install
+```
+
+### Build on Windows with MSVC
+To build on Windows with Visual Studio 2017 additionally the generator needs to
+be specified. The following command assumes installed build tools as well as Qt5
+system wide installation
+
+```
+call "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat"
+cmake -H. -B_build -G "Visual Studio 15 2017 Win64" -DCMAKE_INSTALL_PREFIX=%cd%/_install -DPLUGIN_IO_QRDB=ON -Drdb_DIR=C:\Users\username\Downloads\rdblib-2.2.1-x86_64-windows\interface\cpp 
+cmake --build _build --config Release --target install
+```

--- a/plugins/3rdParty/qRDBIO/info.json
+++ b/plugins/3rdParty/qRDBIO/info.json
@@ -1,0 +1,23 @@
+{
+	"type" : "I/O",
+	"name" : "RDB2 (I/O Plugin)",
+	"description": "This plugin adds capabilities to read Riegl RDBX pointcloud data.",
+	"authors" : [
+		{
+			"name" : "Reinhold Gschweicher",
+			"email" : "support@riegl.com"
+		}
+	],
+	"maintainers" : [
+		{
+			"name" : "Reinhold Gschweicher",
+			"email" : "support@riegl.com"
+		}
+	],
+	"references" : [
+		{
+			"text" : "Riegl LMS",
+			"url" : "https://riegl.com/"
+		}
+	]
+}

--- a/plugins/3rdParty/qRDBIO/openRDBDlg.ui
+++ b/plugins/3rdParty/qRDBIO/openRDBDlg.ui
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>RDBOpenDlg</class>
+ <widget class="QDialog" name="RDBOpenDlg">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>388</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Open Riegl RDB 2 file</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>RDB Info</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Points</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="rdbPointsNumber">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="rdbTableWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>RDBOpenDlg</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>RDBOpenDlg</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/plugins/3rdParty/qRDBIO/qRDBIO.cpp
+++ b/plugins/3rdParty/qRDBIO/qRDBIO.cpp
@@ -1,0 +1,42 @@
+//##########################################################################
+//#                                                                        #
+//#                       CLOUDCOMPARE PLUGIN: qRDBIO                      #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 of the License.               #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#          COPYRIGHT: RIEGL Laser Measurement Systems GmbH               #
+//#                                                                        #
+//##########################################################################
+
+#include "qRDBIO.h"
+
+#include "RDBFilter.h"
+
+
+qRDBIO::qRDBIO( QObject* parent )
+	: QObject( parent )
+	, ccIOPluginInterface( ":/CC/plugin/qRDBIO/info.json" )
+{
+}
+
+void qRDBIO::registerCommands( ccCommandLineInterface *cmd )
+{
+	// If you want to register this plugin for the command line, create a
+	// ccCommandLineInterface::Command and add it here. e.g.:
+	//
+	// cmd->registerCommand( ccCommandLineInterface::Command::Shared( new FooCommand ) );
+}
+
+ccIOPluginInterface::FilterList qRDBIO::getFilters()
+{
+	return {
+		FileIOFilter::Shared( new RDBFilter ),
+	};
+}

--- a/plugins/3rdParty/qRDBIO/qRDBIO.h
+++ b/plugins/3rdParty/qRDBIO/qRDBIO.h
@@ -1,0 +1,41 @@
+#ifndef Q_RDB_IO_PLUGIN_HEADER
+#define Q_RDB_IO_PLUGIN_HEADER
+
+//##########################################################################
+//#                                                                        #
+//#                       CLOUDCOMPARE PLUGIN: qRDBIO                      #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 of the License.               #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#          COPYRIGHT: RIEGL Laser Measurement Systems GmbH               #
+//#                                                                        #
+//##########################################################################
+
+#include "ccIOPluginInterface.h"
+
+//! RDB file (3D cloud)
+class qRDBIO : public QObject, public ccIOPluginInterface
+{
+	Q_OBJECT
+	Q_INTERFACES( ccIOPluginInterface )
+	
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qRDBIO" FILE "info.json" )
+
+public:
+    explicit qRDBIO( QObject *parent = nullptr );
+	~qRDBIO() override = default;
+	
+	void registerCommands( ccCommandLineInterface *cmd ) override;
+	
+	// inherited from ccIOPluginInterface
+	ccIOPluginInterface::FilterList getFilters() override;
+};
+
+#endif //Q_RDB_IO_PLUGIN_HEADER

--- a/plugins/3rdParty/qRDBIO/qRDBIO.qrc
+++ b/plugins/3rdParty/qRDBIO/qRDBIO.qrc
@@ -1,0 +1,5 @@
+<RCC>
+  <qresource prefix="/CC/plugin/qRDBIO" >
+    <file>info.json</file>
+  </qresource>
+</RCC>


### PR DESCRIPTION
- support extensions rdbx, vxls, ptch and mtch
  - rdbx, vxls and mtch are read solely as pointcloud files
  - ptch files additionally create plane patches
- improved loading speed by preallocating memory, if allocation failes
  try to load as much as possible into memory (or until user aborts)
- add basic README with information where to get rdblib