### PR TITLE
Lib e57 plugin cleanups

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -38,7 +38,7 @@
   - `OPTION_USE_DXFLIB`: to add support for DXF files in CloudCompare/ccViewer with **dxflib** - see [below](#optional-setup-for-dxflib-support)
   - `OPTION_USE_FBX_SDK`: to add support for FBX files in CloudCompare/ccViewer with the official **FBX SDK** - see [below](#optional-setup-for-fbx-sdk-support)
   - `OPTION_USE_GDAL`: to add support for a lot of raster files in CloudCompare/ccViewer with **GDAL** library - see [below](#optional-setup-for-gdal-support)
-  - `OPTION_USE_LIBE57`: to add support for E57 files in CloudCompare/ccViewer with **libE57** - see [below](#optional-setup-for-libe57-support)
+  - `PLUGIN_IO_QE57`: to add support for E57 files in CloudCompare/ccViewer with **libE57** - see [below](#optional-setup-for-libe57-support)
   - `OPTION_USE_SHAPE_LIB`: to add support for SHP files in CloudCompare/ccViewer
   - `OPTION_PDAL_LAS`: to add support for LAS files in CloudCompare/ccViewer with **PDAL** - see [below](#optional-setup-for-las-using-pdal)
 
@@ -121,8 +121,8 @@ set the `PDAL_DIR` to the path containing `PDALConfig.cmake`.
 
 If you want to compile CloudCompare (and ccViewer) with LibE57 files support, you'll need:
 
-1. [Boost](http://www.boost.org/) multi-thread static libraries
-2. [Xerces-C++](http://xerces.apache.org/xerces-c) multi-thread **static** libraries
+1. [Xerces-C++](http://xerces.apache.org/xerces-c) multi-thread **static** libraries
+    - On Ubuntu install the package `libxerces-c-dev`
     - On Visual C++ (Windows):
         1. select the `Static Debug` or `Static Release` configurations
         2. you'll have to manually modify the `XercesLib` project options so that the `C/C++ > Code Generation > Runtime Library` are of DLL type in both release and debug modes (i.e. `/MD` in release or `/MDd` in debug)
@@ -130,14 +130,8 @@ If you want to compile CloudCompare (and ccViewer) with LibE57 files support, yo
     - only the XercesLib project neet to be compiled
     - eventually, CMake will look for the resulting files in `/include` (instead of `/src`) and `/lib` (without the Release or Debug subfolders). By default the visual project will put them in `/Build/WinXX/VCXX/StaticXXX`. Therefore you should create a custom folder with the right organization and copy the files there.
 
-3. [LibE57](http://libe57.org) (*last tested version: 1.1.312 on Windows*)
-    - **WARNING**: with Visual Studio (at least), you'll need the libraries compiled with `/MD` (=DLL Multithreaded) in release mode and `/MDd` in debug mode. You may have to replace all `/MT` by `/MD` in the main libE57 root CMake file (or in `cmake/c_flag_overrides.cmake` and `cmake/cxx_flag_overrides.cmake` if there's no `/MT` in it)
-    - If you found `set(Boost_USE_STATIC_RUNTIME ON)` in the CMake file, comment it
-    - **the version 1.1.312 of libE57 has a small glitch that must be manually patched**:
-        1.  open `E57FoundationImpl.cpp` and browse to the `CheckedFile::operator<<(float f)` method (line 4670)
-        2.  set the output precision to 8 instead of 7! (otherwise the interal checks for precision loss may fail and libE57 will throw an exception)
-
-The CloudCompare CMake project will only require that you set the path where libE57 has been installed (`LIBE57_INSTALL_DIR`)
+2. [LibE57](https://github.com/asmaloney/libE57Format) (*last tested version: 2.0.1 on Windows*)
+    - Checkout the submodule in `plugins/core/IO/qE57IO/extern/libE57Format` or download and extract the latest [libE57Format](https://github.com/asmaloney/libE57Format) release
 
 ### [Optional] Setup for PCL (required by qPCL)
 

--- a/plugins/core/IO/qE57IO/CMakeLists.txt
+++ b/plugins/core/IO/qE57IO/CMakeLists.txt
@@ -14,7 +14,7 @@ if ( PLUGIN_IO_QE57 )
 	include_directories( src )
 
 	add_subdirectory( src )
-	add_subdirectory( extern/libE57Format )
+	add_subdirectory( extern/libE57Format EXCLUDE_FROM_ALL)
 	
 	include( ../../../CMakePluginTpl.cmake )
 	


### PR DESCRIPTION
update BUILD.md instructions on how to build with `PLUGIN_IO_QE57`
update instructions to use [libE57format](https://github.com/asmaloney/libE57Format) instead of reference implementation

also don't install the libE57 header and static library, those are not needed in the installation folder