### PR TITLE
Segmentation support for ReferenceCloud

### DIFF
--- a/CC/include/ManualSegmentationTools.h
+++ b/CC/include/ManualSegmentationTools.h
@@ -128,12 +128,12 @@ public:
 		{}
 	};
 
-	static bool segmentMeshWitAAPlane(GenericIndexedMesh* mesh,
+	static bool segmentMeshWithAAPlane(GenericIndexedMesh* mesh,
 		GenericIndexedCloudPersist* vertices,
 		MeshCutterParams& ioParams,
 		GenericProgressCallback* progressCb = nullptr);
 
-	static bool segmentMeshWitAABox(GenericIndexedMesh* mesh,
+	static bool segmentMeshWithAABox(GenericIndexedMesh* mesh,
 		GenericIndexedCloudPersist* vertices,
 		MeshCutterParams& ioParams,
 		GenericProgressCallback* progressCb = nullptr);

--- a/CC/include/ManualSegmentationTools.h
+++ b/CC/include/ManualSegmentationTools.h
@@ -52,6 +52,16 @@ public:
 
 	//! Selects the points which associated scalar value fall inside or outside a specified interval
 	/** \warning: be sure to activate an OUTPUT scalar field on the input cloud
+		\param cloud the RefrenceCloud to segment
+		\param minDist the lower boundary
+		\param maxDist the upper boundary
+		\param outside whether to select the points inside or outside
+		\return a new cloud structure containing the extracted points (references to - no duplication)
+	**/
+	static ReferenceCloud* segmentReferenceCloud(ReferenceCloud * cloud, ScalarType minDist, ScalarType maxDist, bool outside);
+
+	//! Selects the points which associated scalar value fall inside or outside a specified interval
+	/** \warning: be sure to activate an OUTPUT scalar field on the input cloud
 		\param cloud the cloud to segment
 		\param minDist the lower boundary
 		\param maxDist the upper boundary

--- a/CC/src/ManualSegmentationTools.cpp
+++ b/CC/src/ManualSegmentationTools.cpp
@@ -57,7 +57,7 @@ ReferenceCloud* ManualSegmentationTools::segment(GenericIndexedCloudPersist* aCl
 		{
 			if (!Y->addPointIndex(i))
 			{
-				//not engouh memory
+				//not enough memory
 				delete Y;
 				Y = nullptr;
 				break;
@@ -154,7 +154,7 @@ ReferenceCloud* ManualSegmentationTools::segmentReferenceCloud(ReferenceCloud* c
 		{
 			if (!Y->addPointIndex(cloud->getPointGlobalIndex(i)))
 			{
-				//not engouh memory
+				//not enough memory
 				delete Y;
 				Y = nullptr;
 				break;
@@ -192,7 +192,7 @@ ReferenceCloud* ManualSegmentationTools::segment(	GenericIndexedCloudPersist* cl
 		{
 			if (!Y->addPointIndex(i))
 			{
-				//not engouh memory
+				//not enough memory
 				delete Y;
 				Y = nullptr;
 				break;

--- a/CC/src/ManualSegmentationTools.cpp
+++ b/CC/src/ManualSegmentationTools.cpp
@@ -133,6 +133,39 @@ bool ManualSegmentationTools::isPointInsidePoly(const CCVector2& P,
 	return inside;
 }
 
+ReferenceCloud* ManualSegmentationTools::segmentReferenceCloud(ReferenceCloud* cloud,
+	ScalarType minDist,
+	ScalarType maxDist,
+	bool outside/*=false*/)
+{
+	if (!cloud)
+	{
+		assert(false);
+		return nullptr;
+	}
+	ReferenceCloud* Y = new ReferenceCloud(cloud->getAssociatedCloud());
+
+	//for each point
+	for (unsigned i = 0; i < cloud->size(); ++i)
+	{
+		const ScalarType dist = cloud->getPointScalarValue(i);
+		//we test if its associated scalar value falls inside the specified interval
+		if ((dist >= minDist && dist <= maxDist) ^ outside)
+		{
+			if (!Y->addPointIndex(cloud->getPointGlobalIndex(i)))
+			{
+				//not engouh memory
+				delete Y;
+				Y = nullptr;
+				break;
+			}
+		}
+	}
+
+	return Y;
+
+}
+
 ReferenceCloud* ManualSegmentationTools::segment(	GenericIndexedCloudPersist* cloud,
 													ScalarType minDist,
 													ScalarType maxDist,
@@ -143,6 +176,10 @@ ReferenceCloud* ManualSegmentationTools::segment(	GenericIndexedCloudPersist* cl
 		assert(false);
 		return nullptr;
 	}
+
+	ReferenceCloud* cloudREFTest = dynamic_cast<ReferenceCloud*>(cloud);
+	if (cloudREFTest)
+		return segmentReferenceCloud(cloudREFTest, minDist, maxDist, outside);
 
 	ReferenceCloud* Y = new ReferenceCloud(cloud);
 

--- a/CC/src/ManualSegmentationTools.cpp
+++ b/CC/src/ManualSegmentationTools.cpp
@@ -608,7 +608,7 @@ bool ImportSourceVertices(GenericIndexedCloudPersist* srcVertices,
 
 	return true;
 }
-bool ManualSegmentationTools::segmentMeshWitAAPlane(GenericIndexedMesh* mesh,
+bool ManualSegmentationTools::segmentMeshWithAAPlane(GenericIndexedMesh* mesh,
 	GenericIndexedCloudPersist* vertices,
 	MeshCutterParams& ioParams,
 	GenericProgressCallback* progressCb/*=0*/)
@@ -895,7 +895,7 @@ bool ManualSegmentationTools::segmentMeshWitAAPlane(GenericIndexedMesh* mesh,
 	return true;
 }
 
-bool ManualSegmentationTools::segmentMeshWitAABox(GenericIndexedMesh* origMesh,
+bool ManualSegmentationTools::segmentMeshWithAABox(GenericIndexedMesh* origMesh,
 	GenericIndexedCloudPersist* origVertices,
 	MeshCutterParams& ioParams,
 	GenericProgressCallback* progressCb/*=0*/)

--- a/plugins/core/Standard/qPCL/PclUtils/utils/my_point_types.h
+++ b/plugins/core/Standard/qPCL/PclUtils/utils/my_point_types.h
@@ -89,7 +89,7 @@ struct ShortScalar
 
 struct UShortScalar
 {
-	short S5c4laR;
+	unsigned short S5c4laR;
 	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
 } EIGEN_ALIGN16;

--- a/qCC/ccCropTool.cpp
+++ b/qCC/ccCropTool.cpp
@@ -90,7 +90,7 @@ ccHObject* ccCropTool::Crop(ccHObject* entity, const ccBBox& box, bool inside/*=
 			cropVertices = rotatedVertices;
 		}
 
-		if (!CCLib::ManualSegmentationTools::segmentMeshWitAABox(mesh, cropVertices, params))
+		if (!CCLib::ManualSegmentationTools::segmentMeshWithAABox(mesh, cropVertices, params))
 		{
 			//process failed!
 			ccLog::Warning(QString("[Crop] Failed to crop mesh '%1'!").arg(mesh->getName()));


### PR DESCRIPTION
I found incorrect results while using ManualSegmentationTools::segment on a reference cloud as segment adds the local index of the reference cloud instead of the global index. I separated the functions to avoid having an if check per point.

I also perform a dynamic_cast in segment on cloud to ReferenceCloud and if successful forward to the new function.