### PR TITLE
Added getEquation() planeEquation : [a, b, c, d] as 'ax+by+cz=d'

### DIFF
--- a/CC/src/DistanceComputationTools.cpp
+++ b/CC/src/DistanceComputationTools.cpp
@@ -1787,7 +1787,7 @@ int DistanceComputationTools::computeCloud2MeshDistance(	GenericIndexedCloudPers
 		params.maxSearchDist = 0;
 	}
 
-	//compute the (cubical) bounding box that contains both the cloud and the mehs BBs
+	//compute the (cubical) bounding box that contains both the cloud and the mesh BBs
 	CCVector3 cloudMinBB,cloudMaxBB;
 	CCVector3 meshMinBB,meshMaxBB;
 	CCVector3 minBB,maxBB;

--- a/libs/qCC_db/ccPlane.cpp
+++ b/libs/qCC_db/ccPlane.cpp
@@ -69,6 +69,12 @@ bool ccPlane::buildUp()
 	addTriangle(0, 3, 2); //A D C
 	addTriangleNormalIndexes(0, 0, 0);
 
+	CCVector3 N = getNormal();	
+	m_PlaneEquation[0] = N.x;
+	m_PlaneEquation[1] = N.y;
+	m_PlaneEquation[2] = N.z;
+	m_PlaneEquation[3] = getCenter().dot(N); //a point on the plane dot the plane normal
+
 	return true;
 }
 
@@ -96,6 +102,11 @@ void ccPlane::getEquation(CCVector3& N, PointCoordinateType& constVal) const
 	m_transformation.applyRotation(N);
 
 	constVal = m_transformation.getTranslationAsVec3D().dot(N);
+}
+
+const PointCoordinateType* ccPlane::getEquation()
+{
+	return m_PlaneEquation;
 }
 
 ccPlane* ccPlane::Fit(CCLib::GenericIndexedCloudPersist *cloud, double* rms/*=0*/)

--- a/libs/qCC_db/ccPlane.cpp
+++ b/libs/qCC_db/ccPlane.cpp
@@ -69,12 +69,6 @@ bool ccPlane::buildUp()
 	addTriangle(0, 3, 2); //A D C
 	addTriangleNormalIndexes(0, 0, 0);
 
-	CCVector3 N = getNormal();	
-	m_PlaneEquation[0] = N.x;
-	m_PlaneEquation[1] = N.y;
-	m_PlaneEquation[2] = N.z;
-	m_PlaneEquation[3] = getCenter().dot(N); //a point on the plane dot the plane normal
-
 	return true;
 }
 
@@ -106,6 +100,11 @@ void ccPlane::getEquation(CCVector3& N, PointCoordinateType& constVal) const
 
 const PointCoordinateType* ccPlane::getEquation()
 {
+	CCVector3 N = getNormal();
+	m_PlaneEquation[0] = N.x;
+	m_PlaneEquation[1] = N.y;
+	m_PlaneEquation[2] = N.z;
+	m_PlaneEquation[3] = getCenter().dot(N); //a point on the plane dot the plane normal
 	return m_PlaneEquation;
 }
 

--- a/libs/qCC_db/ccPlane.h
+++ b/libs/qCC_db/ccPlane.h
@@ -99,6 +99,15 @@ public:
 		i.e. Nx.x + Ny.y + Nz.z + constVal = 0
 	**/
 	void getEquation(CCVector3& N, PointCoordinateType& constVal) const;
+	
+	
+	//! Returns the equation of the plane
+	/** Equation:
+		planeEquation plane equation : [a, b, c, d] as 'ax+by+cz=d'
+		Same equation used in Neighbourhood and DistanceComputationTools 
+	**/
+	const PointCoordinateType* getEquation();
+
 
 	//! Flips the plane
 	void flip();
@@ -118,6 +127,9 @@ protected:
 
 	//! Width along 'Y' dimension
 	PointCoordinateType m_yWidth;
+
+	// Array [a,b,c,d] such that ax+by+cz = d
+	PointCoordinateType m_PlaneEquation[4];
 };
 
 #endif //CC_PLANE_PRIMITIVE_HEADER


### PR DESCRIPTION
Same equation used in Neighbourhood and DistanceComputationTools, also the same data type. 

Calculated in the buildUp function.

Simplifies using the DistanceComputationTools.

No changes to ccPlane Serialization