### PR TITLE
Console stdout

### DIFF
--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -38,28 +38,18 @@ constexpr char COMMAND_SILENT_MODE[]	= "SILENT";
 void ccCommandLineParser::print(const QString& message) const
 {
 	ccConsole::Print(message);
-	if (m_silentMode)
-	{
-		printf("%s\n", qPrintable(message));
-	}
 }
 
 void ccCommandLineParser::warning(const QString& message) const
 {
 	ccConsole::Warning(message);
-	if (m_silentMode)
-	{
-		printf("[WARNING] %s\n", qPrintable(message));
-	}
+	
 }
 
 bool ccCommandLineParser::error(const QString& message) const
 {
 	ccConsole::Error(message);
-	if (m_silentMode)
-	{
-		printf("[ERROR] %s\n", qPrintable(message));
-	}
+	
 
 	return false;
 }
@@ -101,6 +91,13 @@ int ccCommandLineParser::Parse(int nargs, char** args, ccPluginInterfaceList& pl
 		consoleDlg->show();
 		ccConsole::Init(commandLineDlg.consoleWidget, consoleDlg.data());
 		parser->fileLoadingParams().parentWidget = consoleDlg.data();
+		QApplication::processEvents(); //Get rid of the spinner
+	}
+	else
+	{
+		//allows ccLog ccConsole or ccCommandLineParser (print,warning,error) 
+		//to output to the console 
+		ccConsole::Init(nullptr, nullptr, nullptr, true); 
 	}
 
 	//load the plugins commands
@@ -660,6 +657,7 @@ int ccCommandLineParser::start(QDialog* parent/*=0*/)
 	bool success = true;
 	while (success && !m_arguments.empty())
 	{
+		QApplication::processEvents();	//Without this the console is just a spinner until the end of all processing
 		QString argument = m_arguments.takeFirst();
 
 		if (!argument.startsWith("-"))

--- a/qCC/ccConsole.cpp
+++ b/qCC/ccConsole.cpp
@@ -49,6 +49,8 @@
 static ccSingleton<ccConsole> s_console;
 
 bool ccConsole::s_showQtMessagesInConsole = false;
+bool ccConsole::s_redirectToStdOut = false;
+
 
 // ccCustomQListWidget
 ccCustomQListWidget::ccCustomQListWidget(QWidget *parent)
@@ -188,7 +190,8 @@ void ccConsole::EnableQtMessages(bool state)
 
 void ccConsole::Init(	QListWidget* textDisplay/*=0*/,
 						QWidget* parentWidget/*=0*/,
-						MainWindow* parentWindow/*=0*/)
+						MainWindow* parentWindow/*=0*/,
+						bool redirectToStdOut/*=false*/)
 {
 	//should be called only once!
 	if (s_console.instance)
@@ -201,7 +204,7 @@ void ccConsole::Init(	QListWidget* textDisplay/*=0*/,
 	s_console.instance->m_textDisplay = textDisplay;
 	s_console.instance->m_parentWidget = parentWidget;
 	s_console.instance->m_parentWindow = parentWindow;
-
+	s_redirectToStdOut = redirectToStdOut;
 	//auto-start
 	if (textDisplay)
 	{
@@ -216,7 +219,6 @@ void ccConsole::Init(	QListWidget* textDisplay/*=0*/,
 
 		s_console.instance->setAutoRefresh(true);
 	}
-
 	ccLog::RegisterInstance(s_console.instance);
 }
 
@@ -314,7 +316,10 @@ void ccConsole::logMessage(const QString& message, int level)
 #endif
 
 	QString formatedMessage = QStringLiteral("[") + QTime::currentTime().toString() + QStringLiteral("] ") + message;
-
+	if (s_redirectToStdOut)
+	{
+		printf("%s\n", qPrintable(message));
+	}
 	if (m_textDisplay || m_logStream)
 	{
 		m_mutex.lock();

--- a/qCC/ccConsole.h
+++ b/qCC/ccConsole.h
@@ -60,10 +60,12 @@ public:
 		\param textDisplay text output widget (optional)
 		\param parentWidget parent widget (optional)
 		\param parentWindow parent window (if any - optional)
+		\param silentCommandLineMode will cause logmessage to printf (optional)
 	**/
 	static void Init(	QListWidget* textDisplay = nullptr,
 						QWidget* parentWidget = nullptr,
-						MainWindow* parentWindow = nullptr);
+						MainWindow* parentWindow = nullptr,
+						bool redirectToStdOut = false);
 
 	//! Returns the (unique) static instance
 	/** \param autoInit automatically initialize the console instance (with no widget!) if not done already
@@ -131,6 +133,7 @@ protected:
 
 	//! Whether to show Qt messages (qDebug / qWarning / etc.) in Console
 	static bool s_showQtMessagesInConsole;
+	static bool s_redirectToStdOut;
 };
 
 #endif

--- a/qCC/main.cpp
+++ b/qCC/main.cpp
@@ -58,6 +58,18 @@
 
 int main(int argc, char **argv)
 {
+
+#ifdef _WIN32 //This will allow printf to function on windows when opened from command line	
+	DWORD stdout_type = GetFileType(GetStdHandle(STD_OUTPUT_HANDLE));
+	if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+		if (stdout_type == FILE_TYPE_UNKNOWN) // this will allow std redirection (./executable > out.txt)
+		{
+			freopen("CONOUT$", "w", stdout);
+			freopen("CONOUT$", "w", stderr);
+		}
+	}
+#endif
+
 #ifdef Q_OS_MAC
 	bool commandLine = isatty( fileno( stdin ) );
 #else


### PR DESCRIPTION
Fixes #983 on windows command line mode. (allows printf)

Also adds the console redirection to ccConsole which allows us to remove the specialty ccCommandLineParser extensions

```C++
ccCommandLineParser::print(const QString& message) const{}
ccCommandLineParser::warning(const QString& message) const{}
ccCommandLineParser::error(const QString& message) const{}
```
I left these in but removed the calls to printf so they are just forwarding directly to ccConsole.


