### PR TITLE
Restore Color and SF state after ICP

### DIFF
--- a/qCC/ccRegistrationTools.cpp
+++ b/qCC/ccRegistrationTools.cpp
@@ -62,8 +62,8 @@ bool ccRegistrationTools::ICP(	ccHObject* data,
 								int maxThreadCount/*=0*/,
 								QWidget* parent/*=0*/)
 {
-	bool RestoreColorState = false;
-	bool RestoreSFState = false;
+	bool restoreColorState = false;
+	bool restoreSFState = false;
 
 	//progress bar
 	QScopedPointer<ccProgressDialog> progressDlg;
@@ -112,8 +112,8 @@ bool ccRegistrationTools::ICP(	ccHObject* data,
 	if (data->isA(CC_TYPES::POINT_CLOUD))
 	{
 		ccPointCloud* pc = static_cast<ccPointCloud*>(data);
-		RestoreColorState = pc->colorsShown();
-		RestoreSFState = pc->sfShown();
+		restoreColorState = pc->colorsShown();
+		restoreSFState = pc->sfShown();
 		dataDisplayedSF = pc->getCurrentDisplayedScalarField();
 		oldDataSfIdx = pc->getCurrentInScalarFieldIndex();
 		dataSfIdx = pc->getScalarFieldIndexByName(REGISTRATION_DISTS_SF);
@@ -199,7 +199,7 @@ bool ccRegistrationTools::ICP(	ccHObject* data,
 			ParallelSort(distances.begin(), distances.end());
 			
 			//now look for the max value at 'finalOverlapRatio+margin' percent
-			maxSearchDist = distances[static_cast<unsigned>(std::max(1.0,count*(static_cast<double>(finalOverlapRatio)+s_overlapMarginRatio)))-1];
+			maxSearchDist = distances[static_cast<size_t>(std::max(1.0,count*(finalOverlapRatio+s_overlapMarginRatio)))-1];
 		}
 
 		//evntually select the points with distance below 'maxSearchDist'
@@ -312,8 +312,8 @@ bool ccRegistrationTools::ICP(	ccHObject* data,
 		ccPointCloud* pc = static_cast<ccPointCloud*>(data);
 		pc->setCurrentScalarField(oldDataSfIdx);
 		pc->deleteScalarField(dataSfIdx);
-		pc->showColors(RestoreColorState);
-		pc->showSF(RestoreSFState);
+		pc->showColors(restoreColorState);
+		pc->showSF(restoreSFState);
 	}
 
 	return (result < CCLib::ICPRegistrationTools::ICP_ERROR);

--- a/qCC/ccRegistrationTools.cpp
+++ b/qCC/ccRegistrationTools.cpp
@@ -62,6 +62,9 @@ bool ccRegistrationTools::ICP(	ccHObject* data,
 								int maxThreadCount/*=0*/,
 								QWidget* parent/*=0*/)
 {
+	bool RestoreColorState = false;
+	bool RestoreSFState = false;
+
 	//progress bar
 	QScopedPointer<ccProgressDialog> progressDlg;
 	if (parent)
@@ -109,6 +112,8 @@ bool ccRegistrationTools::ICP(	ccHObject* data,
 	if (data->isA(CC_TYPES::POINT_CLOUD))
 	{
 		ccPointCloud* pc = static_cast<ccPointCloud*>(data);
+		RestoreColorState = pc->colorsShown();
+		RestoreSFState = pc->sfShown();
 		dataDisplayedSF = pc->getCurrentDisplayedScalarField();
 		oldDataSfIdx = pc->getCurrentInScalarFieldIndex();
 		dataSfIdx = pc->getScalarFieldIndexByName(REGISTRATION_DISTS_SF);
@@ -194,7 +199,7 @@ bool ccRegistrationTools::ICP(	ccHObject* data,
 			ParallelSort(distances.begin(), distances.end());
 			
 			//now look for the max value at 'finalOverlapRatio+margin' percent
-			maxSearchDist = distances[static_cast<unsigned>(std::max(1.0,count*(finalOverlapRatio+s_overlapMarginRatio)))-1];
+			maxSearchDist = distances[static_cast<unsigned>(std::max(1.0,count*(static_cast<double>(finalOverlapRatio)+s_overlapMarginRatio)))-1];
 		}
 
 		//evntually select the points with distance below 'maxSearchDist'
@@ -307,6 +312,8 @@ bool ccRegistrationTools::ICP(	ccHObject* data,
 		ccPointCloud* pc = static_cast<ccPointCloud*>(data);
 		pc->setCurrentScalarField(oldDataSfIdx);
 		pc->deleteScalarField(dataSfIdx);
+		pc->showColors(RestoreColorState);
+		pc->showSF(RestoreSFState);
 	}
 
 	return (result < CCLib::ICPRegistrationTools::ICP_ERROR);


### PR DESCRIPTION
Fixes #991 

And casts finalOverlapRatio to double to avoid compiler Warning C26451: Arithmetic overflow not that it would happen but it shuts up visual studios static analyzer :)