### PR TITLE
computeCloud2ConeEquation and support in the CloudPrimitiveDist function

### DIFF
--- a/CC/include/DistanceComputationTools.h
+++ b/CC/include/DistanceComputationTools.h
@@ -263,6 +263,19 @@ public: //distance to simple entities (triangles, planes, etc.)
 	**/
 	static ScalarType computePoint2PlaneDistance(const CCVector3* P, const PointCoordinateType* planeEquation);
 
+	//! Computes the distance between each point in a cloud and a cone
+	/** \param cloud a 3D point cloud
+		\param coneP1 center point associated with the larger radii
+		\param coneP2 center point associated with the smaller radii
+		\param coneR1 cone radius at coneP1 (larger)
+		\param coneR2 cone radius at coneP2 (smaller)
+		\param signedDist whether to compute the signed or positive (absolute) distance (optional)
+		\param solutionType if true the scalar field will be set to which solution was selected 1-4 (optional)
+		\param[out] rms will be set with the Root Mean Square (RMS) distance between a cloud and a cylinder (optional)
+		\return negative error code or a positive value in case of success
+	**/
+	static int computeCloud2ConeEquation(GenericIndexedCloudPersist* cloud, const CCVector3& coneP1, const CCVector3& coneP2, const PointCoordinateType coneR1, const PointCoordinateType coneR2, bool signedDistances = true, bool solutionType = false, double* rms = nullptr);
+
 	//! Computes the distance between each point in a cloud and a cylinder
 	/** \param cloud a 3D point cloud
 		\param cylinderP1 center bottom point

--- a/CC/src/DistanceComputationTools.cpp
+++ b/CC/src/DistanceComputationTools.cpp
@@ -2228,7 +2228,7 @@ int DistanceComputationTools::computeCloud2ConeEquation(GenericIndexedCloudPersi
 						y = sqrt(yy) - coneR1;
 						ry = y * side[0] - x * side[1]; //rotated y value (distance from the coneside axis)
 						d = std::min(axisLength - x, x); //determine whether closer to either radii 
-						d = std::min(d, abs(ry)); //or to side
+						d = std::min(d, static_cast<double>(abs(ry))); //or to side
 						d = -d; //negative inside
 					}
 					else
@@ -2270,7 +2270,7 @@ int DistanceComputationTools::computeCloud2ConeEquation(GenericIndexedCloudPersi
 								if (ry < 0) 
 								{//point is interior to the cone
 									d = std::min(axisLength - x, x); //determine whether closer to either radii 
-									d = std::min(d, abs(ry)); //or to side
+									d = std::min(d, static_cast<double>(abs(ry))); //or to side
 									d = -d; //negative inside
 								}
 							}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ v2.11 (Anoia) - (in development)
   - Edit > Plane > Compare: to compare the two selected planes (angle and relative distances)
   - Edit > Mesh > Flip triangles: to flip the triangles (vertices) in case they are defined in the wrong order
   - Tools > Distances > Cloud/Primitive Dist
-	- [Used to calculate distance to primitive shape (supports sphere and planes) rather than the mesh of that shape (more accurate results for spheres)
-		for planes this works with the planes equation rather than the mesh so it works as if the plane is infinite.]
+	- [Used to calculate distance to primitive shape (supports spheres, planes, cylinders and cones) rather than the mesh of that shape (more accurate results for spheres)
+		for planes this works with the planes equation rather than the mesh so it works as if the plane is infinite.
+		for cones this will not work with Snout mode cones.]
 
 - Improvements
   - Align (Point-pair based registration) tool

--- a/libs/qCC_db/ccCone.cpp
+++ b/libs/qCC_db/ccCone.cpp
@@ -254,6 +254,57 @@ void ccCone::setTopRadius(PointCoordinateType radius)
 	applyTransformationToVertices();
 }
 
+CCVector3 ccCone::getBottomCenter() const
+{
+	CCVector3 bottomCenter = CCVector3(m_xOff, m_yOff, -m_height) / 2;
+	ccGLMatrix trans = getGLTransformationHistory();
+	trans.apply(bottomCenter);
+	return bottomCenter;
+}
+CCVector3 ccCone::getTopCenter() const
+{
+	CCVector3 topCenter = CCVector3(-m_xOff, -m_yOff, m_height) / 2;
+	ccGLMatrix trans = getGLTransformationHistory();
+	trans.apply(topCenter);
+	return topCenter;
+}
+
+CCVector3 ccCone::getSmallCenter() const
+{
+	if (m_topRadius <= m_bottomRadius)
+	{
+		return getTopCenter();
+	}
+	return getBottomCenter();
+}
+
+CCVector3 ccCone::getLargeCenter() const
+{
+	if (m_topRadius >= m_bottomRadius)
+	{
+		return getTopCenter();
+	}
+	return getBottomCenter();
+}
+
+PointCoordinateType ccCone::getSmallRadius() const
+{
+	if (m_topRadius <= m_bottomRadius)
+	{
+		return m_topRadius;
+	}
+	return m_bottomRadius;
+}
+
+PointCoordinateType ccCone::getLargeRadius() const
+{
+	if (m_topRadius >= m_bottomRadius)
+	{
+		return m_topRadius;
+	}
+	return m_bottomRadius;
+}
+
 bool ccCone::toFile_MeOnly(QFile& out) const
 {
 	if (!ccGenericPrimitive::toFile_MeOnly(out))

--- a/libs/qCC_db/ccCone.h
+++ b/libs/qCC_db/ccCone.h
@@ -83,6 +83,24 @@ public:
 	**/
 	virtual void setTopRadius(PointCoordinateType radius);
 
+	//! Returns cone axis bottom end point after applying transformation
+	virtual CCVector3 getBottomCenter() const;
+	//! Returns cone axis top end point after applying transformation
+	virtual CCVector3 getTopCenter() const;
+
+	//! Returns cone axis end point associated with whichever radii is smaller
+	virtual CCVector3 getSmallCenter() const;
+	//! Returns cone axis end point associated with whichever radii is larger
+	virtual CCVector3 getLargeCenter() const;
+
+	//! Returns whichever cone radii is smaller
+	virtual PointCoordinateType getSmallRadius() const;
+	//! Returns whichever cone radii is larger
+	virtual PointCoordinateType getLargeRadius() const;
+
+	//! Returns true if the Cone was created in snout mode 
+	virtual bool isSnoutMode() const { return (m_xOff != 0 || m_yOff != 0); }
+
 	//inherited from ccGenericPrimitive
 	virtual QString getTypeName() const override { return "Cone"; }
 	virtual bool hasDrawingPrecision() const override { return true; }

--- a/qCC/ui_templates/primitiveDistanceDlg.ui
+++ b/qCC/ui_templates/primitiveDistanceDlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>381</width>
-    <height>301</height>
+    <width>450</width>
+    <height>312</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,12 +18,12 @@
     <rect>
      <x>30</x>
      <y>20</y>
-     <width>291</width>
-     <height>81</height>
+     <width>351</width>
+     <height>91</height>
     </rect>
    </property>
    <property name="text">
-    <string>[NOTE]: This tool will measure each clouds points to either an infinite plane or sphere, if distance to a bounded plane is required use the cloud/mesh distance tool.</string>
+    <string>[NOTE]: This tool will measure each clouds points to either an infinite plane, sphere, cylinder, or cone, if distance to a bounded plane is required use the cloud/mesh distance tool.</string>
    </property>
    <property name="alignment">
     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -79,7 +79,7 @@
      <x>4</x>
      <y>270</y>
      <width>371</width>
-     <height>25</height>
+     <height>30</height>
     </rect>
    </property>
    <layout class="QHBoxLayout">


### PR DESCRIPTION
Added support for cone Primitives, snout mode is not supported.

Also added a couple helper methods to ccCone to simplify grabbing cone axis end points and radii (the algorithm expects larger radii first and adding the helper method seemed a lot cleaner than adding it to the distance function)

again not surprising but here is a comparison between the cloud2Mesh and cloud2Primitive with only negative values shown
![image](https://user-images.githubusercontent.com/7495752/69471258-31ab2300-0d52-11ea-8bcf-bdb4a859ef87.png)
![image](https://user-images.githubusercontent.com/7495752/69471262-3e2f7b80-0d52-11ea-9a66-8366b195deed.png)
