### PR TITLE
Fix primitive dist warning

### DIFF
--- a/CC/src/DistanceComputationTools.cpp
+++ b/CC/src/DistanceComputationTools.cpp
@@ -2228,7 +2228,7 @@ int DistanceComputationTools::computeCloud2ConeEquation(GenericIndexedCloudPersi
 						y = sqrt(yy) - coneR1;
 						ry = y * side[0] - x * side[1]; //rotated y value (distance from the coneside axis)
 						d = std::min(axisLength - x, x); //determine whether closer to either radii 
-						d = std::min(d, static_cast<double>(abs(ry))); //or to side
+						d = std::min(d, static_cast<double>(std::abs(ry))); //or to side
 						d = -d; //negative inside
 					}
 					else
@@ -2270,7 +2270,7 @@ int DistanceComputationTools::computeCloud2ConeEquation(GenericIndexedCloudPersi
 								if (ry < 0) 
 								{//point is interior to the cone
 									d = std::min(axisLength - x, x); //determine whether closer to either radii 
-									d = std::min(d, static_cast<double>(abs(ry))); //or to side
+									d = std::min(d, static_cast<double>(std::abs(ry))); //or to side
 									d = -d; //negative inside
 								}
 							}


### PR DESCRIPTION
This is to fix the warnings generated on Clang SCALAR_DOUBLE=OFF travis build
![image](https://user-images.githubusercontent.com/7495752/69587933-eab06e00-0f9b-11ea-9238-02d6302cd80f.png)
