### PR TITLE
Minor distance related improvements

### DIFF
--- a/CC/src/DistanceComputationTools.cpp
+++ b/CC/src/DistanceComputationTools.cpp
@@ -944,7 +944,7 @@ int DistanceComputationTools::intersectMeshWithOctree(	OctreeAndMeshIntersection
 														+ _pointsPosition[12] + _pointsPosition[13];
 
 											//if all the sub-cube vertices are not on the same side, then the triangle may intersect the cell
-											if (abs(sum) < 8)
+											if (std::abs(sum) < 8)
 											{
 												//we make newCell point on next cell in array (we copy current info by the way)
 												cellsToTest[++cellsToTestCount] = *_newCell;
@@ -1224,7 +1224,7 @@ void cloudMeshDistCellFunc_MT(const DgmOctree::IndexAndCode& desc)
 
 		for (int i = -a; i <= b; ++i)
 		{
-			bool imax = (abs(i) == dist);
+			bool imax = (std::abs(i) == dist);
 			Tuple3i cellPos(startPos.x + i, 0, 0);
 
 			for (int j = -c; j <= d; j++)
@@ -1232,7 +1232,7 @@ void cloudMeshDistCellFunc_MT(const DgmOctree::IndexAndCode& desc)
 				cellPos.y = startPos.y + j;
 
 				//if i or j is 'maximal'
-				if (imax || abs(j) == dist)
+				if (imax || std::abs(j) == dist)
 				{
 					//we must be on the border of the neighborhood
 					for (int k = -e; k <= f; k++)
@@ -1570,7 +1570,7 @@ int DistanceComputationTools::computeCloud2MeshDistanceWithOctree(	OctreeAndMesh
 
 				for (int i = -a; i <= b; i++)
 				{
-					bool imax = (abs(i) == dist);
+					bool imax = (std::abs(i) == dist);
 					Tuple3i cellPos(startPos.x + i, 0, 0);
 
 					for (int j = -c; j <= d; j++)
@@ -1578,7 +1578,7 @@ int DistanceComputationTools::computeCloud2MeshDistanceWithOctree(	OctreeAndMesh
 						cellPos.y = startPos.y + j;
 
 						//if i or j is 'maximal'
-						if (imax || abs(j) == dist)
+						if (imax || std::abs(j) == dist)
 						{
 							//we must be on the border of the neighborhood
 							for (int k = -e; k <= f; k++)
@@ -2646,7 +2646,7 @@ int DistanceComputationTools::computeCloud2BoxEquation(GenericIndexedCloudPersis
 		}
 		else if (insideBox)
 		{
-			dist.x = abs(p_inBoxCoords.x) - hu;
+			dist.x = std::abs(p_inBoxCoords.x) - hu;
 		}
 
 		if (p_inBoxCoords.y < -hv)
@@ -2659,7 +2659,7 @@ int DistanceComputationTools::computeCloud2BoxEquation(GenericIndexedCloudPersis
 		}
 		else if (insideBox)
 		{
-			dist.y = abs(p_inBoxCoords.y) - hv;
+			dist.y = std::abs(p_inBoxCoords.y) - hv;
 		}
 
 		if (p_inBoxCoords.z < -hw)
@@ -2672,7 +2672,7 @@ int DistanceComputationTools::computeCloud2BoxEquation(GenericIndexedCloudPersis
 		}
 		else if (insideBox)
 		{
-			dist.z = abs(p_inBoxCoords.z) - hw;
+			dist.z = std::abs(p_inBoxCoords.z) - hw;
 		}
 
 		if (insideBox)//take min distance inside box

--- a/CC/src/DistanceComputationTools.cpp
+++ b/CC/src/DistanceComputationTools.cpp
@@ -1928,9 +1928,10 @@ ScalarType DistanceComputationTools::computePoint2TriangleDistance(const CCVecto
 
 	//we do all computations with double precision, otherwise
 	//some triangles with sharp angles will give very poor results.
-	CCVector3d AP(P->x - A->x, P->y - A->y, P->z - A->z);
-	CCVector3d AB(B->x - A->x, B->y - A->y, B->z - A->z);
-	CCVector3d AC(C->x - A->x, C->y - A->y, C->z - A->z);
+	//slight precision improvement by casting to double prior to subtraction
+	CCVector3d AP(static_cast<double>(P->x) - A->x, static_cast<double>(P->y) - A->y, static_cast<double>(P->z) - A->z);
+	CCVector3d AB(static_cast<double>(B->x) - A->x, static_cast<double>(B->y) - A->y, static_cast<double>(B->z) - A->z);
+	CCVector3d AC(static_cast<double>(C->x) - A->x, static_cast<double>(C->y) - A->y, static_cast<double>(C->z) - A->z);
 
     double a00 =  AB.dot(AB);
     double a01 =  AB.dot(AC);

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -10462,7 +10462,7 @@ void MainWindow::enableUIItems(dbTreeSelectionInfo& selInfo)
 	m_UI->actionAlign->setEnabled(exactlyTwoEntities); //Aurelien BEY le 13/11/2008
 	m_UI->actionCloudCloudDist->setEnabled(exactlyTwoClouds);
 	m_UI->actionCloudMeshDist->setEnabled(exactlyTwoEntities && atLeastOneMesh);
-	m_UI->actionCloudPrimitiveDist->setEnabled(atLeastOneCloud && atLeastOneMesh || atLeastOnePolyline);
+	m_UI->actionCloudPrimitiveDist->setEnabled(atLeastOneCloud && (atLeastOneMesh || atLeastOnePolyline));
 	m_UI->actionCPS->setEnabled(exactlyTwoClouds);
 	m_UI->actionScalarFieldArithmetic->setEnabled(exactlyOneEntity && atLeastOneSF);
 


### PR DESCRIPTION
To fix the clang warning about using abs, went through and set all uses of abs to std::abs

![image](https://user-images.githubusercontent.com/7495752/72569595-a771cd80-386f-11ea-9824-5088608ca91d.png)

In computePoint2TriangleDistance I cast to double prior to subtraction, I found a slight improvement in the number of outliers when measuring with Cloud2Mesh after this change.

Finally I noticed the primitive distance function was being enabled when just a polyline was being selected. so I added parenthesis to the setEnabled check.
