### PR TITLE
Classic snap confinement instead of strict

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,7 @@ description: |
 icon: snap/gui/cloudcompare.png
 
 grade: stable
-confinement: strict
+confinement: classic
 base: core18
 
 apps:


### PR DESCRIPTION
Proposal to use classic confinement instead of strict. If the data source directory resides outside of the user's /home, its not possible to access it when using strict confinement. 