### PR TITLE
Translate along and rotate around any arbitrary vector

### DIFF
--- a/qCC/ccGraphicalTransformationTool.cpp
+++ b/qCC/ccGraphicalTransformationTool.cpp
@@ -132,7 +132,6 @@ void ccGraphicalTransformationTool::advModeToggle(bool state)
 	}
 	else
 	{
-		rotComboBox->setEnabled(true);
 		TxCheckBox->setEnabled(true);
 		TyCheckBox->setEnabled(true);
 		this->setGeometry(this->x() , this->y(), 0, 0);
@@ -166,7 +165,7 @@ void ccGraphicalTransformationTool::populateAdvModeItems()
 		}
 		if (!polylines.empty())
 		{
-			for (int i = 0; i < polylines.size(); i++)
+			for (size_t i = 0; i < polylines.size(); i++)
 			{
 				ccPolyline* poly = static_cast<ccPolyline*>(polylines[i]);
 				if (poly->size() == 2) //only single segment polylines allowed
@@ -177,7 +176,7 @@ void ccGraphicalTransformationTool::populateAdvModeItems()
 		}
 		if (!m_planesAndLineSegments.empty())
 		{
-			for (int i = 0; i < m_planesAndLineSegments.size(); ++i)
+			for (size_t i = 0; i < m_planesAndLineSegments.size(); ++i)
 			{
 				QString item = QString("%1 (ID=%2)").arg(m_planesAndLineSegments[i]->getName()).arg(m_planesAndLineSegments[i]->getUniqueID());
 				advTranslateComboBox->insertItem(i+1, item, QVariant(m_planesAndLineSegments[i]->getUniqueID()));
@@ -363,7 +362,6 @@ bool ccGraphicalTransformationTool::setAdvRotationAxis(ccHObject* rotateRef)
 		CCVector3d newCenter = CCVector3d::fromArray(m_toTransform.getBB_recursive().getCenter().u);
 		setRotationCenter(newCenter);
 		advRotateComboBox->setCurrentIndex(0);
-		rotComboBox->setEnabled(true);
 		return false;
 	}
 }
@@ -384,7 +382,7 @@ void ccGraphicalTransformationTool::advTranslateRefUpdate(int index)
 		return;
 	}
 	int id = advTranslateComboBox->itemData(index).toInt();
-	for (int i = 0; i < m_planesAndLineSegments.size(); i++)
+	for (size_t i = 0; i < m_planesAndLineSegments.size(); i++)
 	{
 		if (id == m_planesAndLineSegments[i]->getUniqueID())
 		{
@@ -425,7 +423,7 @@ void ccGraphicalTransformationTool::advRotateRefUpdate(int index)
 			rotComboBox->insertItem(2, "Y");
 			rotComboBox->insertItem(3, "Z");
 			rotComboBox->insertItem(4, "None");
-			rotComboBox->setCurrentIndex(3);
+			rotComboBox->setCurrentIndex(rotComboBoxItems::Z);
 		}
 		CCVector3d center = CCVector3d::fromArray(m_toTransform.getBB_recursive().getCenter().u);
 		setRotationCenter(center);
@@ -440,7 +438,7 @@ void ccGraphicalTransformationTool::advRotateRefUpdate(int index)
 		return;
 	}
 	int id = advRotateComboBox->itemData(index).toInt();
-	for (int i = 0; i < m_planesAndLineSegments.size(); i++)
+	for (size_t i = 0; i < m_planesAndLineSegments.size(); i++)
 	{
 		if (id == m_planesAndLineSegments[i]->getUniqueID())
 		{
@@ -687,19 +685,19 @@ void ccGraphicalTransformationTool::glRotate(const ccGLMatrixd& rotMat)
 	{
 		switch (rotComboBox->currentIndex())
 		{
-		case 0: //XYZ
+		case rotComboBoxItems::XYZ:
 			m_rotation = rotMat * m_rotation;
 			break;
-		case 1: //X
+		case rotComboBoxItems::X:
 			m_rotation = rotMat.xRotation() * m_rotation;
 			break;
-		case 2: //Y
+		case rotComboBoxItems::Y:
 			m_rotation = rotMat.yRotation() * m_rotation;
 			break;
-		case 3: //Z
+		case rotComboBoxItems::Z:
 			m_rotation = rotMat.zRotation() * m_rotation;
 			break;
-		case 4: //None
+		case rotComboBoxItems::NONE:
 			break;
 		}
 	}

--- a/qCC/ccGraphicalTransformationTool.cpp
+++ b/qCC/ccGraphicalTransformationTool.cpp
@@ -43,8 +43,8 @@ ccGraphicalTransformationTool::ccGraphicalTransformationTool(QWidget* parent)
 	connect(advPushButton, &QPushButton::toggled, this, &ccGraphicalTransformationTool::advModeToggle);
 	connect(advTranslateComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ccGraphicalTransformationTool::advTranslateRefUpdate);
 	connect(advRotateComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ccGraphicalTransformationTool::advRotateRefUpdate);
-	connect(refAxisRadio, &QRadioButton::toggled, this, &ccGraphicalTransformationTool::advAxisRefChanged);
-
+	connect(refAxisRadio, &QRadioButton::toggled, this, &ccGraphicalTransformationTool::advRefAxisCenter);
+	connect(objCenterRadio, &QRadioButton::toggled, this, &ccGraphicalTransformationTool::advObjectCenterAxis);
 	//add shortcuts
 	addOverridenShortcut(Qt::Key_Space); //space bar for the "pause" button
 	addOverridenShortcut(Qt::Key_Escape); //escape key for the "cancel" button
@@ -116,12 +116,11 @@ void ccGraphicalTransformationTool::advModeToggle(bool state)
 	rotAxisLabel->setVisible(state);
 	objCenterRadio->setVisible(state);
 	refAxisRadio->setVisible(state);
-	groupBox->setVisible(state);
 	m_advMode = state;
 	int wPrev = this->width();
 	if (state)
 	{
-		this->setGeometry(this->x() + (-wPrev + 250), this->y(), 250, 225);
+		this->setGeometry(this->x() + (-wPrev + 250), this->y(), 250, 235);
 		if (advTranslateComboBox->currentIndex() != 0)
 		{
 			TxCheckBox->setEnabled(false);
@@ -467,9 +466,22 @@ void ccGraphicalTransformationTool::advRotateRefUpdate(int index)
 	advRotateRefUpdate(0);
 }
 
-void ccGraphicalTransformationTool::advAxisRefChanged(bool state)
+void ccGraphicalTransformationTool::advRefAxisCenter(bool state)
 {
-	advRotateRefUpdate(advRotateComboBox->currentIndex()); //force an update
+	if (state)
+	{
+		advRotateRefUpdate(advRotateComboBox->currentIndex()); //force an update
+		objCenterRadio->setChecked(false);
+	}
+}
+
+void ccGraphicalTransformationTool::advObjectCenterAxis(bool state)
+{
+	if (state)
+	{
+		advRotateRefUpdate(advRotateComboBox->currentIndex()); //force an update
+		refAxisRadio->setChecked(false);
+	}
 }
 
 void ccGraphicalTransformationTool::clear()

--- a/qCC/ccGraphicalTransformationTool.cpp
+++ b/qCC/ccGraphicalTransformationTool.cpp
@@ -37,7 +37,8 @@ ccGraphicalTransformationTool::ccGraphicalTransformationTool(QWidget* parent)
 	connect(okButton,       &QAbstractButton::clicked,	this, &ccGraphicalTransformationTool::apply);
 	connect(razButton,	  &QAbstractButton::clicked,	this, &ccGraphicalTransformationTool::reset);
 	connect(cancelButton,   &QAbstractButton::clicked,	this, &ccGraphicalTransformationTool::cancel);
-
+	connect(advComboBox, qOverload<int>(&QComboBox::currentIndexChanged), this, &ccGraphicalTransformationTool::advancedModeChanged);
+	
 	//add shortcuts
 	addOverridenShortcut(Qt::Key_Space); //space bar for the "pause" button
 	addOverridenShortcut(Qt::Key_Escape); //escape key for the "cancel" button
@@ -86,7 +87,16 @@ void ccGraphicalTransformationTool::pause(bool state)
 	else
 	{
 		m_associatedWin->setInteractionMode(ccGLWindow::TRANSFORM_ENTITIES());
-		m_associatedWin->displayNewMessage("[Rotation/Translation mode]",ccGLWindow::UPPER_CENTER_MESSAGE,false,3600,ccGLWindow::MANUAL_TRANSFORMATION_MESSAGE);
+		if (advComboBox->currentIndex() == 1)
+		{
+			m_associatedWin->displayNewMessage("[Advanced Translation mode]", ccGLWindow::UPPER_CENTER_MESSAGE, false, 3600, ccGLWindow::MANUAL_TRANSFORMATION_MESSAGE);
+			m_associatedWin->displayNewMessage("[Select Plane or Line to translate along]", ccGLWindow::UPPER_CENTER_MESSAGE, true, 3600, ccGLWindow::MANUAL_TRANSFORMATION_MESSAGE);
+			m_associatedWin->displayNewMessage("[If plane selected, translation will be along the plane normal]", ccGLWindow::UPPER_CENTER_MESSAGE, true, 3600, ccGLWindow::MANUAL_TRANSFORMATION_MESSAGE);
+		}
+		else 
+		{
+			m_associatedWin->displayNewMessage("[Rotation/Translation mode]", ccGLWindow::UPPER_CENTER_MESSAGE, false, 3600, ccGLWindow::MANUAL_TRANSFORMATION_MESSAGE);
+		}
 	}
 
 	//update mini-GUI
@@ -94,6 +104,34 @@ void ccGraphicalTransformationTool::pause(bool state)
 	pauseButton->setChecked(state);
 	pauseButton->blockSignals(false);
 
+	m_associatedWin->redraw(true, false);
+}
+
+void ccGraphicalTransformationTool::advancedModeChanged(int)
+{
+	if (!m_associatedWin)
+		return;
+	switch (advComboBox->currentIndex())
+	{
+		case 0: //None
+		{
+			if (!pauseButton->isChecked())
+			{
+				m_associatedWin->displayNewMessage("[Rotation/Translation mode]", ccGLWindow::UPPER_CENTER_MESSAGE, false, 3600, ccGLWindow::MANUAL_TRANSFORMATION_MESSAGE);
+			}
+			break;
+		}
+		case 1: //advanced translate mode
+		{
+			if (!pauseButton->isChecked())
+			{
+				m_associatedWin->displayNewMessage("[Advanced Translation mode]", ccGLWindow::UPPER_CENTER_MESSAGE, false, 3600, ccGLWindow::MANUAL_TRANSFORMATION_MESSAGE);
+				m_associatedWin->displayNewMessage("[Select Plane or Line to translate along]", ccGLWindow::UPPER_CENTER_MESSAGE, true, 3600, ccGLWindow::MANUAL_TRANSFORMATION_MESSAGE);
+				m_associatedWin->displayNewMessage("[If plane selected, translation will be along the plane normal]", ccGLWindow::UPPER_CENTER_MESSAGE, true, 3600, ccGLWindow::MANUAL_TRANSFORMATION_MESSAGE);
+			}
+			break;
+		}
+	}
 	m_associatedWin->redraw(true, false);
 }
 

--- a/qCC/ccGraphicalTransformationTool.cpp
+++ b/qCC/ccGraphicalTransformationTool.cpp
@@ -856,7 +856,8 @@ void ccGraphicalTransformationTool::updateAllGLTransformations()
 		else if (m_advTranslateRef->isA(CC_TYPES::POLY_LINE))
 		{
 			ccPolyline* line = static_cast<ccPolyline*>(m_advTranslateRef);
-			m_advTranslationTransform = m_position * arbitraryVectorTranslation(*line->getPoint(1) - *line->getPoint(0));
+			CCVector3 arbitraryVec = line->getGLTransformation() * (*line->getPoint(1) - *line->getPoint(0));
+			m_advTranslationTransform = m_position * arbitraryVectorTranslation(arbitraryVec);
 		}
 	}
 	

--- a/qCC/ccGraphicalTransformationTool.cpp
+++ b/qCC/ccGraphicalTransformationTool.cpp
@@ -121,7 +121,7 @@ void ccGraphicalTransformationTool::advModeToggle(bool state)
 	int wPrev = this->width();
 	if (state)
 	{
-		this->setGeometry(this->x() + (-wPrev + 200), this->y(), 200, 225);
+		this->setGeometry(this->x() + (-wPrev + 250), this->y(), 250, 225);
 		if (advTranslateComboBox->currentIndex() != 0)
 		{
 			TxCheckBox->setEnabled(false);
@@ -136,7 +136,7 @@ void ccGraphicalTransformationTool::advModeToggle(bool state)
 		TyCheckBox->setEnabled(true);
 		this->setGeometry(this->x() , this->y(), 0, 0);
 		this->adjustSize(); //adjust size will minimize the display height with the dropdowns not visible
-		this->setGeometry(this->x() + (wPrev - 200), this->y(), 200, this->height());
+		this->setGeometry(this->x() + (wPrev - 250), this->y(), 250, this->height());
 		advRotateRefUpdate(0); //index 0 is always the origin
 		advTranslateRefUpdate(0); //index 0 is always the origin
 	}
@@ -626,15 +626,20 @@ void ccGraphicalTransformationTool::stop(bool state)
 
 void ccGraphicalTransformationTool::glTranslate(const CCVector3d& realT)
 {
-	CCVector3d t(	realT.x * (TxCheckBox->isChecked() ? 1 : 0),
-					realT.y * (TyCheckBox->isChecked() ? 1 : 0),
-					realT.z * (TzCheckBox->isChecked() ? 1 : 0));
-
+	CCVector3d mouseMove = realT;
+	if (m_advMode)
+	{
+		m_advTranslationTransform.inverse().applyRotation(mouseMove);
+	}
+	CCVector3d t(	mouseMove.x * (TxCheckBox->isChecked() ? 1 : 0),
+					mouseMove.y * (TyCheckBox->isChecked() ? 1 : 0),
+					mouseMove.z * (TzCheckBox->isChecked() ? 1 : 0));
+		
 	if (m_advMode)
 	{
 		m_advTranslationTransform.applyRotation(t);
 	}
-		
+
 	if (t.norm2() != 0)
 	{
 		m_translation += t;

--- a/qCC/ccGraphicalTransformationTool.cpp
+++ b/qCC/ccGraphicalTransformationTool.cpp
@@ -41,8 +41,8 @@ ccGraphicalTransformationTool::ccGraphicalTransformationTool(QWidget* parent)
 	connect(razButton,	  &QAbstractButton::clicked,	this, &ccGraphicalTransformationTool::reset);
 	connect(cancelButton,   &QAbstractButton::clicked,	this, &ccGraphicalTransformationTool::cancel);
 	connect(advPushButton, &QPushButton::toggled, this, &ccGraphicalTransformationTool::advModeToggle);
-	connect(advTranslateComboBox, qOverload<int>(&QComboBox::currentIndexChanged), this, &ccGraphicalTransformationTool::advTranslateRefUpdate);
-	connect(advRotateComboBox, qOverload<int>(&QComboBox::currentIndexChanged), this, &ccGraphicalTransformationTool::advRotateRefUpdate);
+	connect(advTranslateComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ccGraphicalTransformationTool::advTranslateRefUpdate);
+	connect(advRotateComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ccGraphicalTransformationTool::advRotateRefUpdate);
 	connect(refAxisRadio, &QRadioButton::toggled, this, &ccGraphicalTransformationTool::advAxisRefChanged);
 
 	//add shortcuts

--- a/qCC/ccGraphicalTransformationTool.h
+++ b/qCC/ccGraphicalTransformationTool.h
@@ -89,8 +89,11 @@ protected slots:
 	//! Updates the transform for advanced mode rotation when rotate ref changed
 	void advRotateRefUpdate(int index);
 
-	//! Updates the axis center of rotation in adv rotate/translate mode
-	void advAxisRefChanged(bool state);
+	//! Updates the axis center of rotation to the ref object in adv rotate/translate mode
+	void advRefAxisCenter(bool state);
+
+	//! Updates the axis center of rotation to the object center in adv rotate/translate mode
+	void advObjectCenterAxis(bool state);
 
 	//! Updates the top center display message according to the mode
 	void updateDisplayMessage();

--- a/qCC/ccGraphicalTransformationTool.h
+++ b/qCC/ccGraphicalTransformationTool.h
@@ -48,7 +48,7 @@ public:
 	virtual void stop(bool state) override;
 
 	//! unselect all advanced mode references
-	void ccGraphicalTransformationTool::clearAdvModeEntities();
+	void clearAdvModeEntities();
 
 	//! Adds an entity to the 'selected' entities set
 	/** Only the 'selected' entities are moved.

--- a/qCC/ccGraphicalTransformationTool.h
+++ b/qCC/ccGraphicalTransformationTool.h
@@ -81,13 +81,13 @@ protected slots:
 	void pause(bool);
 
 	//! Togggles the visibility of the advanced mode ui
-	void advModeVisible(bool state);
+	void advModeToggle(bool state);
 
 	//! Updates the transform for advanced mode rotation when translate ref changed
-	void advTranslateRefChanged(int index);
+	void advTranslateRefUpdate(int index);
 
 	//! Updates the transform for advanced mode rotation when rotate ref changed
-	void advRotateRefChanged(int index);
+	void advRotateRefUpdate(int index);
 
 	//! Updates the axis center of rotation in adv rotate/translate mode
 	void advAxisRefChanged(bool state);
@@ -116,13 +116,22 @@ protected:
 	void populateAdvModeItems();
 
 	//! Sets the translation transform used in advanced translate/rotate mode
-	bool setAdvancedTranslationTransform(ccHObject* translateRef);
+	bool setAdvTranslationTransform(ccHObject* translateRef);
 
 	//! Sets the rotation transform used in advaced translate/rotate mode
-	bool setAdvancedRotationTransform(ccHObject* translateRef);
+	bool setAdvRotationAxis(ccHObject* rotateRef);
+
+	//! Flag for advanced mode
+	bool m_advMode;
 
 	//! List of entities to be transformed
 	ccHObject m_toTransform;
+
+	//! Current advanced translate mode ref object
+	ccHObject* m_advTranslateRef = nullptr;
+
+	//! Current advanced rotate mode ref object
+	ccHObject* m_advRotateRef = nullptr;
 
 	//! Current rotation
 	ccGLMatrixd m_rotation;
@@ -136,9 +145,10 @@ protected:
 	//! Transform used in advanced translate/rotate mode
 	ccGLMatrixd m_advTranslationTransform;
 
-	//! Current rotation axis for adv translate/rotate mode
+	//! Current rotation axis vector for adv translate/rotate mode (not neccesarily rotation center)
 	CCVector3d m_advRotationAxis;
 
+	//! Current reference object for rotation center point
 	CCVector3d m_advRotationRefObjCenter;
 
 	//! Rotation center

--- a/qCC/ccGraphicalTransformationTool.h
+++ b/qCC/ccGraphicalTransformationTool.h
@@ -63,7 +63,7 @@ public:
 	void setRotationCenter(CCVector3d& center);
 
 	//! Calculates the transform for translating along an arbitrary vector
-	ccGLMatrix getArbitraryVectorTranslationTransform(const CCVector3& vec);
+	ccGLMatrixd getArbitraryVectorTranslationTransform(const CCVector3& vec);
 
 
 protected slots:
@@ -83,8 +83,14 @@ protected slots:
 	//! Togggles the visibility of the advanced mode ui
 	void advModeVisible(bool state);
 
-	//! Updates the transform for advanced mode when translate ref changed
+	//! Updates the transform for advanced mode rotation when translate ref changed
 	void advTranslateRefChanged(int index);
+
+	//! Updates the transform for advanced mode rotation when rotate ref changed
+	void advRotateRefChanged(int index);
+
+	//! Updates the axis center of rotation in adv rotate/translate mode
+	void advAxisRefChanged(bool state);
 
 	//! Updates the top center display message according to the mode
 	void updateDisplayMessage();
@@ -109,8 +115,11 @@ protected:
 	//! Sets Advanced translate/rotation mode reference items
 	void populateAdvModeItems();
 
-	//! Sets the transform used in advanced translate/rotate mode
+	//! Sets the translation transform used in advanced translate/rotate mode
 	bool setAdvancedTranslationTransform(ccHObject* translateRef);
+
+	//! Sets the rotation transform used in advaced translate/rotate mode
+	bool setAdvancedRotationTransform(ccHObject* translateRef);
 
 	//! List of entities to be transformed
 	ccHObject m_toTransform;
@@ -121,8 +130,16 @@ protected:
 	//! Current translation
 	CCVector3d m_translation;
 
+	//! Current position
+	ccGLMatrixd m_position;
+
 	//! Transform used in advanced translate/rotate mode
-	ccGLMatrix m_advancedTranslationTransform;
+	ccGLMatrixd m_advTranslationTransform;
+
+	//! Current rotation axis for adv translate/rotate mode
+	CCVector3d m_advRotationAxis;
+
+	CCVector3d m_advRotationRefObjCenter;
 
 	//! Rotation center
 	/** The rotation center is actually the center of gravity of the selected 'entities'

--- a/qCC/ccGraphicalTransformationTool.h
+++ b/qCC/ccGraphicalTransformationTool.h
@@ -62,8 +62,11 @@ public:
 	//! Sets the rotation center
 	void setRotationCenter(CCVector3d& center);
 
-	//! Calculates the transform for translating along an arbitrary vector
-	ccGLMatrixd getArbitraryVectorTranslationTransform(const CCVector3& vec);
+	//! Returns the transform for translating along an arbitrary vector
+	ccGLMatrixd arbitraryVectorTranslation(const CCVector3& vec);
+
+	//! Returns the transform for rotation around an arbitrary vector
+	ccGLMatrixd arbitraryVectorRotation(double angle, const CCVector3d&);
 
 
 protected slots:
@@ -90,10 +93,10 @@ protected slots:
 	void advRotateRefUpdate(int index);
 
 	//! Updates the axis center of rotation to the ref object in adv rotate/translate mode
-	void advRefAxisCenter(bool state);
+	void advRefAxisRadioToggled(bool state);
 
 	//! Updates the axis center of rotation to the object center in adv rotate/translate mode
-	void advObjectCenterAxis(bool state);
+	void advObjectAxisRadioToggled(bool state);
 
 	//! Updates the top center display message according to the mode
 	void updateDisplayMessage();
@@ -124,8 +127,17 @@ protected:
 	//! Sets the rotation transform used in advaced translate/rotate mode
 	bool setAdvRotationAxis(ccHObject* rotateRef);
 
+	//! Check if the entitry is in m_toTransform
+	bool entityInTransformList(ccHObject* entity);
+
 	//! Flag for advanced mode
 	bool m_advMode;
+
+	//! Flag if the rotation reference object is in m_toTransform
+	bool m_advRotateRefIsChild;
+
+	//! Flag if the translate reference object is in m_toTransform
+	bool m_advTranslateRefIsChild;
 
 	//! List of entities to be transformed
 	ccHObject m_toTransform;

--- a/qCC/ccGraphicalTransformationTool.h
+++ b/qCC/ccGraphicalTransformationTool.h
@@ -47,6 +47,9 @@ public:
 	virtual bool start() override;
 	virtual void stop(bool state) override;
 
+	//! unselect all advanced mode references
+	void ccGraphicalTransformationTool::clearAdvModeEntities();
+
 	//! Adds an entity to the 'selected' entities set
 	/** Only the 'selected' entities are moved.
 		\return success, if the entity is eligible for graphical transformation

--- a/qCC/ccGraphicalTransformationTool.h
+++ b/qCC/ccGraphicalTransformationTool.h
@@ -79,6 +79,8 @@ protected slots:
 	//! Pauses the transformation mode
 	void pause(bool);
 
+	void advancedModeChanged(int);
+
 	//! Applies translation (graphically) to selected entities
 	void glTranslate(const CCVector3d&);
 

--- a/qCC/ccGraphicalTransformationTool.h
+++ b/qCC/ccGraphicalTransformationTool.h
@@ -62,7 +62,7 @@ public:
 	//! Sets the rotation center
 	void setRotationCenter(CCVector3d& center);
 
-	void arbitraryVectorTranslate(CCVector3d& vectorToTranslate, const CCVector3d& vec);
+	ccGLMatrix getArbitraryVectorTranslationTransform(const CCVector3& vec);
 
 
 protected slots:
@@ -80,6 +80,10 @@ protected slots:
 	void pause(bool);
 
 	void advancedModeChanged(int);
+
+	bool setAdvancedTranslationTransform();
+
+	void updateDisplayMessage();
 
 	//! Applies translation (graphically) to selected entities
 	void glTranslate(const CCVector3d&);
@@ -106,6 +110,8 @@ protected:
 
 	//! Current translation
 	CCVector3d m_translation;
+
+	ccGLMatrix m_advancedTranslationTransform;
 
 	//! Rotation center
 	/** The rotation center is actually the center of gravity of the selected 'entities'

--- a/qCC/ccGraphicalTransformationTool.h
+++ b/qCC/ccGraphicalTransformationTool.h
@@ -158,6 +158,9 @@ protected:
 
 	//! Planes and line segments found in the dbtree for adv transate/rotate
 	ccHObject::Container m_planesAndLineSegments;
+
+	//! rotComboBox enum
+	enum rotComboBoxItems {XYZ, X, Y, Z, NONE};
 };
 
 #endif //CC_GRAPHICAL_TRANSFORMATION_TOOL_HEADER

--- a/qCC/ccGraphicalTransformationTool.h
+++ b/qCC/ccGraphicalTransformationTool.h
@@ -62,6 +62,7 @@ public:
 	//! Sets the rotation center
 	void setRotationCenter(CCVector3d& center);
 
+	//! Calculates the transform for translating along an arbitrary vector
 	ccGLMatrix getArbitraryVectorTranslationTransform(const CCVector3& vec);
 
 
@@ -79,10 +80,13 @@ protected slots:
 	//! Pauses the transformation mode
 	void pause(bool);
 
-	void advancedModeChanged(int);
+	//! Togggles the visibility of the advanced mode ui
+	void advModeVisible(bool state);
 
-	bool setAdvancedTranslationTransform();
+	//! Updates the transform for advanced mode when translate ref changed
+	void advTranslateRefChanged(int index);
 
+	//! Updates the top center display message according to the mode
 	void updateDisplayMessage();
 
 	//! Applies translation (graphically) to selected entities
@@ -102,6 +106,12 @@ protected:
 	//! Updates all selected entities GL transformation matrices
 	void updateAllGLTransformations();
 
+	//! Sets Advanced translate/rotation mode reference items
+	void populateAdvModeItems();
+
+	//! Sets the transform used in advanced translate/rotate mode
+	bool setAdvancedTranslationTransform(ccHObject* translateRef);
+
 	//! List of entities to be transformed
 	ccHObject m_toTransform;
 
@@ -111,12 +121,16 @@ protected:
 	//! Current translation
 	CCVector3d m_translation;
 
+	//! Transform used in advanced translate/rotate mode
 	ccGLMatrix m_advancedTranslationTransform;
 
 	//! Rotation center
 	/** The rotation center is actually the center of gravity of the selected 'entities'
 	**/
 	CCVector3d m_rotationCenter;
+
+	//! Planes and line segments found in the dbtree for adv transate/rotate
+	ccHObject::Container m_planesAndLineSegments;
 };
 
 #endif //CC_GRAPHICAL_TRANSFORMATION_TOOL_HEADER

--- a/qCC/ccGraphicalTransformationTool.h
+++ b/qCC/ccGraphicalTransformationTool.h
@@ -62,6 +62,9 @@ public:
 	//! Sets the rotation center
 	void setRotationCenter(CCVector3d& center);
 
+	void arbitraryVectorTranslate(CCVector3d& vectorToTranslate, const CCVector3d& vec);
+
+
 protected slots:
 
 	//! Applies transformation to selected entities

--- a/qCC/ui_templates/graphicalTransformationDlg.ui
+++ b/qCC/ui_templates/graphicalTransformationDlg.ui
@@ -305,7 +305,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="translateComboBox">
+      <widget class="QComboBox" name="advTranslateComboBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -337,7 +337,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="rotateComboBox">
+      <widget class="QComboBox" name="advRotateComboBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
          <horstretch>0</horstretch>

--- a/qCC/ui_templates/graphicalTransformationDlg.ui
+++ b/qCC/ui_templates/graphicalTransformationDlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>146</width>
-    <height>109</height>
+    <height>141</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -20,6 +20,9 @@
    <string>Graphical Transformation</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetDefaultConstraint</enum>
+   </property>
    <property name="leftMargin">
     <number>6</number>
    </property>
@@ -256,6 +259,31 @@
        <property name="checked">
         <bool>true</bool>
        </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Advanced</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="advComboBox">
+       <item>
+        <property name="text">
+         <string>None</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Translate</string>
+        </property>
+       </item>
       </widget>
      </item>
     </layout>

--- a/qCC/ui_templates/graphicalTransformationDlg.ui
+++ b/qCC/ui_templates/graphicalTransformationDlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>250</width>
-    <height>225</height>
+    <height>235</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -369,36 +369,29 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_7">
      <item>
-      <widget class="QGroupBox" name="groupBox">
-       <property name="title">
-        <string/>
+      <widget class="QRadioButton" name="objCenterRadio">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <widget class="QRadioButton" name="refAxisRadio">
-        <property name="geometry">
-         <rect>
-          <x>90</x>
-          <y>0</y>
-          <width>91</width>
-          <height>16</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Reference Axis</string>
-        </property>
-       </widget>
-       <widget class="QRadioButton" name="objCenterRadio">
-        <property name="geometry">
-         <rect>
-          <x>0</x>
-          <y>0</y>
-          <width>91</width>
-          <height>16</height>
-         </rect>
-        </property>
-        <property name="text">
-         <string>Object Center</string>
-        </property>
-       </widget>
+       <property name="text">
+        <string>Object Center</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="refAxisRadio">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Reference Axis</string>
+       </property>
       </widget>
      </item>
     </layout>

--- a/qCC/ui_templates/graphicalTransformationDlg.ui
+++ b/qCC/ui_templates/graphicalTransformationDlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>146</width>
-    <height>141</height>
+    <width>200</width>
+    <height>200</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -204,6 +204,11 @@
          <string notr="true">Z</string>
         </property>
        </item>
+       <item>
+        <property name="text">
+         <string>None</string>
+        </property>
+       </item>
       </widget>
      </item>
     </layout>
@@ -266,22 +271,82 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
-      <widget class="QLabel" name="label_2">
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="advPushButton">
        <property name="text">
         <string>Advanced</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,0">
+     <item>
+      <widget class="QLabel" name="translateLabel">
+       <property name="text">
+        <string>Translate Along:</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="advComboBox">
+      <widget class="QComboBox" name="translateComboBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <item>
         <property name="text">
-         <string>None</string>
+         <string>Origin</string>
         </property>
        </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_6">
+     <item>
+      <widget class="QLabel" name="rotateLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Rotate Around:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="rotateComboBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <item>
         <property name="text">
-         <string>Translate</string>
+         <string>Origin</string>
         </property>
        </item>
       </widget>

--- a/qCC/ui_templates/graphicalTransformationDlg.ui
+++ b/qCC/ui_templates/graphicalTransformationDlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>200</width>
-    <height>200</height>
+    <height>225</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -349,6 +349,56 @@
          <string>Origin</string>
         </property>
        </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="rotAxisLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Rotation Axis Selection:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_7">
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string/>
+       </property>
+       <widget class="QRadioButton" name="refAxisRadio">
+        <property name="geometry">
+         <rect>
+          <x>90</x>
+          <y>0</y>
+          <width>91</width>
+          <height>16</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Reference Axis</string>
+        </property>
+       </widget>
+       <widget class="QRadioButton" name="objCenterRadio">
+        <property name="geometry">
+         <rect>
+          <x>0</x>
+          <y>0</y>
+          <width>91</width>
+          <height>16</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Object Center</string>
+        </property>
+       </widget>
       </widget>
      </item>
     </layout>

--- a/qCC/ui_templates/graphicalTransformationDlg.ui
+++ b/qCC/ui_templates/graphicalTransformationDlg.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>200</width>
+    <width>250</width>
     <height>225</height>
    </rect>
   </property>


### PR DESCRIPTION
This PR fixes #895 by adding the following functions:
- Rotation using an arbitrary vector as both the axis and center of rotation.
- Rotation using an arbitrary vector as the axis but using the object's center as the center of rotation.
- Rotation as above but using an arbitrary plane's normal as the vector.
- Translation along an arbitrary plane in the plane's x, y, and z coordinates.
- Translation along an arbitrary vector using the vector as the z direction.

The Rotation/Translation UI was modified to have dropdown menus to select the plane/line references if they exist in the db root. Only single segment polylines are allowed to be selected. There is a button to toggle between the advanced mode and the regular mode as well. Any comments or suggestions would be appreciated! Thanks for your time to review.