### PR TITLE
WIP: Select correct LAS version_minor depending on the point format used

### DIFF
--- a/plugins/core/IO/qLASFWFIO/CMakeLists.txt
+++ b/plugins/core/IO/qLASFWFIO/CMakeLists.txt
@@ -16,7 +16,7 @@ if (WIN32)
 		set( CC_PLUGIN_CUSTOM_SOURCE_LIST Filter/LASFWFFilter.cpp )
 			
 		#we need the saveLASFileDlg.ui file
-		set( CC_PLUGIN_CUSTOM_UI_LIST ${QCC_IO_LIB_SOURCE_DIR}/ui_templates/saveLASFileDlg.ui )
+		set( CC_PLUGIN_CUSTOM_UI_LIST ../qPDALIO/ui/saveLASFileDlg.ui )
 
 		set( CC_IS_IO_PLUGIN 1 )
 

--- a/plugins/core/IO/qLASFWFIO/Filter/LASFWFFilter.cpp
+++ b/plugins/core/IO/qLASFWFIO/Filter/LASFWFFilter.cpp
@@ -261,6 +261,7 @@ CC_FILE_ERROR LASFWFFilter::saveToFile(ccHObject* entity, const QString& filenam
 			minPointFormat = LasField::UpdateMinPointFormat(minPointFormat, hasColors, hasFWF, false); //no legacy format with this plugin
 			
 			lasheader.point_data_format = minPointFormat;
+			lasheader.version_minor = LasField::VersionMinorForPointFormat(minPointFormat);
 			lasheader.point_data_record_length = LasField::GetFormatRecordLength(lasheader.point_data_format);
 
 			//FWF descriptors and other parameters

--- a/plugins/core/IO/qPDALIO/src/LASFields.h
+++ b/plugins/core/IO/qPDALIO/src/LASFields.h
@@ -218,6 +218,10 @@ struct LasField
 		}
 	}
 
+	static uint8_t VersionMinorForPointFormat(uint8_t pointFormat) {
+		return pointFormat >= 6 ? 4 : 2;
+	}
+
 	static uint8_t UpdateMinPointFormat(uint8_t minPointFormat, bool withRGB, bool withFWF, bool allowLegacyFormats = true)
 	{
 		//can we keep the (short) legacy formats?


### PR DESCRIPTION
It should fix  #1012 
Also corrects the save dialog ui path which was not changed when the standard LASFilter was moved to a IO Plugin

I was not able to test it yet as I have a problem linking the qLASFWIO plugin to LASlib
