### PR TITLE
Remove json cpp from qPDALIO plugin

### DIFF
--- a/plugins/core/IO/qPDALIO/CMakeLists.txt
+++ b/plugins/core/IO/qPDALIO/CMakeLists.txt
@@ -19,14 +19,6 @@ if ( PLUGIN_IO_QPDAL )
 		link_directories( ${PDAL_LIBRARY_DIRS} )
 	endif()
 
-	set( JSON_ROOT_DIR "" CACHE PATH "Jsoncpp root dir (PDAL/vendor/jsoncpp/dist)" )
-	
-	if( NOT JSON_ROOT_DIR )
-		message( WARNING "Jsoncpp root dir is not specified (JSON_ROOT_DIR)" )
-	else()
-		include_directories( ${JSON_ROOT_DIR} )
-	endif()
-	
 	# Plugin source
 	include_directories( src )
 


### PR DESCRIPTION
It was never used, and it displays a warning during cmake's generation