### PR TITLE
Ransac compilation for arm

### DIFF
--- a/plugins/core/Standard/qRANSAC_SD/RANSAC_SD_orig/GfxTL/FlatCopyVector.h
+++ b/plugins/core/Standard/qRANSAC_SD/RANSAC_SD_orig/GfxTL/FlatCopyVector.h
@@ -8,6 +8,32 @@
 #include <memory.h>
 #include <iterator>
 
+#if defined(__x86_64__) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64)
+#include <xmmintrin.h>
+#endif
+
+#ifndef _WIN32
+void* _aligned_malloc(size_t size, size_t alignment) {
+	void* buffer;
+	posix_memalign(&buffer, alignment, size);
+	return buffer;
+}
+#endif
+
+#ifdef _mm_malloc
+#define a_malloc(align,sz) _mm_malloc((align),(sz))
+#endif
+#ifdef _mm_free
+#define a_free(ptr)  _mm_free((ptr))
+#endif
+
+#ifndef a_free  
+#define a_free(a)      free(a) 
+#endif // !_mm_free
+#ifndef a_malloc
+#define a_malloc(a, b) _aligned_malloc(a, b)
+#endif // !_mm_malloc
+
 namespace GfxTL
 {
 	template< class T >
@@ -35,7 +61,7 @@ namespace GfxTL
 
 			FlatCopyVector(size_t s)
 			{
-				m_begin = (T *)_mm_malloc(s * sizeof(T), 16); //new T[s];
+				m_begin = (T *)a_malloc(s * sizeof(T), 16); //new T[s];
 				m_end = m_begin + s;
 				m_capacity = m_end;
 			}
@@ -50,7 +76,7 @@ namespace GfxTL
 					m_capacity = NULL;
 					return;
 				}
-				m_begin = (T *)_mm_malloc(s * sizeof(T), 16); //new T[s];
+				m_begin = (T *)a_malloc(s * sizeof(T), 16); //new T[s];
 				m_end = m_begin + s;
 				m_capacity = m_end;
 				memcpy(m_begin, v.m_begin, s * sizeof(T));
@@ -59,7 +85,7 @@ namespace GfxTL
 			~FlatCopyVector()
 			{
 				if(m_begin)
-					_mm_free(m_begin); //delete[] m_begin;
+					a_free(m_begin); //delete[] m_begin;
 			}
 
 			FlatCopyVector< T > &operator=(const FlatCopyVector< T > &v)
@@ -73,8 +99,8 @@ namespace GfxTL
 					return *this;
 				}
 				if(m_begin)
-					_mm_free(m_begin); //delete[] m_begin;
-				m_begin = (T *)_mm_malloc(s * sizeof(T), 16); //new T[s];
+					a_free(m_begin); //delete[] m_begin;
+				m_begin = (T *)a_malloc(s * sizeof(T), 16); //new T[s];
 				m_end = m_begin + s;
 				m_capacity = m_end;
 				memcpy(m_begin, v.m_begin, s * sizeof(T));
@@ -92,11 +118,11 @@ namespace GfxTL
 				if((size_t)(m_capacity - m_begin) < s)
 				{
 					size_t olds = size();
-					T *newBegin = (T *)_mm_malloc(s * sizeof(T), 16); //new T[s];
+					T *newBegin = (T *)a_malloc(s * sizeof(T), 16); //new T[s];
 					if(m_begin)
 					{
 						memcpy(newBegin, m_begin, olds * sizeof(T));
-						_mm_free(m_begin); //delete[] m_begin;
+						a_free(m_begin); //delete[] m_begin;
 					}
 					m_end = newBegin + olds;
 					m_begin = newBegin;
@@ -126,11 +152,11 @@ namespace GfxTL
 					m_end = m_begin + s;
 					return;
 				}
-				T *newBegin = (T *)_mm_malloc(s * sizeof(T), 16); //new T[s];
+				T *newBegin = (T *)a_malloc(s * sizeof(T), 16); //new T[s];
 				if(m_begin)
 				{
 					memcpy(newBegin, m_begin, size() * sizeof(T));
-					_mm_free(m_begin); //delete[] m_begin;
+					a_free(m_begin); //delete[] m_begin;
 				}
 				m_end = newBegin + s;
 				m_begin = newBegin;
@@ -175,11 +201,11 @@ namespace GfxTL
 					size_t olds = size();
 					size_t s = olds * 2;
 					if(!s) s = 1;
-					T *newBegin = (T *)_mm_malloc(s * sizeof(T), 16); //new T[s];
+					T *newBegin = (T *)a_malloc(s * sizeof(T), 16); //new T[s];
 					if(m_begin)
 					{
 						memcpy(newBegin, m_begin, olds * sizeof(T));
-						_mm_free(m_begin); //delete[] m_begin;
+						a_free(m_begin); //delete[] m_begin;
 					}
 					m_end = newBegin + olds;
 					m_begin = newBegin;
@@ -197,11 +223,11 @@ namespace GfxTL
 					size_t olds = size();
 					size_t s = olds * 2;
 					if(!s) s = 1;
-					T *newBegin = (T *)_mm_malloc(s * sizeof(T), 16); //new T[s];
+					T *newBegin = (T *)a_malloc(s * sizeof(T), 16); //new T[s];
 					if(m_begin)
 					{
 						memcpy(newBegin, m_begin, olds * sizeof(T));
-						_mm_free(m_begin); //delete[] m_begin;
+						a_free(m_begin); //delete[] m_begin;
 					}
 					m_end = newBegin + olds;
 					m_begin = newBegin;


### PR DESCRIPTION
Adds preproccesor directives to only include xmmintrin.h while on compatible chips.
Also adds a non windows aligned malloc, this "should" allow compilation on Mac (unless there are other issues preventing this plugin from working on Mac) @asmaloney  

Fixes #925 