### PR TITLE
Use Ubunutu Bionic for the CI & add qpdal plugin to compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: xenial
+dist: bionic
 cache: ccache
 language: cpp
 compiler:
@@ -17,7 +17,7 @@ install:
   libboost-program-options-dev libcgal-dev libcgal-qt5-dev
   libdlib-dev libswscale-dev libtbb-dev
   libqt5opengl5-dev qt5-default qttools5-dev qttools5-dev-tools
-  libproj-dev libdlib-dev libxerces-c-dev xvfb
+  libproj-dev libdlib-dev libxerces-c-dev xvfb libpdal-dev
 - git submodule init && git submodule update
 
 before_script:
@@ -39,6 +39,7 @@ before_script:
   -DPLUGIN_IO_QCORE=ON
   -DPLUGIN_IO_QE57=ON
   -DPLUGIN_IO_QPHOTOSCAN=ON
+  -DPLUGIN_IO_QPDAL=ON
   -DPLUGIN_STANDARD_QANIMATION=ON
   -DPLUGIN_STANDARD_QBROOM=ON
   -DPLUGIN_STANDARD_QCANUPO=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   libboost-program-options-dev libcgal-dev libcgal-qt5-dev
   libdlib-dev libswscale-dev libtbb-dev
   libqt5opengl5-dev qt5-default qttools5-dev qttools5-dev-tools
-  libproj-dev libdlib-dev libxerces-c-dev xvfb libpdal-dev
+  libproj-dev libdlib-dev libxerces-c-dev xvfb libpdal-dev libjsoncpp-dev
 - git submodule init && git submodule update
 
 before_script:
@@ -25,6 +25,7 @@ before_script:
 - cd build
 - cmake -DCMAKE_BUILD_TYPE=Release
   -DEIGEN_ROOT_DIR=/usr/include/eigen3
+  -DJSON_ROOT_DIR=/usr/include/jsoncpp
   -DCOMPILE_CC_CORE_LIB_WITH_TBB=ON
   -DDLIB_ROOT=/usr/include
   -DOPTION_USE_DXF_LIB=ON

--- a/plugins/core/IO/qPDALIO/CMakeLists.txt
+++ b/plugins/core/IO/qPDALIO/CMakeLists.txt
@@ -19,6 +19,15 @@ if ( PLUGIN_IO_QPDAL )
 		link_directories( ${PDAL_LIBRARY_DIRS} )
 	endif()
 
+    if (PDAL_VERSION LESS 2.0.0)
+		set(JSON_ROOT_DIR "" CACHE PATH "Jsoncpp root dir (PDAL/vendor/jsoncpp/dist)")
+		if (NOT JSON_ROOT_DIR)
+			message(WARNING "Jsoncpp root dir is not specified (JSON_ROOT_DIR)")
+		else ()
+			include_directories(${JSON_ROOT_DIR})
+		endif ()
+	endif()
+
 	# Plugin source
 	include_directories( src )
 

--- a/plugins/core/IO/qPDALIO/CMakeLists.txt
+++ b/plugins/core/IO/qPDALIO/CMakeLists.txt
@@ -19,7 +19,7 @@ if ( PLUGIN_IO_QPDAL )
 		link_directories( ${PDAL_LIBRARY_DIRS} )
 	endif()
 
-    if (PDAL_VERSION LESS 2.0.0)
+	if (PDAL_VERSION LESS 2.0.0)
 		set(JSON_ROOT_DIR "" CACHE PATH "Jsoncpp root dir (PDAL/vendor/jsoncpp/dist)")
 		if (NOT JSON_ROOT_DIR)
 			message(WARNING "Jsoncpp root dir is not specified (JSON_ROOT_DIR)")


### PR DESCRIPTION
Changes the travis ci to build the qPDALIO plugin, this makes travis use Ubuntu Bionic (18.04LTS) as  Xenial (16.04LTS) does not have pdal in the repos.

I don't know if upgrading from Xenial to Bionic will have some unwanted effects and if there any objections to doing it.