### PR TITLE
[Build] Move to C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 
 set (CC_CMAKE_SCRIPTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/cmake/CMakeSetCompilerOptions.cmake
+++ b/cmake/CMakeSetCompilerOptions.cmake
@@ -1,25 +1,13 @@
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 if( UNIX OR MINGW )
-    # You need a c++11 Compiler to build CC
-    # When we require cmake 3.1, we can use a cleaner method:
-    #   CXX_STANDARD & CXX_STANDARD_REQUIRED
-    #   https://cmake.org/cmake/help/v3.1/prop_tgt/CXX_STANDARD.html
-    include(CheckCXXCompilerFlag)
-    
-    CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-    
-    if (NOT COMPILER_SUPPORTS_CXX11)
-        message(ERROR "Your compiler does not support C++11")
-    endif()
-    
-    set( CXX11_FLAG "-std=c++11")
-    
     # MinGW doesn't use fPIC
     if( UNIX )
         set( FPIC_FLAG  "-fPIC")
     endif()
-    
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX11_FLAG} ${FPIC_FLAG}")
-    set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FPIC_FLAG}")
+    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FPIC_FLAG}" )
+    set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FPIC_FLAG}" )
 elseif( MSVC )
     add_definitions(-DNOMINMAX -D_CRT_SECURE_NO_WARNINGS -D__STDC_LIMIT_MACROS)
 


### PR DESCRIPTION
- Require CMake >= 3.1 in Order to use CMAKE_CXX_STANDARD instead of relying on CHECK_CXX_COMPILER_FLAG
- CC build require now at least a C++14 capable compiler