### PR TITLE
Invert 'Tr' transparency

### DIFF
--- a/libs/qCC_db/ccMaterialSet.cpp
+++ b/libs/qCC_db/ccMaterialSet.cpp
@@ -220,10 +220,15 @@ bool ccMaterialSet::ParseMTL(QString path, const QString& filename, ccMaterialSe
 					currentMaterial->setShininess(tokens[1].toFloat());
 			}
 			//transparent
-			else if (tokens.front() == "d" || tokens.front() == "Tr")
+			else if (tokens.front() == "d")
 			{
 				if (tokens.size() > 1)
 					currentMaterial->setTransparency(tokens[1].toFloat());
+			}
+			else if (tokens.front() == "Tr")
+			{
+				if (tokens.size() > 1)
+					currentMaterial->setTransparency(1.0f - tokens[1].toFloat());
 			}
 			//reflection
 			else if (tokens.front() == "r")


### PR DESCRIPTION
Fixes MTL (material library for OBJ) loading, such that the transparency for `Tr` declarations is correct, rather than being the same as `d` declarations (which it is the inversion of). See the [Wikipedia documentation](https://en.wikipedia.org/wiki/Wavefront_.obj_file#Basic_materials)

The issue revealed itself after #1040 