### PR TITLE
MeshIO plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "plugins/core/IO/qE57IO/extern/libE57Format"]
 path = plugins/core/IO/qE57IO/extern/libE57Format
 url = https://github.com/asmaloney/libE57Format
+[submodule "plugins/3rdParty/MeshIO"]
+	path = plugins/3rdParty/MeshIO
+	url = https://github.com/asmaloney/MeshIO

--- a/BUILD.md
+++ b/BUILD.md
@@ -40,6 +40,7 @@
   - `PLUGIN_IO_QE57`: to add support for E57 files in CloudCompare/ccViewer with **libE57** - see [below](#optional-setup-for-libe57-support)
   - `OPTION_USE_SHAPE_LIB`: to add support for SHP files in CloudCompare/ccViewer
   - `PLUGIN_IO_QPDAL`: to add support for LAS files in CloudCompare/ccViewer with **PDAL** - see [below](#optional-setup-for-las-using-pdal)
+  - `PLUGIN-3rdParty_MESH_IO`: to add support for loading GLTF/GLB/COLLADA files in CloudCompare/ccViewer with **assimp** - see [below](#optional-setup-meshio)
 
   The following are Windows-only options:
   - `OPTION_MP_BUILD`: for Visual Studio only *(multi-process build --> much faster but uses a lot of CPU power)*
@@ -172,3 +173,7 @@ Then, the CloudCompare CMake project will request that you set the following var
 1. `CORK_INCLUDE_DIR` and `MPIR_INCLUDE_DIR`: both libraries include directories (pretty straightforward ;)
 2. `CORK_RELEASE_LIBRARY_FILE` and `MPIR_RELEASE_LIBRARY_FILE`: both main library files
 3. and optionally `CORK_DEBUG_LIBRARY_FILE` and `MPIR_DEBUG_LIBRARY_FILE`: both main library files (for debug mode)
+
+### [Optional] Setup MeshIO
+
+[MeshIO](https://github.com/asmaloney/MeshIO) is also a submodule of the CC repository, and must be synchronised


### PR DESCRIPTION
Add [MeshIO](https://github.com/asmaloney/MeshIO) as a plugin for loading GLTF/GLB/COLLADA mesh files

This replaces #1060 

Note: the cmake variable is `PLUGIN-3rdParty_MESH_IO`, when perhaps it should become `PLUGIN_MESH_IO`