### PR TITLE
[Plugin] Fix alloc issue with RANSAC_SD plugin

### DIFF
--- a/plugins/core/Standard/qRANSAC_SD/RANSAC_SD_orig/GfxTL/FlatCopyVector.h
+++ b/plugins/core/Standard/qRANSAC_SD/RANSAC_SD_orig/GfxTL/FlatCopyVector.h
@@ -15,7 +15,7 @@
 
 #ifdef _mm_malloc
 #ifndef a_malloc
-#define a_malloc(align,sz) _mm_malloc((align),(sz))
+#define a_malloc(sz, align) _mm_malloc((sz), (align))
 #endif // !a_malloc
 #endif // !_mm_malloc
 #ifdef _mm_free
@@ -28,7 +28,7 @@
 #define a_free(a)      free(a) 
 #endif // !_mm_free
 #ifndef a_malloc
-#define a_malloc(a, b) aligned_alloc(a, b)
+#define a_malloc(sz, align) aligned_alloc((align), (sz))
 #endif // !_mm_malloc
 
 namespace GfxTL

--- a/plugins/core/Standard/qRANSAC_SD/RANSAC_SD_orig/MiscLib/AlignedAllocator.h
+++ b/plugins/core/Standard/qRANSAC_SD/RANSAC_SD_orig/MiscLib/AlignedAllocator.h
@@ -13,7 +13,7 @@
 
 #ifdef _mm_malloc
 #ifndef a_malloc
-#define a_malloc(align,sz) _mm_malloc((align),(sz))
+#define a_malloc(sz, align) _mm_malloc((sz), (align))
 #endif // !a_malloc
 #endif // !_mm_malloc
 #ifdef _mm_free
@@ -26,7 +26,7 @@
 #define a_free(a)      free(a) 
 #endif // !_mm_free
 #ifndef a_malloc
-#define a_malloc(a, b) aligned_alloc(a, b)
+#define a_malloc(sz, align) aligned_alloc((align), (sz))
 #endif // !_mm_malloc
 
 


### PR DESCRIPTION
- `size` and `align` parameters were inverted in `aligned_alloc` calls, this make CC segfault when using the plugin
- `a_malloc` calls are `(size, align)` not `(align, size)`, so this commit change definitions of `a_malloc` accordingly, to be consistent