### PR TITLE
{cmake} Replace CC_CMAKE_SCRIPTS_DIR with standard cmake way of doing this

### DIFF
--- a/CC/CMakeLists.txt
+++ b/CC/CMakeLists.txt
@@ -19,8 +19,8 @@ endif()
 # to compile CCLib only! (CMake implicitly imposes to declare a project before anything...)
 project( CC_CORE_LIB VERSION 1.0 )
 
-include ( ../cmake/CMakePolicies.cmake )
-include ( ../cmake/CMakeSetCompilerOptions.cmake )
+include ( CMakePolicies )
+include ( CMakeSetCompilerOptions )
 
 if (COMPILE_CC_CORE_LIB_WITH_CGAL)
 	include( cmake/CGALSupport.cmake )
@@ -36,7 +36,7 @@ endif()
 
 # Additional dependencies (only Qt in fact)
 if (COMPILE_CC_CORE_LIB_WITH_QT)
-	include( ../cmake/CMakeExternalLibs.cmake )
+	include( CMakeExternalLibs )
 endif()
 
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/include )
@@ -89,7 +89,7 @@ if ( COMPILE_CC_CORE_LIB_WITH_QT )
 endif()
 
 # Load advanced scripts
-include( ../cmake/CMakeInclude.cmake )
+include( CMakeInclude )
 
 if ( COMPILE_CC_CORE_LIB_SHARED )
 	# Install (shared) library to specified destinations

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,14 @@
 cmake_minimum_required(VERSION 3.0)
 
-set (CC_CMAKE_SCRIPTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-
 project( CloudCompareProjects )
 
 option(BUILD_TESTING "" OFF)
 include(CTest)
 
-include( cmake/CMakePolicies.cmake )
-include( cmake/CMakeSetCompilerOptions.cmake )
+list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/" )
+
+include( CMakePolicies )
+include( CMakeSetCompilerOptions )
 
 # Default debug suffix for libraries.
 set( CMAKE_DEBUG_POSTFIX "d" )
@@ -81,7 +81,7 @@ elseif( UNIX )
 endif()
 
 # Load advanced scripts
-include( cmake/CMakeInclude.cmake )
+include( CMakeInclude )
 
 add_subdirectory( CC )
 
@@ -93,7 +93,7 @@ else()
 endif()
 
 # Add external libraries
-include( cmake/CMakeExternalLibs.cmake )
+include( CMakeExternalLibs )
 
 # Contrib. libraries (mainly for I/O)
 include( contrib/AllSupport.cmake )

--- a/ccViewer/CMakeLists.txt
+++ b/ccViewer/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 
 project( ccViewer VERSION 1.38.0 )
 
-include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+include( CMakePolicies NO_POLICY_SCOPE )
 
 include_directories( ${CC_FBO_LIB_SOURCE_DIR}/include )
 include_directories( ${CC_CORE_LIB_SOURCE_DIR}/include )

--- a/libs/qCC_io/CMakeLists.txt
+++ b/libs/qCC_io/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 
-include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+include( CMakePolicies NO_POLICY_SCOPE )
 
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 include_directories( ${CC_CORE_LIB_SOURCE_DIR}/include )

--- a/plugins/3rdParty/qRDBIO/CMakeLists.txt
+++ b/plugins/3rdParty/qRDBIO/CMakeLists.txt
@@ -6,7 +6,7 @@ option( PLUGIN_IO_QRDB "Check to install RDB 2 I/O plugin" OFF )
 if (PLUGIN_IO_QRDB)
 	project( QRDB_IO_PLUGIN )
 
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	# find rdb
 	# if not defined globally define path to rdb-config.cmake by settin the

--- a/plugins/CMakePluginTpl.cmake
+++ b/plugins/CMakePluginTpl.cmake
@@ -1,6 +1,6 @@
 ### DEFAULT CC "STANDARD" PLUGIN CMAKE SCRIPT ###
 
-include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+include( CMakePolicies NO_POLICY_SCOPE )
 
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 include_directories( ${CMAKE_CURRENT_BINARY_DIR} )

--- a/plugins/core/GL/qEDL/CMakeLists.txt
+++ b/plugins/core/GL/qEDL/CMakeLists.txt
@@ -6,7 +6,7 @@ option( PLUGIN_GL_QEDL "Check to install qEDL plugin" OFF )
 if (PLUGIN_GL_QEDL)
     project( QEDL_GL_PLUGIN )
     
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	include_directories( src )
 	

--- a/plugins/core/GL/qSSAO/CMakeLists.txt
+++ b/plugins/core/GL/qSSAO/CMakeLists.txt
@@ -8,7 +8,7 @@ if (PLUGIN_GL_QSSAO)
     
     project( QSSAO_GL_PLUGIN )
     
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
     set( CC_SHADER_FOLDER SSAO )
     include( ../../../CMakePluginTpl.cmake )

--- a/plugins/core/IO/qAdditionalIO/CMakeLists.txt
+++ b/plugins/core/IO/qAdditionalIO/CMakeLists.txt
@@ -5,7 +5,7 @@ option( PLUGIN_IO_QADDITIONAL "Check to install qAdditionalIO plugin" OFF )
 if (PLUGIN_IO_QADDITIONAL)
 	project( QADDITIONAL_IO_PLUGIN )
 
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	set( CC_IS_IO_PLUGIN 1 )
 

--- a/plugins/core/IO/qCSVMatrixIO/CMakeLists.txt
+++ b/plugins/core/IO/qCSVMatrixIO/CMakeLists.txt
@@ -6,7 +6,7 @@ option( PLUGIN_IO_QCSV_MATRIX "Check to install qCSVMatrix I/O plugin" OFF )
 if (PLUGIN_IO_QCSV_MATRIX)
     project( QCSV_MATRIX_IO_PLUGIN )
     
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
     set( CC_IS_IO_PLUGIN 1 )
 	

--- a/plugins/core/IO/qCoreIO/CMakeLists.txt
+++ b/plugins/core/IO/qCoreIO/CMakeLists.txt
@@ -5,7 +5,7 @@ option( PLUGIN_IO_QCORE "Check to install the CoreIO plugin" ON )
 if ( PLUGIN_IO_QCORE )
 	project( QCORE_IO_PLUGIN )
 
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	set( CC_IS_IO_PLUGIN 1 )
 	

--- a/plugins/core/IO/qE57IO/CMakeLists.txt
+++ b/plugins/core/IO/qE57IO/CMakeLists.txt
@@ -5,7 +5,7 @@ option( PLUGIN_IO_QE57 "Install qE57_IO plugin to read & write E57 files using l
 if ( PLUGIN_IO_QE57 )
 	project( QE57_IO_PLUGIN )
 
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	set( CC_IS_IO_PLUGIN 1 )
 

--- a/plugins/core/IO/qFBXIO/CMakeLists.txt
+++ b/plugins/core/IO/qFBXIO/CMakeLists.txt
@@ -5,7 +5,7 @@ option( PLUGIN_IO_QFBX "Install qFBXIO plugin to read & write AutoDesk FBX files
 if ( PLUGIN_IO_QFBX )
 	project( QFBX_IO_PLUGIN )
 
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	set( CC_IS_IO_PLUGIN 1 )
 

--- a/plugins/core/IO/qLASFWFIO/CMakeLists.txt
+++ b/plugins/core/IO/qLASFWFIO/CMakeLists.txt
@@ -10,7 +10,7 @@ if (WIN32)
 		#CloudCompare LAS FWF (i.e. version >= 1.3) I/O plugin
 		project( QLAS_FWF_IO_PLUGIN )
 		
-		include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+		include( CMakePolicies NO_POLICY_SCOPE )
 
 		include( LASLibSupport.cmake )
 

--- a/plugins/core/IO/qPDALIO/CMakeLists.txt
+++ b/plugins/core/IO/qPDALIO/CMakeLists.txt
@@ -5,7 +5,7 @@ option( PLUGIN_IO_QPDAL "Install qPDALIO plugin to read & write LAS files" OFF )
 if ( PLUGIN_IO_QPDAL )
 	project( QPDAL_IO_PLUGIN )
 
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	set( CC_IS_IO_PLUGIN 1 )
 	

--- a/plugins/core/IO/qPhotoscanIO/CMakeLists.txt
+++ b/plugins/core/IO/qPhotoscanIO/CMakeLists.txt
@@ -5,7 +5,7 @@ option( PLUGIN_IO_QPHOTOSCAN "Check to install qPhotoscan I/O plugin" OFF )
 # CloudCompare Photoscan I/O plugin
 if (PLUGIN_IO_QPHOTOSCAN)
     
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	include( src/contrib/QuazipLibSupport.cmake )
 	

--- a/plugins/core/Standard/qAnimation/CMakeLists.txt
+++ b/plugins/core/Standard/qAnimation/CMakeLists.txt
@@ -8,7 +8,7 @@ if (PLUGIN_STANDARD_QANIMATION)
 
 	project( QANIMATION_PLUGIN )
 
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	if (WITH_FFMPEG_SUPPORT)
 		add_subdirectory( src/QTFFmpegWrapper )

--- a/plugins/core/Standard/qBroom/CMakeLists.txt
+++ b/plugins/core/Standard/qBroom/CMakeLists.txt
@@ -7,7 +7,7 @@ if (PLUGIN_STANDARD_QBROOM)
 	#CloudCompare 'Virtual broom' plugin
 	project( QBROOM_PLUGIN )
 	
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	include_directories( src )
 	

--- a/plugins/core/Standard/qCSF/CMakeLists.txt
+++ b/plugins/core/Standard/qCSF/CMakeLists.txt
@@ -7,7 +7,7 @@ if (PLUGIN_STANDARD_QCSF)
 	#CloudCompare 'CSF' plugin
 	project( QCSF_PLUGIN )
 
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	include_directories( src )
 	

--- a/plugins/core/Standard/qCanupo/CMakeLists.txt
+++ b/plugins/core/Standard/qCanupo/CMakeLists.txt
@@ -7,7 +7,7 @@ if (PLUGIN_STANDARD_QCANUPO)
 	#CloudCompare 'Canupo' plugin
 	project( QCANUPO_PLUGIN )
 	
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	set( DLIB_ROOT "" CACHE PATH "DLib library root directory" )
 	if ( NOT DLIB_ROOT )

--- a/plugins/core/Standard/qCompass/CMakeLists.txt
+++ b/plugins/core/Standard/qCompass/CMakeLists.txt
@@ -7,7 +7,7 @@ if (PLUGIN_STANDARD_QCOMPASS)
 	# CloudCompare 'compass' plugin
 	project( QCOMPASS_PLUGIN )
 
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	# we need includes from the main CC source dir
 	include_directories( ${CloudCompare_SOURCE_DIR} )

--- a/plugins/core/Standard/qCork/CMakeLists.txt
+++ b/plugins/core/Standard/qCork/CMakeLists.txt
@@ -6,7 +6,7 @@ option( PLUGIN_STANDARD_QCORK "Check to install qCORK plugin" OFF )
 if (PLUGIN_STANDARD_QCORK)
     project( QCORK_PLUGIN )
     
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
     # Cork lib and MPIR are needed to build this plugin
     include( CorkSupport.cmake NO_POLICY_SCOPE )

--- a/plugins/core/Standard/qFacets/CMakeLists.txt
+++ b/plugins/core/Standard/qFacets/CMakeLists.txt
@@ -10,7 +10,7 @@ if (PLUGIN_STANDARD_QFACETS)
 
 	project( QFACETS_PLUGIN )
 
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	# we need includes from the main CC source dir
 	include_directories( ${CloudCompare_SOURCE_DIR} )

--- a/plugins/core/Standard/qHPR/CMakeLists.txt
+++ b/plugins/core/Standard/qHPR/CMakeLists.txt
@@ -6,7 +6,7 @@ option( PLUGIN_STANDARD_QHPR "Check to install qHPR plugin" OFF )
 if (PLUGIN_STANDARD_QHPR)
     project( QHPR_PLUGIN )
     	
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	include_directories( src )
 	

--- a/plugins/core/Standard/qHoughNormals/CMakeLists.txt
+++ b/plugins/core/Standard/qHoughNormals/CMakeLists.txt
@@ -17,7 +17,7 @@ if (PLUGIN_STANDARD_QHOUGH_NORMALS)
 
 	project( QHOUGH_NORMALS_PLUGIN )
 
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	include_directories( src )
 	include_directories( src/normals_Hough )

--- a/plugins/core/Standard/qM3C2/CMakeLists.txt
+++ b/plugins/core/Standard/qM3C2/CMakeLists.txt
@@ -6,7 +6,7 @@ if (PLUGIN_STANDARD_QM3C2)
 
 	project( QM3C2_PLUGIN )
 
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	include_directories( src )
 

--- a/plugins/core/Standard/qPCL/CMakeLists.txt
+++ b/plugins/core/Standard/qPCL/CMakeLists.txt
@@ -15,7 +15,7 @@ if (PLUGIN_STANDARD_QPCL)
     
     project( QPCL_PLUGIN )
     
-    include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+    include( CMakePolicies NO_POLICY_SCOPE )
 
     #documentation
     add_subdirectory(doc)

--- a/plugins/core/Standard/qPCL/PclIO/CMakeLists.txt
+++ b/plugins/core/Standard/qPCL/PclIO/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 #CloudCompare PCL I/O plugin (for PCD files)
 project( QPCL_IO_PLUGIN )
 
-include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+include ( CMakePolicies NO_POLICY_SCOPE )
 
 include_directories( ${QPCL_PLUGIN_UTILS_LIB_SOURCE_DIR}/filters )
 include_directories( ${QPCL_PLUGIN_UTILS_LIB_SOURCE_DIR}/utils )

--- a/plugins/core/Standard/qPCL/PclUtils/CMakeLists.txt
+++ b/plugins/core/Standard/qPCL/PclUtils/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 
 project( QPCL_PLUGIN_UTILS_LIB )
 
-include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+include ( CMakePolicies NO_POLICY_SCOPE )
 
 include_directories( ${PCL_INCLUDE_DIRS} )
 

--- a/plugins/core/Standard/qPCV/CMakeLists.txt
+++ b/plugins/core/Standard/qPCV/CMakeLists.txt
@@ -8,7 +8,7 @@ if (PLUGIN_STANDARD_QPCV)
 
     project( QPCV_PLUGIN )
     
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	find_package( OpenGL REQUIRED )
 	if( NOT OPENGL_FOUND )

--- a/plugins/core/Standard/qPoissonRecon/CMakeLists.txt
+++ b/plugins/core/Standard/qPoissonRecon/CMakeLists.txt
@@ -6,7 +6,7 @@ option( PLUGIN_STANDARD_QPOISSON_RECON "Check to install qPoissonRecon plugin" O
 if (PLUGIN_STANDARD_QPOISSON_RECON)
 	project( QPOISSON_RECON_PLUGIN )
 		
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	add_subdirectory (PoissonReconLib)
 

--- a/plugins/core/Standard/qRANSAC_SD/CMakeLists.txt
+++ b/plugins/core/Standard/qRANSAC_SD/CMakeLists.txt
@@ -8,7 +8,7 @@ if (PLUGIN_STANDARD_QRANSAC_SD)
 
 	add_definitions( -DPOINTSWITHINDEX ) #Causes the sub clouds to be generated as partial clones of original cloud
 
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 
 	add_subdirectory (RANSAC_SD_orig)

--- a/plugins/core/Standard/qSRA/CMakeLists.txt
+++ b/plugins/core/Standard/qSRA/CMakeLists.txt
@@ -11,7 +11,7 @@ if (PLUGIN_STANDARD_QSRA)
 	
 	project( QSRA_PLUGIN )
 
-	include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+	include( CMakePolicies NO_POLICY_SCOPE )
 
 	# we need includes from the main CC source dir
 	include_directories( ${CloudCompare_SOURCE_DIR} )

--- a/qCC/CMakeLists.txt
+++ b/qCC/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 
 project( CloudCompare VERSION 2.11.0 )
 
-include ( ${CC_CMAKE_SCRIPTS_DIR}/CMakePolicies.cmake NO_POLICY_SCOPE )
+include( CMakePolicies NO_POLICY_SCOPE )
 
 include_directories( ${CC_FBO_LIB_SOURCE_DIR}/include )
 include_directories( ${CC_CORE_LIB_SOURCE_DIR}/include )


### PR DESCRIPTION
Add path to CMAKE_MODULE_PATH and remove relative paths in includes.