### PR TITLE
Fix crash on quit in Facets plugin after showing stereogram

### DIFF
--- a/plugins/core/Standard/qFacets/qFacets.cpp
+++ b/plugins/core/Standard/qFacets/qFacets.cpp
@@ -66,8 +66,6 @@ static double	s_stereogramAngleStep = 30.0;
 static double	s_stereogramResolution_deg = 5.0;
 static ccPointCloud* s_lastCloud = nullptr;
 
-//persistent dialog
-static StereogramDialog* s_fcDlg = nullptr;
 
 qFacets::qFacets(QObject* parent)
 	: QObject(parent)
@@ -78,16 +76,8 @@ qFacets::qFacets(QObject* parent)
 	, m_doExportFacetsInfo(nullptr)
 	, m_doClassifyFacetsByAngle(nullptr)
 	, m_doShowStereogram(nullptr)
+	, m_stereogramDialog(nullptr)
 {
-}
-
-qFacets::~qFacets()
-{
-	if (s_fcDlg)
-	{
-		s_fcDlg->close();
-		s_fcDlg = nullptr;
-	}
 }
 
 QList<QAction *> qFacets::getActions()
@@ -954,12 +944,15 @@ void qFacets::showStereogram()
 	s_stereogramAngleStep = stereogramParamsDlg.angleStepDoubleSpinBox->value();
 	s_stereogramResolution_deg = stereogramParamsDlg.resolutionDoubleSpinBox->value();
 
-	if (!s_fcDlg)
-		s_fcDlg = new StereogramDialog(m_app);
-	if (s_fcDlg->init(s_stereogramAngleStep, selectedEntities.back(), s_stereogramResolution_deg))
+	if ( m_stereogramDialog == nullptr )
 	{
-		s_fcDlg->show();
-		s_fcDlg->raise();
+		m_stereogramDialog = new StereogramDialog( m_app );
+	}
+	
+	if (m_stereogramDialog->init(s_stereogramAngleStep, selectedEntities.back(), s_stereogramResolution_deg))
+	{
+		m_stereogramDialog->show();
+		m_stereogramDialog->raise();
 	}
 }
 

--- a/plugins/core/Standard/qFacets/qFacets.h
+++ b/plugins/core/Standard/qFacets/qFacets.h
@@ -40,6 +40,8 @@ class ccPointCloud;
 class ccPolyline;
 class ccFacet;
 
+class StereogramDialog;
+
 //! Facet detection plugin (BRGM)
 /** BRGM: BUREAU DE RECHERCHES GEOLOGIQUES ET MINIERES - http://www.brgm.fr/
 **/
@@ -55,7 +57,7 @@ public:
 	qFacets(QObject* parent = nullptr);
 	
 	//! Destructor
-	virtual ~qFacets();
+	virtual ~qFacets() = default;
 
 	//inherited from ccStdPluginInterface
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
@@ -117,6 +119,8 @@ protected:
 	QAction* m_doClassifyFacetsByAngle;
 	//! Associated action
 	QAction* m_doShowStereogram;
+	
+	StereogramDialog* m_stereogramDialog;
 };
 
 #endif //QFACET_PLUGIN_HEADER

--- a/plugins/core/Standard/qFacets/src/stereogramDlg.cpp
+++ b/plugins/core/Standard/qFacets/src/stereogramDlg.cpp
@@ -568,8 +568,8 @@ void StereogramWidget::paintEvent(QPaintEvent* event)
 	}
 }
 
-StereogramDialog::StereogramDialog(ccMainAppInterface* app/*=0*/)
-	: QDialog(app ? app->getMainWindow() : nullptr)
+StereogramDialog::StereogramDialog(ccMainAppInterface* app)
+	: QDialog( app->getMainWindow() )
 	, Ui::StereogramDialog()
 	, m_classifWidget(nullptr)
 	, m_colorScaleSelector(nullptr)

--- a/plugins/core/Standard/qFacets/src/stereogramDlg.h
+++ b/plugins/core/Standard/qFacets/src/stereogramDlg.h
@@ -157,7 +157,7 @@ class StereogramDialog : public QDialog, public Ui::StereogramDialog
 public:
 
 	//! Default constructor
-	StereogramDialog(ccMainAppInterface* app = nullptr);
+	StereogramDialog(ccMainAppInterface* app);
 
 	//! Inits dialog
 	/** Warning: input 'facetGroup' should not be deleted before this dialog is closed!


### PR DESCRIPTION
There's no need to use a global here as there is only one instance of the plugin.

Globals are bad.

Fixes #1091