### PR TITLE
Fix crash when color table not initialized

### DIFF
--- a/qCC/ccColorFromScalarDlg.cpp
+++ b/qCC/ccColorFromScalarDlg.cpp
@@ -420,6 +420,10 @@ void ccColorFromScalarDlg::onApply()
 					col[i] = 255 - col[i];
 				}
 			}
+			if (!m_cloud->hasColors())
+			{
+				m_cloud->resizeTheRGBTable(false);
+			}
 			m_cloud->setPointColor(p, ccColor::FromQColor(QColor(col[0], col[1], col[2], col[3])));
 		}
 	}


### PR DESCRIPTION
Fix crash when colors table not initialized in color from scalar field dialog

Fixes https://github.com/CloudCompare/CloudCompare/issues/1106