### PR TITLE
use Visual Studio Generator on windows to get parallel builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
           - {
               name: "Windows Latest MSVC",
               os: windows-latest,
-              generator: "NMake Makefiles",
+              generator: "Visual Studio 16 2019",
               conda_library_dir: "Library",
               compile_qpcl: "ON",
               compile_qransac: "ON",
@@ -110,4 +110,4 @@ jobs:
             .
 
       - name: Build
-        run: cmake --build build
+        run: cmake --build build --parallel --config Release


### PR DESCRIPTION
I can't mange to make Ninja builds work on the Windows CI, so instead we switch to Visual Studio Generator which can do parallel builds.

Windows builds are faster than with NMake but not as fast as on macOs