### PR TITLE
Update all remaining Qt4-style connects to Qt5-style

### DIFF
--- a/ccViewer/ccviewer.h
+++ b/ccViewer/ccviewer.h
@@ -56,14 +56,14 @@ public:
 	**/
 	bool checkForLoadedEntities();
 
-public slots:
+public:
 
 	//! Tries to load (and then adds to main db) a list of entity (files)
 	/** \param filenames filenames to load
 	**/
 	void addToDB(QStringList filenames);
 
-protected slots:
+protected:
 
 	//! Shows display parameters dialog
 	void showDisplayParameters();

--- a/common/ccCameraParamEditDlg.h
+++ b/common/ccCameraParamEditDlg.h
@@ -66,7 +66,7 @@ public:
 	//inherited from ccPickingListener
 	void onItemPicked(const PickedItem& pi) override;
 
-public slots:
+public:
 
 	//! Links this dialog with a given sub-window
 	void linkWith(QMdiSubWindow* qWin);
@@ -110,7 +110,7 @@ public slots:
 	void pickPointAsPivot(bool);
 	void processPickedItem(ccHObject*, unsigned, int, int, const CCVector3&, const CCVector3d&);
 
-protected slots:
+protected:
 
 	//! Reflects any dialog parameter change
 	void reflectParamChange();

--- a/common/ccDisplayOptionsDlg.h
+++ b/common/ccDisplayOptionsDlg.h
@@ -44,7 +44,7 @@ public:
 signals:
 	void aspectHasChanged();
 
-protected slots:
+protected:
 	void changeLightDiffuseColor();
 	void changeLightAmbientColor();
 	void changeLightSpecularColor();

--- a/common/ccOverlayDialog.h
+++ b/common/ccOverlayDialog.h
@@ -80,7 +80,7 @@ signals:
 	//! Signal emitted when a 'show' event is detected
 	void shown();
 
-protected slots:
+protected:
 
 	//! Slot called when the linked window is deleted (calls 'onClose')
 	virtual void onLinkedWindowDeletion(QObject* object = nullptr);

--- a/common/ccPickingHub.h
+++ b/common/ccPickingHub.h
@@ -82,7 +82,7 @@ public:
 	//! Returns whether the picking mechanism is currently locked (i.e. an exclusive listener is registered)
 	bool isLocked() const { return m_exclusive && !m_listeners.empty(); }
 
-public slots:
+public:
 
 	void onActiveWindowChanged(QMdiSubWindow*);
 	void onActiveWindowDeleted(QObject*);

--- a/common/ccStereoModeDlg.h
+++ b/common/ccStereoModeDlg.h
@@ -49,7 +49,7 @@ public:
 	//! Returns whether the FOV should be updated or not
 	bool updateFOV() const;
 
-protected slots:
+protected:
 
 	//! Slot called when the glass type is modified
 	void glassTypeChanged(int);

--- a/libs/qCC_db/ccOctreeSpinBox.h
+++ b/libs/qCC_db/ccOctreeSpinBox.h
@@ -49,7 +49,7 @@ public:
 	**/
 	void setOctree(CCLib::DgmOctree* octree);
 
-protected slots:
+protected:
 
 	//! Called each time the spinbox value changes
 	void onValueChange(int);

--- a/libs/qCC_db/ccProgressDialog.h
+++ b/libs/qCC_db/ccProgressDialog.h
@@ -70,7 +70,7 @@ public:
 	//! setInfo with a QString as argument
 	virtual void setInfo(QString infoStr);
 
-protected slots:
+protected:
 
 	//! Refreshes the progress
 	/** Should only be called in the main Qt thread!

--- a/libs/qCC_glWindow/ccGLWindow.h
+++ b/libs/qCC_glWindow/ccGLWindow.h
@@ -619,7 +619,7 @@ public: //stereo mode
 	bool isRotationAxisLocked() const { return m_rotationAxisLocked; }
 
 
-public slots:
+public:
 
 	//! Applies a 1:1 global zoom
 	void zoomGlobal();
@@ -643,7 +643,7 @@ public slots:
 	inline void update() { paintGL(); }
 #endif
 
-protected slots:
+protected:
 
 #ifdef CC_GL_WINDOW_USE_QWINDOW
 	//! Updates the display

--- a/libs/qCC_io/AsciiOpenDlg.h
+++ b/libs/qCC_io/AsciiOpenDlg.h
@@ -189,7 +189,7 @@ public:
 	//! Resets the "apply all" flag (if set)
 	static void ResetApplyAll();
 
-public slots:
+public:
 	//! Slot called when separator changes
 	void onSeparatorChange(const QString& separator);
 	//! Forces the table to update itself
@@ -199,7 +199,7 @@ public slots:
 	//! Slot called when the 'comma as decimal' checkbox is toggled
 	void commaDecimalCheckBoxToggled(bool);
 
-protected slots:
+protected:
 	bool apply();
 	void applyAll();
 	void columnsTypeHasChanged(int index);

--- a/libs/qCC_io/AsciiSaveDlg.h
+++ b/libs/qCC_io/AsciiSaveDlg.h
@@ -90,7 +90,7 @@ public:
 	//! Returns whether to save the alpha (transparency) channel
 	bool saveAlphaChannel() const;
 
-protected slots:
+protected:
 
 	//! Saves dialog state to persistent settings
 	void acceptAndSaveSettings();

--- a/libs/qCC_io/PlyOpenDlg.h
+++ b/libs/qCC_io/PlyOpenDlg.h
@@ -69,10 +69,10 @@ public:
 	**/
 	bool canBeSkipped() const;
 
-public slots:
+public:
 	void addSFComboBox(int selectedIndex = 0);
 
-protected slots:
+protected:
 	void apply();
 	void applyAll();
 

--- a/libs/qCC_io/Tests/TestShpFilter.h
+++ b/libs/qCC_io/Tests/TestShpFilter.h
@@ -18,7 +18,7 @@
 class TestShpFilter : public QObject
 {
 Q_OBJECT
-private slots:
+private:
 	/* Reading tests */
 	void readPolylineFile(const QString &filePath = LINE_FILE) const;
 

--- a/libs/qCC_io/ccShiftAndScaleCloudDlg.h
+++ b/libs/qCC_io/ccShiftAndScaleCloudDlg.h
@@ -114,7 +114,7 @@ public:
     //! Sets the last shift and scale information
     static void SetLastInfo(const CCVector3d& shift, double scale);
 
-protected slots:
+protected:
 
 	//! Slot called when the 'loadComboBox' index changes
 	void onLoadIndexChanged(int);

--- a/plugins/core/IO/qAdditionalIO/src/BundlerImportDlg.h
+++ b/plugins/core/IO/qAdditionalIO/src/BundlerImportDlg.h
@@ -88,7 +88,7 @@ public:
 	//! Returns the optional transformation matrix (if defined)
 	bool getOptionalTransfoMatrix(ccGLMatrix& mat);
 
-protected slots:
+protected:
 	void browseImageListFilename();
 	void browseAltKeypointsFilename();
 	void acceptAndSaveSettings();

--- a/plugins/core/IO/qCSVMatrixIO/src/CSVMatrixOpenDialog.h
+++ b/plugins/core/IO/qCSVMatrixIO/src/CSVMatrixOpenDialog.h
@@ -34,7 +34,7 @@ public:
 	//! Default constructor
 	explicit CSVMatrixOpenDialog(QWidget* parent = 0);
 
-protected slots:
+protected:
 
 	//! Bowse texture file
 	void browseTextureFile();

--- a/plugins/core/IO/qPDALIO/src/LASOpenDlg.h
+++ b/plugins/core/IO/qPDALIO/src/LASOpenDlg.h
@@ -71,7 +71,7 @@ public:
 	//! Resets the "apply all" flag (if set)
 	void resetApplyAll();
 
-protected slots:
+protected:
 
 	void onApplyAll();
 	void onBrowse();

--- a/plugins/core/Standard/qAnimation/src/qAnimationDlg.cpp
+++ b/plugins/core/Standard/qAnimation/src/qAnimationDlg.cpp
@@ -103,16 +103,16 @@ qAnimationDlg::qAnimationDlg(ccGLWindow* view3d, QWidget* parent)
 		settings.endGroup();
 	}
 
-	connect ( fpsSpinBox,				SIGNAL( valueChanged(int) ),		this, SLOT( onFPSChanged(int) ) );
-	connect ( totalTimeDoubleSpinBox,	SIGNAL( valueChanged(double) ),		this, SLOT( onTotalTimeChanged(double) ) );
-	connect ( stepTimeDoubleSpinBox,	SIGNAL( valueChanged(double) ),		this, SLOT( onStepTimeChanged(double) ) );
-	connect ( loopCheckBox,				SIGNAL( toggled(bool) ),			this, SLOT( onLoopToggled(bool) ) );
+	connect( fpsSpinBox,				static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &qAnimationDlg::onFPSChanged );
+	connect( totalTimeDoubleSpinBox,	static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, &qAnimationDlg::onTotalTimeChanged );
+	connect( stepTimeDoubleSpinBox,		static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, &qAnimationDlg::onStepTimeChanged );
+	connect( loopCheckBox,				&QAbstractButton::toggled, this, &qAnimationDlg::onLoopToggled );
 
-	connect ( browseButton,				SIGNAL( clicked() ),				this, SLOT( onBrowseButtonClicked() ) );
-	connect ( previewButton,			SIGNAL( clicked() ),				this, SLOT( preview() ) );
-	connect ( renderButton,				SIGNAL( clicked() ),				this, SLOT( renderAnimation() ) );
-	connect ( exportFramesPushButton,	SIGNAL( clicked() ),				this, SLOT( renderFrames() ) );
-	connect ( buttonBox,				SIGNAL( accepted() ),				this, SLOT( onAccept() ) );
+	connect( browseButton,			&QAbstractButton::clicked,		this, &qAnimationDlg::onBrowseButtonClicked );
+	connect( previewButton,			&QAbstractButton::clicked,		this, &qAnimationDlg::preview );
+	connect( renderButton,			&QAbstractButton::clicked,		this, &qAnimationDlg::renderAnimation );
+	connect( exportFramesPushButton,&QAbstractButton::clicked,		this, &qAnimationDlg::renderFrames );
+	connect( buttonBox,				&QDialogButtonBox::accepted,	this, &qAnimationDlg::onAccept );
 }
 
 bool qAnimationDlg::init(const std::vector<cc2DViewportObject*>& viewports)
@@ -159,8 +159,8 @@ bool qAnimationDlg::init(const std::vector<cc2DViewportObject*>& viewports)
 		m_videoSteps[i].duration_sec = duration_sec;
 	}
 
-	connect ( stepSelectionList, SIGNAL( currentRowChanged(int) ),			this, SLOT( onCurrentStepChanged(int) ) );
-	connect ( stepSelectionList, SIGNAL( itemChanged(QListWidgetItem*) ),	this, SLOT( onItemChanged(QListWidgetItem*) ) );
+	connect( stepSelectionList, &QListWidget::currentRowChanged, this, &qAnimationDlg::onCurrentStepChanged );
+	connect( stepSelectionList, &QListWidget::itemChanged, this, &qAnimationDlg::onItemChanged );
 
 	stepSelectionList->setCurrentRow(0); //select the first one by default
 	onCurrentStepChanged(getCurrentStepIndex());

--- a/plugins/core/Standard/qAnimation/src/qAnimationDlg.h
+++ b/plugins/core/Standard/qAnimation/src/qAnimationDlg.h
@@ -43,7 +43,7 @@ public:
 	//! Initialize the dialog with a set of viewports
 	bool init(const std::vector<cc2DViewportObject*>& viewports);
 
-protected slots:
+protected:
 
 	void onFPSChanged(int);
 

--- a/plugins/core/Standard/qBroom/qBroom.h
+++ b/plugins/core/Standard/qBroom/qBroom.h
@@ -38,7 +38,7 @@ public:
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
 	virtual QList<QAction *> getActions() override;
 
-protected slots:
+protected:
 
 	//! Slot called when associated ation is triggered
 	void doAction();

--- a/plugins/core/Standard/qBroom/src/qBroomDlg.cpp
+++ b/plugins/core/Standard/qBroom/src/qBroomDlg.cpp
@@ -146,27 +146,26 @@ qBroomDlg::qBroomDlg(ccMainAppInterface* app/*=0*/)
 
 	//connect signals/slots
 	{
-		connect(m_glWindow, SIGNAL(itemPicked(ccHObject*, unsigned, int, int, const CCVector3&, const CCVector3d&)), this, SLOT(handlePickedItem(ccHObject*, unsigned, int, int, const CCVector3&, const CCVector3d&)));
+		connect(m_glWindow, &ccGLWindow::itemPicked, this, &qBroomDlg::handlePickedItem);
 
-		connect(m_glWindow, SIGNAL(leftButtonClicked(int,int)), this, SLOT(onLeftButtonClicked(int,int)));
-		//connect(m_glWindow, SIGNAL(rightButtonClicked(int,int)), this, SLOT(onRightButtonClicked(int,int)));
-		connect(m_glWindow, SIGNAL(mouseMoved(int,int,Qt::MouseButtons)), this, SLOT(onMouseMoved(int,int,Qt::MouseButtons)));
-		connect(m_glWindow, SIGNAL(buttonReleased()), this, SLOT(onButtonReleased()));
+		connect(m_glWindow, &ccGLWindow::leftButtonClicked, this, &qBroomDlg::onLeftButtonClicked);
+		connect(m_glWindow, &ccGLWindow::mouseMoved, this, &qBroomDlg::onMouseMoved);
+		connect(m_glWindow, &ccGLWindow::buttonReleased, this, &qBroomDlg::onButtonReleased);
 
-		connect(cleanHeightDoubleSpinBox,    SIGNAL(valueChanged(double)), this, SLOT(onCleanHeightChanged(double)));
-		connect(broomLengthDoubleSpinBox,    SIGNAL(valueChanged(double)), this, SLOT(onDimensionChanged(double)));
-		connect(broomWidthDoubleSpinBox,     SIGNAL(valueChanged(double)), this, SLOT(onDimensionChanged(double)));
-		connect(broomThicknessDoubleSpinBox, SIGNAL(valueChanged(double)), this, SLOT(onDimensionChanged(double)));
+		connect(cleanHeightDoubleSpinBox,    static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, &qBroomDlg::onCleanHeightChanged);
+		connect(broomLengthDoubleSpinBox,    static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, &qBroomDlg::onDimensionChanged);
+		connect(broomWidthDoubleSpinBox,     static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, &qBroomDlg::onDimensionChanged);
+		connect(broomThicknessDoubleSpinBox, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, &qBroomDlg::onDimensionChanged);
 
-		connect(selectionModeComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(onSelectionModeChanged(int)));
-		connect(undoPushButton,        SIGNAL(clicked()), this, SLOT(doUndo()));
-		connect(undo10PushButton,      SIGNAL(clicked()), this, SLOT(doUndo10()));
-		connect(repositionPushButton,  SIGNAL(clicked()), this, SLOT(onReposition()));
-		connect(automatePushButton,    SIGNAL(clicked()), this, SLOT(onAutomate()));
+		connect(selectionModeComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &qBroomDlg::onSelectionModeChanged);
+		connect(undoPushButton,        &QAbstractButton::clicked, this, &qBroomDlg::doUndo);
+		connect(undo10PushButton,      &QAbstractButton::clicked, this, &qBroomDlg::doUndo10);
+		connect(repositionPushButton,  &QAbstractButton::clicked, this, &qBroomDlg::onReposition);
+		connect(automatePushButton,    &QAbstractButton::clicked, this, &qBroomDlg::onAutomate);
 
-		connect(cancelPushButton,   SIGNAL(clicked()), this, SLOT(cancel()));
-		connect(applyPushButton,    SIGNAL(clicked()), this, SLOT(apply()));
-		connect(validatePushButton, SIGNAL(clicked()), this, SLOT(validate()));
+		connect(cancelPushButton,   &QAbstractButton::clicked, this, &qBroomDlg::cancel);
+		connect(applyPushButton,    &QAbstractButton::clicked, this, &qBroomDlg::apply);
+		connect(validatePushButton, &QAbstractButton::clicked, this, &qBroomDlg::validate);
 
 		//view buttons
 		connect(topViewToolButton,    &QToolButton::clicked, [&]() { if (m_glWindow) m_glWindow->setView(CC_TOP_VIEW  ); });

--- a/plugins/core/Standard/qBroom/src/qBroomDlg.h
+++ b/plugins/core/Standard/qBroom/src/qBroomDlg.h
@@ -63,7 +63,7 @@ public:
 	**/
 	bool setCloud(ccPointCloud* cloud, bool ownCloud = false, bool autoRedraw = true);
 
-protected slots:
+protected:
 
 	//! Slot called when the 'reposition' button is clicked
 	void onReposition();

--- a/plugins/core/Standard/qCSF/qCSF.h
+++ b/plugins/core/Standard/qCSF/qCSF.h
@@ -52,7 +52,7 @@ public:
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
 	virtual QList<QAction *> getActions() override;
 
-protected slots:
+protected:
 
 	//! Slot called when associated ation is triggered
 	void doAction();

--- a/plugins/core/Standard/qCSF/src/ccCSFDlg.h
+++ b/plugins/core/Standard/qCSF/src/ccCSFDlg.h
@@ -41,7 +41,7 @@ public:
 	//! Default constructor
 	explicit ccCSFDlg(QWidget* parent = 0);
 
-protected slots:
+protected:
 
 	//! Saves (temporarily) the dialog parameters on acceptation
 	void saveSettings();

--- a/plugins/core/Standard/qCanupo/qCanupo.cpp
+++ b/plugins/core/Standard/qCanupo/qCanupo.cpp
@@ -65,7 +65,7 @@ QList<QAction*> qCanupoPlugin::getActions()
 		m_trainAction = new QAction("Train classifier", this);
 		m_trainAction->setToolTip("Train classifier");
 		m_trainAction->setIcon(QIcon(QString::fromUtf8(":/CC/plugin/qCanupoPlugin/iconCreate.png")));
-		connect(m_trainAction, SIGNAL(triggered()), this, SLOT(doTrainAction()));
+		connect(m_trainAction, &QAction::triggered, this, &qCanupoPlugin::doTrainAction);
 	}
 	group.push_back(m_trainAction);
 
@@ -74,7 +74,7 @@ QList<QAction*> qCanupoPlugin::getActions()
 		m_classifyAction = new QAction("Classify", this);
 		m_classifyAction->setToolTip("Classify cloud");
 		m_classifyAction->setIcon(QIcon(QString::fromUtf8(":/CC/plugin/qCanupoPlugin/iconClassify.png")));
-		connect(m_classifyAction, SIGNAL(triggered()), this, SLOT(doClassifyAction()));
+		connect(m_classifyAction, &QAction::triggered, this, &qCanupoPlugin::doClassifyAction);
 	}
 	group.push_back(m_classifyAction);
 

--- a/plugins/core/Standard/qCanupo/qCanupo.h
+++ b/plugins/core/Standard/qCanupo/qCanupo.h
@@ -44,7 +44,7 @@ public:
 	virtual QList<QAction*> getActions() override;
 	virtual void registerCommands(ccCommandLineInterface* cmd) override;
 
-protected slots:
+protected:
 
 	void doClassifyAction();
 	void doTrainAction();

--- a/plugins/core/Standard/qCanupo/qCanupo2DViewDialog.cpp
+++ b/plugins/core/Standard/qCanupo/qCanupo2DViewDialog.cpp
@@ -101,21 +101,22 @@ qCanupo2DViewDialog::qCanupo2DViewDialog(	const CorePointDescSet* descriptors1,
 		viewFrame->setLayout(new QHBoxLayout());
 		viewFrame->layout()->addWidget(glWidget);
 
-		connect(m_glWindow, SIGNAL(leftButtonClicked(int, int)),			this, SLOT(addOrSelectPoint(int, int)));
-		connect(m_glWindow, SIGNAL(rightButtonClicked(int, int)),			this, SLOT(removePoint(int, int)));
-		connect(m_glWindow, SIGNAL(mouseMoved(int, int, Qt::MouseButtons)),	this, SLOT(moveSelectedPoint(int, int, Qt::MouseButtons)));
-		connect(m_glWindow, SIGNAL(buttonReleased()),						this, SLOT(deselectPoint()));
+		connect(m_glWindow, &ccGLWindow::leftButtonClicked,		this, &qCanupo2DViewDialog::addOrSelectPoint);
+		connect(m_glWindow, &ccGLWindow::rightButtonClicked,	this, &qCanupo2DViewDialog::removePoint);
+		connect(m_glWindow, &ccGLWindow::mouseMoved,			this, &qCanupo2DViewDialog::moveSelectedPoint);
+		connect(m_glWindow, &ccGLWindow::buttonReleased,		this, &qCanupo2DViewDialog::deselectPoint);
 	}
 
 	updateScalesList(true);
 
 	//loadParamsFromPersistentSettings();
-	connect(resetToolButton,		SIGNAL(clicked()),			this, SLOT(resetBoundary()));
-	connect(statisticsToolButton,	SIGNAL(clicked()),			this, SLOT(computeStatistics()));
-	connect(savePushButton,			SIGNAL(clicked()),			this, SLOT(saveClassifier()));
-	connect(donePushButton,			SIGNAL(clicked()),			this, SLOT(checkBeforeAccept()));
-	connect(pointSizeSpinBox,		SIGNAL(valueChanged(int)),	this, SLOT(setPointSize(int)));
-	connect(scalesCountSpinBox,		SIGNAL(valueChanged(int)),	this, SLOT(onScalesCountSpinBoxChanged(int)));
+	connect(resetToolButton,		&QAbstractButton::clicked, this, &qCanupo2DViewDialog::resetBoundary);
+	connect(statisticsToolButton,	&QAbstractButton::clicked, this, &qCanupo2DViewDialog::computeStatistics);
+	connect(savePushButton,			&QAbstractButton::clicked, this, &qCanupo2DViewDialog::saveClassifier);
+	connect(donePushButton,			&QAbstractButton::clicked, this, &qCanupo2DViewDialog::checkBeforeAccept);
+	
+	connect(pointSizeSpinBox,		static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &qCanupo2DViewDialog::setPointSize);
+	connect(scalesCountSpinBox,		static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &qCanupo2DViewDialog::onScalesCountSpinBoxChanged);
 }
 
 qCanupo2DViewDialog::~qCanupo2DViewDialog()

--- a/plugins/core/Standard/qCanupo/qCanupo2DViewDialog.h
+++ b/plugins/core/Standard/qCanupo/qCanupo2DViewDialog.h
@@ -58,12 +58,12 @@ public:
 	//! Returns classifier
 	const Classifier& getClassifier() { return m_classifier; }
 
-public slots:
+public:
 
 	//! Trains the classifier (with the current number of scales!)
 	bool trainClassifier();
 
-protected slots:
+protected:
 
 	//! Updates the boundary representation 
 	void resetBoundary();

--- a/plugins/core/Standard/qCanupo/qCanupoClassifDialog.cpp
+++ b/plugins/core/Standard/qCanupo/qCanupoClassifDialog.cpp
@@ -75,8 +75,8 @@ qCanupoClassifDialog::qCanupoClassifDialog(ccPointCloud* cloud, ccMainAppInterfa
 		}
 	}
 
-	connect(browseToolButton,		SIGNAL(clicked()), this, SLOT(browseClassifierFile()));
-	connect(mscBrowseToolButton,	SIGNAL(clicked()), this, SLOT(browseMscFile()));
+	connect(browseToolButton, &QAbstractButton::clicked, this, &qCanupoClassifDialog::browseClassifierFile);
+	connect(mscBrowseToolButton, &QAbstractButton::clicked, this, &qCanupoClassifDialog::browseMscFile);
 
 	buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
 }

--- a/plugins/core/Standard/qCanupo/qCanupoClassifDialog.h
+++ b/plugins/core/Standard/qCanupo/qCanupoClassifDialog.h
@@ -68,7 +68,7 @@ public:
 	//! Saves parameters to persistent settings
 	void saveParamsToPersistentSettings();
 
-protected slots:
+protected:
 
 	void browseClassifierFile();
 	void browseMscFile();

--- a/plugins/core/Standard/qCanupo/qCanupoTrainingDialog.cpp
+++ b/plugins/core/Standard/qCanupo/qCanupoTrainingDialog.cpp
@@ -93,10 +93,11 @@ qCanupoTrainingDialog::qCanupoTrainingDialog(ccMainAppInterface* app)
 
 	loadParamsFromPersistentSettings();
 
-	connect(cloud1ClassSpinBox,		SIGNAL(valueChanged(int)),			this,	SLOT(onClassChanged(int)));
-	connect(cloud2ClassSpinBox,		SIGNAL(valueChanged(int)),			this,	SLOT(onClassChanged(int)));
-	connect(class1CloudComboBox,	SIGNAL(currentIndexChanged (int)),	this,	SLOT(onCloudChanged(int)));
-	connect(class2CloudComboBox,	SIGNAL(currentIndexChanged (int)),	this,	SLOT(onCloudChanged(int)));
+	connect(cloud1ClassSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &qCanupoTrainingDialog::onClassChanged);
+	connect(cloud2ClassSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &qCanupoTrainingDialog::onClassChanged);
+	
+	connect(class1CloudComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &qCanupoTrainingDialog::onCloudChanged);
+	connect(class2CloudComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &qCanupoTrainingDialog::onCloudChanged);
 
 	onClassChanged(0);
 	onCloudChanged(0);

--- a/plugins/core/Standard/qCanupo/qCanupoTrainingDialog.h
+++ b/plugins/core/Standard/qCanupo/qCanupoTrainingDialog.h
@@ -55,7 +55,7 @@ public:
 	//! Returns the selected descriptor ID
 	unsigned getDescriptorID() const;
 
-protected slots:
+protected:
 
 	void onClassChanged(int);
 	void onCloudChanged(int);

--- a/plugins/core/Standard/qCompass/ccCompass.cpp
+++ b/plugins/core/Standard/qCompass/ccCompass.cpp
@@ -226,60 +226,60 @@ void ccCompass::doAction()
 		m_dlg = new ccCompassDlg(m_app->getMainWindow());
 
 		//general
-		ccCompassDlg::connect(m_dlg->closeButton, SIGNAL(clicked()), this, SLOT(onClose()));
-		ccCompassDlg::connect(m_dlg->acceptButton, SIGNAL(clicked()), this, SLOT(onAccept()));
-		ccCompassDlg::connect(m_dlg->saveButton, SIGNAL(clicked()), this, SLOT(onSave()));
-		ccCompassDlg::connect(m_dlg->undoButton, SIGNAL(clicked()), this, SLOT(onUndo()));
-		ccCompassDlg::connect(m_dlg->infoButton, SIGNAL(clicked()), this, SLOT(showHelp()));
+		connect(m_dlg->closeButton, &QAbstractButton::clicked, this, &ccCompass::onClose);
+		connect(m_dlg->acceptButton, &QAbstractButton::clicked, this, &ccCompass::onAccept);
+		connect(m_dlg->saveButton, &QAbstractButton::clicked, this, &ccCompass::onSave);
+		connect(m_dlg->undoButton, &QAbstractButton::clicked, this, &ccCompass::onUndo);
+		connect(m_dlg->infoButton, &QAbstractButton::clicked, this, &ccCompass::showHelp);
 
 		//modes
-		ccCompassDlg::connect(m_dlg->mapMode, SIGNAL(clicked()), this, SLOT(enableMapMode()));
-		ccCompassDlg::connect(m_dlg->compassMode, SIGNAL(clicked()), this, SLOT(enableMeasureMode()));
+		connect(m_dlg->mapMode, &QAbstractButton::clicked, this, &ccCompass::enableMapMode);
+		connect(m_dlg->compassMode, &QAbstractButton::clicked, this, &ccCompass::enableMeasureMode);
 
 		//tools
-		ccCompassDlg::connect(m_dlg->pickModeButton, SIGNAL(clicked()), this, SLOT(setPick()));
-		ccCompassDlg::connect(m_dlg->pairModeButton, SIGNAL(clicked()), this, SLOT(setLineation()));
-		ccCompassDlg::connect(m_dlg->planeModeButton, SIGNAL(clicked()), this, SLOT(setPlane()));
-		ccCompassDlg::connect(m_dlg->traceModeButton, SIGNAL(clicked()), this, SLOT(setTrace()));
+		connect(m_dlg->pickModeButton, &QAbstractButton::clicked, this, &ccCompass::setPick);
+		connect(m_dlg->pairModeButton, &QAbstractButton::clicked, this, &ccCompass::setLineation);
+		connect(m_dlg->planeModeButton, &QAbstractButton::clicked, this, &ccCompass::setPlane);
+		connect(m_dlg->traceModeButton, &QAbstractButton::clicked, this, &ccCompass::setTrace);
 
 		//extra tools
-		ccCompassDlg::connect(m_dlg->m_pinchTool, SIGNAL(triggered()), this, SLOT(addPinchNode()));
-		ccCompassDlg::connect(m_dlg->m_measure_thickness, SIGNAL(triggered()), this, SLOT(setThickness()));
-		ccCompassDlg::connect(m_dlg->m_measure_thickness_twoPoint, SIGNAL(triggered()), this, SLOT(setThickness2()));
+		connect(m_dlg->m_pinchTool, &QAction::triggered, this, &ccCompass::addPinchNode);
+		connect(m_dlg->m_measure_thickness, &QAction::triggered, this, &ccCompass::setThickness);
+		connect(m_dlg->m_measure_thickness_twoPoint, &QAction::triggered, this, &ccCompass::setThickness2);
 
-		ccCompassDlg::connect(m_dlg->m_youngerThan, SIGNAL(triggered()), this, SLOT(setYoungerThan()));
-		ccCompassDlg::connect(m_dlg->m_follows, SIGNAL(triggered()), this, SLOT(setFollows()));
-		ccCompassDlg::connect(m_dlg->m_equivalent, SIGNAL(triggered()), this, SLOT(setEquivalent()));
+		connect(m_dlg->m_youngerThan, &QAction::triggered, this, &ccCompass::setYoungerThan);
+		connect(m_dlg->m_follows, &QAction::triggered, this, &ccCompass::setFollows);
+		connect(m_dlg->m_equivalent, &QAction::triggered, this, &ccCompass::setEquivalent);
 
-		ccCompassDlg::connect(m_dlg->m_mergeSelected, SIGNAL(triggered()), this, SLOT(mergeGeoObjects()));
-		ccCompassDlg::connect(m_dlg->m_fitPlaneToGeoObject, SIGNAL(triggered()), this, SLOT(fitPlaneToGeoObject()));
-		ccCompassDlg::connect(m_dlg->m_recalculateFitPlanes, SIGNAL(triggered()), this, SLOT(recalculateFitPlanes()));
-		ccCompassDlg::connect(m_dlg->m_toPointCloud, SIGNAL(triggered()), this, SLOT(convertToPointCloud()));
-		ccCompassDlg::connect(m_dlg->m_distributeSelection, SIGNAL(triggered()), this, SLOT(distributeSelection()));
-		ccCompassDlg::connect(m_dlg->m_estimateNormals, SIGNAL(triggered()), this, SLOT(estimateStructureNormals()));
-		ccCompassDlg::connect(m_dlg->m_estimateP21, SIGNAL(triggered()), this, SLOT(estimateP21()));
-		ccCompassDlg::connect(m_dlg->m_estimateStrain, SIGNAL(triggered()), this, SLOT(estimateStrain()));
-		ccCompassDlg::connect(m_dlg->m_noteTool, SIGNAL(triggered()), this, SLOT(setNote()));
-		ccCompassDlg::connect(m_dlg->m_loadFoliations, SIGNAL(triggered()), this, SLOT(importFoliations()));
-		ccCompassDlg::connect(m_dlg->m_loadLineations, SIGNAL(triggered()), this, SLOT(importLineations()));
-		ccCompassDlg::connect(m_dlg->m_toSVG, SIGNAL(triggered()), this, SLOT(exportToSVG()));
+		connect(m_dlg->m_mergeSelected, &QAction::triggered, this, &ccCompass::mergeGeoObjects);
+		connect(m_dlg->m_fitPlaneToGeoObject, &QAction::triggered, this, &ccCompass::fitPlaneToGeoObject);
+		connect(m_dlg->m_recalculateFitPlanes, &QAction::triggered, this, &ccCompass::recalculateFitPlanes);
+		connect(m_dlg->m_toPointCloud, &QAction::triggered, this, &ccCompass::convertToPointCloud);
+		connect(m_dlg->m_distributeSelection, &QAction::triggered, this, &ccCompass::distributeSelection);
+		connect(m_dlg->m_estimateNormals, &QAction::triggered, this, &ccCompass::estimateStructureNormals);
+		connect(m_dlg->m_estimateP21, &QAction::triggered, this, &ccCompass::estimateP21);
+		connect(m_dlg->m_estimateStrain, &QAction::triggered, this, &ccCompass::estimateStrain);
+		connect(m_dlg->m_noteTool, &QAction::triggered, this, &ccCompass::setNote);
+		connect(m_dlg->m_loadFoliations, &QAction::triggered, this, &ccCompass::importFoliations);
+		connect(m_dlg->m_loadLineations, &QAction::triggered, this, &ccCompass::importLineations);
+		connect(m_dlg->m_toSVG, &QAction::triggered, this, &ccCompass::exportToSVG);
 
 		//settings menu
-		ccCompassDlg::connect(m_dlg->m_showNames, SIGNAL(toggled(bool)), this, SLOT(toggleLabels(bool)));
-		ccCompassDlg::connect(m_dlg->m_showStippled, SIGNAL(toggled(bool)), this, SLOT(toggleStipple(bool)));
-		ccCompassDlg::connect(m_dlg->m_showNormals, SIGNAL(toggled(bool)), this, SLOT(toggleNormals(bool)));
-		ccCompassDlg::connect(m_dlg->m_recalculate, SIGNAL(triggered()), this, SLOT(recalculateSelectedTraces()));
+		connect(m_dlg->m_showNames, &QAction::toggled, this, &ccCompass::toggleLabels);
+		connect(m_dlg->m_showStippled, &QAction::toggled, this, &ccCompass::toggleStipple);
+		connect(m_dlg->m_showNormals, &QAction::toggled, this, &ccCompass::toggleNormals);
+		connect(m_dlg->m_recalculate, &QAction::triggered, this, &ccCompass::recalculateSelectedTraces);
 	}
 
 	if (!m_mapDlg)
 	{
 		m_mapDlg = new ccMapDlg(m_app->getMainWindow());
 
-		ccCompassDlg::connect(m_mapDlg->m_create_geoObject, SIGNAL(triggered()), this, SLOT(addGeoObject()));
-		ccCompassDlg::connect(m_mapDlg->m_create_geoObjectSS, SIGNAL(triggered()), this, SLOT(addGeoObjectSS()));
-		ccCompassDlg::connect(m_mapDlg->setInteriorButton, SIGNAL(clicked()), this, SLOT(writeToInterior()));
-		ccCompassDlg::connect(m_mapDlg->setUpperButton, SIGNAL(clicked()), this, SLOT(writeToUpper()));
-		ccCompassDlg::connect(m_mapDlg->setLowerButton, SIGNAL(clicked()), this, SLOT(writeToLower()));
+		connect(m_mapDlg->m_create_geoObject, &QAction::triggered, this, &ccCompass::addGeoObject);
+		connect(m_mapDlg->m_create_geoObjectSS, &QAction::triggered, this, &ccCompass::addGeoObjectSS);
+		connect(m_mapDlg->setInteriorButton, &QAbstractButton::clicked, this, &ccCompass::writeToInterior);
+		connect(m_mapDlg->setUpperButton, &QAbstractButton::clicked, this, &ccCompass::writeToUpper);
+		connect(m_mapDlg->setLowerButton, &QAbstractButton::clicked, this, &ccCompass::writeToLower);
 	}
 
 	m_dlg->linkWith(m_app->getActiveGLWindow());
@@ -1353,8 +1353,8 @@ void ccCompass::estimateStructureNormals()
 	strideText.setToolTip("Standard deviation of the normal distribution used to calculate monte-carlo jumps during sampling. Larger numbers sample more widely but are slower to run.");
 	
 	QDialogButtonBox buttonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-	QObject::connect(&buttonBox, SIGNAL(accepted()), &dlg, SLOT(accept()));
-	QObject::connect(&buttonBox, SIGNAL(rejected()), &dlg, SLOT(reject()));
+	connect(&buttonBox, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
+	connect(&buttonBox, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
 
 	vbox->addWidget(&minSizeLabel);
 	vbox->addWidget(&minSizeText);
@@ -2288,8 +2288,8 @@ void ccCompass::estimateStrain()
 	exagText.setToolTip("Exaggerate the shape of strain ellipses for easier visualisation.");
 
 	QDialogButtonBox buttonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-	QObject::connect(&buttonBox, SIGNAL(accepted()), &dlg, SLOT(accept()));
-	QObject::connect(&buttonBox, SIGNAL(rejected()), &dlg, SLOT(reject()));
+	connect(&buttonBox, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
+	connect(&buttonBox, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
 	vbox->addWidget(&boxSizeLabel);
 	vbox->addWidget(&boxSizeText);
 	vbox->addWidget(&buildBlocksChk);
@@ -2832,8 +2832,8 @@ void ccCompass::estimateP21()
 	subsampleText.setToolTip("Only sample P21 on the each n'th point in the original outcrop model (decreases calculation time).");
 
 	QDialogButtonBox buttonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-	QObject::connect(&buttonBox, SIGNAL(accepted()), &dlg, SLOT(accept()));
-	QObject::connect(&buttonBox, SIGNAL(rejected()), &dlg, SLOT(reject()));
+	connect(&buttonBox, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
+	connect(&buttonBox, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
 	vbox->addWidget(&boxSizeLabel);
 	vbox->addWidget(&boxSizeText);
 	vbox->addWidget(&subsampleLabel);
@@ -3458,8 +3458,8 @@ void ccCompass::importFoliations()
 	}
 
 	QDialogButtonBox buttonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-	QObject::connect(&buttonBox, SIGNAL(accepted()), &dlg, SLOT(accept()));
-	QObject::connect(&buttonBox, SIGNAL(rejected()), &dlg, SLOT(reject()));
+	connect(&buttonBox, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
+	connect(&buttonBox, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
 
 	vbox->addWidget(&dipLabel);
 	vbox->addWidget(&dipCombo);
@@ -3586,8 +3586,8 @@ void ccCompass::importLineations()
 	}
 
 	QDialogButtonBox buttonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-	QObject::connect(&buttonBox, SIGNAL(accepted()), &dlg, SLOT(accept()));
-	QObject::connect(&buttonBox, SIGNAL(rejected()), &dlg, SLOT(reject()));
+	connect(&buttonBox, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
+	connect(&buttonBox, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
 
 	vbox->addWidget(&dipLabel);
 	vbox->addWidget(&dipCombo);

--- a/plugins/core/Standard/qCompass/ccCompass.h
+++ b/plugins/core/Standard/qCompass/ccCompass.h
@@ -59,7 +59,7 @@ public:
 	void onNewSelection(const ccHObject::Container& selectedEntities) override;
 	QList<QAction *> getActions() override;
 
-protected slots:
+protected:
 
 	//initialise the plugin
 	void doAction();

--- a/plugins/core/Standard/qCompass/src/ccCompassDlg.cpp
+++ b/plugins/core/Standard/qCompass/src/ccCompassDlg.cpp
@@ -77,14 +77,14 @@ ccCompassDlg::ccCompassDlg(QWidget* parent/*=0*/)
 	m_cost_algorithm_menu->addAction(m_recalculate);
 
 	//add callbacks
-	ccCompassDlg::connect(m_dark, SIGNAL(triggered()), this, SLOT(setDarkCost()));
-	ccCompassDlg::connect(m_light, SIGNAL(triggered()), this, SLOT(setLightCost()));
-	ccCompassDlg::connect(m_rgb, SIGNAL(triggered()), this, SLOT(setRGBCost()));
-	ccCompassDlg::connect(m_grad, SIGNAL(triggered()), this, SLOT(setGradCost()));
-	ccCompassDlg::connect(m_curve, SIGNAL(triggered()), this, SLOT(setCurveCost()));
-	ccCompassDlg::connect(m_dist, SIGNAL(triggered()), this, SLOT(setDistCost()));
-	ccCompassDlg::connect(m_scalar, SIGNAL(triggered()), this, SLOT(setScalarCost()));
-	ccCompassDlg::connect(m_scalar_inv, SIGNAL(triggered()), this, SLOT(setInvScalarCost()));
+	connect(m_dark, &QAction::triggered, this, &ccCompassDlg::setDarkCost);
+	connect(m_light, &QAction::triggered, this, &ccCompassDlg::setLightCost);
+	connect(m_rgb, &QAction::triggered, this, &ccCompassDlg::setRGBCost);
+	connect(m_grad, &QAction::triggered, this, &ccCompassDlg::setGradCost);
+	connect(m_curve, &QAction::triggered, this, &ccCompassDlg::setCurveCost);
+	connect(m_dist, &QAction::triggered, this, &ccCompassDlg::setDistCost);
+	connect(m_scalar, &QAction::triggered, this, &ccCompassDlg::setScalarCost);
+	connect(m_scalar_inv, &QAction::triggered, this, &ccCompassDlg::setInvScalarCost);
 
 	//setup settings menu
 	m_settings_menu = new QMenu(this);
@@ -195,7 +195,8 @@ ccCompassDlg::ccCompassDlg(QWidget* parent/*=0*/)
 	addOverridenShortcut(Qt::Key_Escape); //escape key for the "cancel" button
 	addOverridenShortcut(Qt::Key_Return); //return key for the "apply" button
 	addOverridenShortcut(Qt::Key_Space); //space key also hits the "apply" button (easier for some)
-	connect(this, SIGNAL(shortcutTriggered(int)), this, SLOT(onShortcutTriggered(int)));
+	
+	connect(this, &ccOverlayDialog::shortcutTriggered, this, &ccCompassDlg::onShortcutTriggered);
 }
 
 int ccCompassDlg::getCostMode()

--- a/plugins/core/Standard/qCompass/src/ccCompassDlg.h
+++ b/plugins/core/Standard/qCompass/src/ccCompassDlg.h
@@ -87,7 +87,7 @@ public:
 	QAction *m_toSVG; //export to svg
 	
 
-protected slots:
+protected:
 	//! To capture overridden shortcuts (pause button, etc.)
 	void onShortcutTriggered(int);
 

--- a/plugins/core/Standard/qCork/ccCorkDlg.h
+++ b/plugins/core/Standard/qCork/ccCorkDlg.h
@@ -42,7 +42,7 @@ public:
 	//! Returns whether mesh order has been swappped or not
 	bool isSwapped() const { return m_isSwapped; }
 
-protected slots:
+protected:
 
 	void unionSelected();
 	void intersectSelected();

--- a/plugins/core/Standard/qCork/qCork.h
+++ b/plugins/core/Standard/qCork/qCork.h
@@ -44,7 +44,7 @@ public:
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities);
 	virtual QList<QAction *> getActions() override;
 
-protected slots:
+protected:
 
 	//! Starts main action
 	void doAction();

--- a/plugins/core/Standard/qFacets/qFacets.h
+++ b/plugins/core/Standard/qFacets/qFacets.h
@@ -63,7 +63,7 @@ public:
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
 	virtual QList<QAction *> getActions() override;
 
-protected slots:
+protected:
 
 	//! Fuses the cells of a kd-tree to produces planar facets
 	void fuseKdTreeCells();

--- a/plugins/core/Standard/qFacets/src/facetsExportDlg.h
+++ b/plugins/core/Standard/qFacets/src/facetsExportDlg.h
@@ -35,7 +35,7 @@ public:
 	//! Default constructor
 	FacetsExportDlg(IOMode mode, QWidget* parent = 0);
 
-protected slots:
+protected:
 
 	//! Called when the 'browse' tool button is pressed
 	void browseDestination();

--- a/plugins/core/Standard/qFacets/src/stereogramDlg.cpp
+++ b/plugins/core/Standard/qFacets/src/stereogramDlg.cpp
@@ -599,8 +599,8 @@ StereogramDialog::StereogramDialog(ccMainAppInterface* app)
 			m_colorScaleSelector->setSelectedScale(scale->getUuid());
 			m_classifWidget->setDensityColorScale(scale);
 		}
-		connect(m_colorScaleSelector, SIGNAL(colorScaleSelected(int)), this, SLOT(colorScaleChanged(int)));
-		connect(m_colorScaleSelector, SIGNAL(colorScaleEditorSummoned()), this, SLOT(spawnColorScaleEditor()));
+		connect(m_colorScaleSelector, &ccColorScaleSelector::colorScaleSelected, this, &StereogramDialog::colorScaleChanged);
+		connect(m_colorScaleSelector, &ccColorScaleSelector::colorScaleEditorSummoned, this, &StereogramDialog::spawnColorScaleEditor);
 		//add selector to group's layout
 		if (!colorRampGroupBox->layout())
 			colorRampGroupBox->setLayout(new QHBoxLayout());
@@ -613,18 +613,18 @@ StereogramDialog::StereogramDialog(ccMainAppInterface* app)
 		m_classifWidget->setDensityColorScale(ccColorScalesManager::GetDefaultScale());
 	}
 
-	connect(colorScaleStepsSpinBox,		SIGNAL(valueChanged(int)),				this,	SLOT(onDensityColorStepsChanged(int)));
-	connect(ticksFreqSpinBox,			SIGNAL(valueChanged(int)),				this,	SLOT(onTicksFreqChanged(int)));
-	connect(showHSVColorsCheckBox,		SIGNAL(toggled(bool)),					this,	SLOT(onHSVColorsToggled(bool)));
+	connect(colorScaleStepsSpinBox,		static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &StereogramDialog::onDensityColorStepsChanged);
+	connect(ticksFreqSpinBox,			static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &StereogramDialog::onTicksFreqChanged);
+	connect(showHSVColorsCheckBox,		&QAbstractButton::toggled, this, &StereogramDialog::onHSVColorsToggled);
 
 	//interactive filtering mechanism
-	connect(filterFacetsGroupBox,		SIGNAL(toggled(bool)),					this,	SLOT(onFilterEnabled(bool)));
-	connect(dipSpanDoubleSpinBox,		SIGNAL(valueChanged(double)),			this,	SLOT(onFilterSizeChanged(double)));
-	connect(dipDirSpanDoubleSpinBox,	SIGNAL(valueChanged(double)),			this,	SLOT(onFilterSizeChanged(double)));
-	connect(dipDoubleSpinBox,			SIGNAL(valueChanged(double)),			this,	SLOT(onFilterCenterChanged(double)));
-	connect(dipDirDoubleSpinBox,		SIGNAL(valueChanged(double)),			this,	SLOT(onFilterCenterChanged(double)));
-	connect(m_classifWidget,			SIGNAL(pointClicked(double, double)),	this,	SLOT(onPointClicked(double, double)));
-	connect(exportPushButton,			SIGNAL(clicked()),						this,	SLOT(exportCurrentSelection()));
+	connect(filterFacetsGroupBox,		&QGroupBox::toggled, this, &StereogramDialog::onFilterEnabled);
+	connect(dipSpanDoubleSpinBox,		static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, &StereogramDialog::onFilterSizeChanged);
+	connect(dipDirSpanDoubleSpinBox,	static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, &StereogramDialog::onFilterSizeChanged);
+	connect(dipDoubleSpinBox,			static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, &StereogramDialog::onFilterCenterChanged);
+	connect(dipDirDoubleSpinBox,		static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, &StereogramDialog::onFilterCenterChanged);
+	connect(m_classifWidget,			&StereogramWidget::pointClicked, this, &StereogramDialog::onPointClicked);
+	connect(exportPushButton,			&QAbstractButton::clicked, this, &StereogramDialog::exportCurrentSelection);
 }
 
 bool StereogramDialog::init(double angularStep_deg,

--- a/plugins/core/Standard/qFacets/src/stereogramDlg.h
+++ b/plugins/core/Standard/qFacets/src/stereogramDlg.h
@@ -169,7 +169,7 @@ public:
 	//! Returns associated widget
 	StereogramWidget* stereogram() { return m_classifWidget; }
 
-protected slots:
+protected:
 
 	void colorScaleChanged(int);
 	void spawnColorScaleEditor();

--- a/plugins/core/Standard/qHPR/qHPR.h
+++ b/plugins/core/Standard/qHPR/qHPR.h
@@ -45,7 +45,7 @@ public:
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
 	virtual QList<QAction *> getActions() override;
 
-protected slots:
+protected:
 
 	//! Slot called when associated ation is triggered
 	void doAction();

--- a/plugins/core/Standard/qHoughNormals/qHoughNormals.h
+++ b/plugins/core/Standard/qHoughNormals/qHoughNormals.h
@@ -41,7 +41,7 @@ public:
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
 	virtual QList<QAction *> getActions() override;
 
-protected slots:
+protected:
 
 	//! Slot called when associated ation is triggered
 	void doAction();

--- a/plugins/core/Standard/qM3C2/src/qM3C2Dialog.cpp
+++ b/plugins/core/Standard/qM3C2/src/qM3C2Dialog.cpp
@@ -94,21 +94,21 @@ qM3C2Dialog::qM3C2Dialog(ccPointCloud* cloud1, ccPointCloud* cloud2, ccMainAppIn
 	maxThreadCountSpinBox->setRange(1, maxThreadCount);
 	maxThreadCountSpinBox->setSuffix(QString(" / %1").arg(maxThreadCount));
 
-	connect(showCloud1CheckBox,			SIGNAL(toggled(bool)),	this, SLOT(setCloud1Visibility(bool)));
-	connect(showCloud2CheckBox,			SIGNAL(toggled(bool)),	this, SLOT(setCloud2Visibility(bool)));
+	connect(showCloud1CheckBox,		&QAbstractButton::toggled,	this, &qM3C2Dialog::setCloud1Visibility);
+	connect(showCloud2CheckBox,		&QAbstractButton::toggled,	this, &qM3C2Dialog::setCloud2Visibility);
 
-	connect(loadParamsToolButton,		SIGNAL(clicked()),		this, SLOT(loadParamsFromFile()));
-	connect(saveParamsToolButton,		SIGNAL(clicked()),		this, SLOT(saveParamsToFile()));
-	connect(swapCloudsToolButton,		SIGNAL(clicked()),		this, SLOT(swapClouds()));
-	connect(guessParamsPushButton,		SIGNAL(clicked()),		this, SLOT(guessParamsSlow()));
+	connect(loadParamsToolButton,	&QAbstractButton::clicked,	this, &qM3C2Dialog::getParamsFromFile);
+	connect(saveParamsToolButton,	&QAbstractButton::clicked,	this, &qM3C2Dialog::saveParamsToFile);
+	connect(swapCloudsToolButton,	&QAbstractButton::clicked,	this, &qM3C2Dialog::swapClouds);
+	connect(guessParamsPushButton,	&QAbstractButton::clicked,	this, &qM3C2Dialog::guessParamsSlow);
 
-	connect(projDestComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(projDestIndexChanged(int)));
+	connect(projDestComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &qM3C2Dialog::projDestIndexChanged);
 
-	connect(cpOtherCloudComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(updateNormalComboBox()));
-	connect(normalSourceComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(onUpdateNormalComboBoxChanged(int)));
-	connect(cpUseCloud1RadioButton, SIGNAL(toggled(bool)), this, SLOT(updateNormalComboBox()));
-	connect(cpSubsampleRadioButton, SIGNAL(toggled(bool)), this, SLOT(updateNormalComboBox()));
-	connect(cpUseOtherCloudRadioButton, SIGNAL(toggled(bool)), this, SLOT(updateNormalComboBox()));
+	connect(cpOtherCloudComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &qM3C2Dialog::updateNormalComboBox);
+	connect(normalSourceComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &qM3C2Dialog::onUpdateNormalComboBoxChanged);
+	connect(cpUseCloud1RadioButton, &QAbstractButton::toggled, this, &qM3C2Dialog::updateNormalComboBox);
+	connect(cpSubsampleRadioButton, &QAbstractButton::toggled, this, &qM3C2Dialog::updateNormalComboBox);
+	connect(cpUseOtherCloudRadioButton, &QAbstractButton::toggled, this, &qM3C2Dialog::updateNormalComboBox);
 
 	loadParamsFromPersistentSettings();
 
@@ -612,7 +612,7 @@ void qM3C2Dialog::saveParamsTo(QSettings& settings)
 	settings.setValue("PM2Scale", pm2ScaleDoubleSpinBox->value());
 }
 
-void qM3C2Dialog::loadParamsFromFile()
+void qM3C2Dialog::getParamsFromFile()
 {
 	//select file to open
 	QString filename;

--- a/plugins/core/Standard/qM3C2/src/qM3C2Dialog.h
+++ b/plugins/core/Standard/qM3C2/src/qM3C2Dialog.h
@@ -87,13 +87,13 @@ public:
 	//! Saves parameters to persistent settings
 	void saveParamsToPersistentSettings();
 
-protected slots:
+protected:
 
 	void swapClouds();
 	void setCloud1Visibility(bool);
 	void setCloud2Visibility(bool);
 	void saveParamsToFile();
-	void loadParamsFromFile();
+	void getParamsFromFile();
 	inline void guessParamsSlow() { guessParams(false); }
 	void projDestIndexChanged(int);
 	void onUpdateNormalComboBoxChanged(int);

--- a/plugins/core/Standard/qPCL/PclUtils/filters/BaseFilter.h
+++ b/plugins/core/Standard/qPCL/PclUtils/filters/BaseFilter.h
@@ -170,7 +170,7 @@ public:
 	//! Returns the associated parent plugin interface
 	ccPluginInterface * getParentPlugin() const { return m_parent_plugin; }
 
-protected slots:
+protected:
 
 	//! Returns is called when the dialog window is accepted.
 	/** it can be overridden but normally should not be necessary

--- a/plugins/core/Standard/qPCL/PclUtils/filters/dialogs/MLSDialog.h
+++ b/plugins/core/Standard/qPCL/PclUtils/filters/dialogs/MLSDialog.h
@@ -30,7 +30,7 @@ class MLSDialog : public QDialog, public Ui::MLSDialog
 public:
 	explicit MLSDialog(QWidget *parent = 0);
 
-protected slots:
+protected:
 	void activateMenu(QString name);
 	void toggleMethods(bool status);
 	void updateSquaredGaussian(double radius);

--- a/plugins/core/Standard/qPCL/qPCL.h
+++ b/plugins/core/Standard/qPCL/qPCL.h
@@ -47,7 +47,7 @@ public:
 	//! Adds a filter
 	int addFilter(BaseFilter* filter);
 
-public slots:
+public:
 	//! Handles new entity
 	void handleNewEntity(ccHObject*);
 

--- a/plugins/core/Standard/qPoissonRecon/qPoissonRecon.h
+++ b/plugins/core/Standard/qPoissonRecon/qPoissonRecon.h
@@ -42,7 +42,7 @@ public:
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
 	virtual QList<QAction *> getActions() override;
 
-protected slots:
+protected:
 
 	//! Slot called when associated ation is triggered
 	void doAction();

--- a/plugins/core/Standard/qRANSAC_SD/ccRansacSDDlg.h
+++ b/plugins/core/Standard/qRANSAC_SD/ccRansacSDDlg.h
@@ -30,7 +30,7 @@ public:
 	//! Default constructor
 	explicit ccRansacSDDlg(QWidget* parent = 0);
 
-protected slots:
+protected:
 
 	//! Saves (temporarily) the dialog parameters on acceptation
 	void saveSettings();

--- a/plugins/core/Standard/qRANSAC_SD/qRANSAC_SD.h
+++ b/plugins/core/Standard/qRANSAC_SD/qRANSAC_SD.h
@@ -79,7 +79,7 @@ public:
 	virtual void registerCommands(ccCommandLineInterface* cmd) override;
 
 	static ccHObject* executeRANSAC(ccPointCloud* ccPC, const RansacParams& params, bool silent = false);
-protected slots:
+protected:
 
 	//! Slot called when associated ation is triggered
 	void doAction();

--- a/plugins/core/Standard/qSRA/distanceMapGenerationDlg.cpp
+++ b/plugins/core/Standard/qSRA/distanceMapGenerationDlg.cpp
@@ -125,8 +125,8 @@ DistanceMapGenerationDlg::DistanceMapGenerationDlg(ccPointCloud* cloud, ccScalar
 		m_colorScaleSelector = new ccColorScaleSelector(m_app->getColorScalesManager(),this,QString::fromUtf8(":/CC/plugin/qSRA/gearIcon.png"));
 		m_colorScaleSelector->init();
 		m_colorScaleSelector->setSelectedScale(ccColorScalesManager::GetDefaultScale()->getUuid());
-		connect(m_colorScaleSelector, SIGNAL(colorScaleSelected(int)), this, SLOT(colorScaleChanged(int)));
-		connect(m_colorScaleSelector, SIGNAL(colorScaleEditorSummoned()), this, SLOT(spawnColorScaleEditor()));
+		connect(m_colorScaleSelector, &ccColorScaleSelector::colorScaleSelected, this, &DistanceMapGenerationDlg::colorScaleChanged);
+		connect(m_colorScaleSelector, &ccColorScaleSelector::colorScaleEditorSummoned, this, &DistanceMapGenerationDlg::spawnColorScaleEditor);
 		//add selector to group's layout
 		if (!colorRampGroupBox->layout())
 			colorRampGroupBox->setLayout(new QHBoxLayout());
@@ -239,49 +239,52 @@ DistanceMapGenerationDlg::DistanceMapGenerationDlg(ccPointCloud* cloud, ccScalar
 		m_window->addToOwnDB(m_yLabels,false);
 	}
 
-	connect(projectionComboBox,				SIGNAL(currentIndexChanged(int)),	this,	SLOT(projectionModeChanged(int)));
-	connect(angularUnitComboBox,			SIGNAL(currentIndexChanged(int)),	this,	SLOT(angularUnitChanged(int)));
-	connect(xStepDoubleSpinBox,				SIGNAL(valueChanged(double)),		this,	SLOT(updateGridSteps()));
-	connect(hStepDoubleSpinBox,				SIGNAL(valueChanged(double)),		this,	SLOT(updateGridSteps()));
-	connect(latStepDoubleSpinBox,			SIGNAL(valueChanged(double)),		this,	SLOT(updateGridSteps()));
-	connect(xMinDoubleSpinBox,				SIGNAL(valueChanged(double)),		this,	SLOT(updateGridSteps()));
-	connect(xMaxDoubleSpinBox,				SIGNAL(valueChanged(double)),		this,	SLOT(updateGridSteps()));
-	connect(hMinDoubleSpinBox,				SIGNAL(valueChanged(double)),		this,	SLOT(updateGridSteps()));
-	connect(hMaxDoubleSpinBox,				SIGNAL(valueChanged(double)),		this,	SLOT(updateGridSteps()));
-	connect(latMinDoubleSpinBox,			SIGNAL(valueChanged(double)),		this,	SLOT(updateGridSteps()));
-	connect(latMaxDoubleSpinBox,			SIGNAL(valueChanged(double)),		this,	SLOT(updateGridSteps()));
-	connect(axisDimComboBox,				SIGNAL(currentIndexChanged(int)),	this,	SLOT(updateProfileRevolDim(int)));
-	connect(xOriginDoubleSpinBox,			SIGNAL(valueChanged(double)),		this,	SLOT(updateProfileOrigin()));
-	connect(yOriginDoubleSpinBox,			SIGNAL(valueChanged(double)),		this,	SLOT(updateProfileOrigin()));
-	connect(zOriginDoubleSpinBox,			SIGNAL(valueChanged(double)),		this,	SLOT(updateProfileOrigin()));
-	connect(baseRadiusDoubleSpinBox,		SIGNAL(valueChanged(double)),		this,	SLOT(baseRadiusChanged(double)));
-	connect(heightUnitLineEdit,				SIGNAL(editingFinished()),			this,	SLOT(updateHeightUnits()));
-	connect(exportCloudPushButton,			SIGNAL(clicked()),					this,	SLOT(exportMapAsCloud()));
-	connect(exportMeshPushButton,			SIGNAL(clicked()),					this,	SLOT(exportMapAsMesh()));
-	connect(exportMatrixPushButton,			SIGNAL(clicked()),					this,	SLOT(exportMapAsGrid()));
-	connect(exportImagePushButton,			SIGNAL(clicked()),					this,	SLOT(exportMapAsImage()));
-	connect(loadLabelsPushButton,			SIGNAL(clicked()),					this,	SLOT(loadOverlaySymbols()));
-	connect(clearLabelsPushButton,			SIGNAL(clicked()),					this,	SLOT(clearOverlaySymbols()));
-	connect(symbolSizeSpinBox,				SIGNAL(valueChanged(int)),			this,	SLOT(overlaySymbolsSizeChanged(int)));
-	connect(fontSizeSpinBox,				SIGNAL(valueChanged(int)),			this,	SLOT(labelFontSizeChanged(int)));
-	connect(precisionSpinBox,				SIGNAL(valueChanged(int)),			this,	SLOT(labelPrecisionChanged(int)));
+	connect(projectionComboBox,			static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),			this, &DistanceMapGenerationDlg::projectionModeChanged);
+	connect(angularUnitComboBox,		static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),			this, &DistanceMapGenerationDlg::angularUnitChanged);
+	connect(xStepDoubleSpinBox,			static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),	this, &DistanceMapGenerationDlg::updateGridSteps);
+	connect(hStepDoubleSpinBox,			static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),	this, &DistanceMapGenerationDlg::updateGridSteps);
+	connect(latStepDoubleSpinBox,		static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),	this, &DistanceMapGenerationDlg::updateGridSteps);
+	connect(xMinDoubleSpinBox,			static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),	this, &DistanceMapGenerationDlg::updateGridSteps);
+	connect(xMaxDoubleSpinBox,			static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),	this, &DistanceMapGenerationDlg::updateGridSteps);
+	connect(hMinDoubleSpinBox,			static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),	this, &DistanceMapGenerationDlg::updateGridSteps);
+	connect(hMaxDoubleSpinBox,			static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),	this, &DistanceMapGenerationDlg::updateGridSteps);
+	connect(latMinDoubleSpinBox,		static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),	this, &DistanceMapGenerationDlg::updateGridSteps);
+	connect(latMaxDoubleSpinBox,		static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),	this, &DistanceMapGenerationDlg::updateGridSteps);
+	connect(axisDimComboBox,			static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),			this, &DistanceMapGenerationDlg::updateProfileRevolDim);
+	connect(xOriginDoubleSpinBox,		static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),	this, &DistanceMapGenerationDlg::updateProfileOrigin);
+	connect(yOriginDoubleSpinBox,		static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),	this, &DistanceMapGenerationDlg::updateProfileOrigin);
+	connect(zOriginDoubleSpinBox,		static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),	this, &DistanceMapGenerationDlg::updateProfileOrigin);
+	connect(baseRadiusDoubleSpinBox,	static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),	this, &DistanceMapGenerationDlg::baseRadiusChanged);
 	
-	connect(colorScaleStepsSpinBox,			SIGNAL(valueChanged(int)),			this,	SLOT(colorRampStepsChanged(int)));
-	connect(overlayGridGroupBox,			SIGNAL(toggled(bool)),				this,	SLOT(toggleOverlayGrid(bool)));
-	connect(scaleXStepDoubleSpinBox,		SIGNAL(editingFinished()),			this,	SLOT(updateOverlayGrid()));
-	connect(scaleHStepDoubleSpinBox,		SIGNAL(editingFinished()),			this,	SLOT(updateOverlayGrid()));
-	connect(scaleLatStepDoubleSpinBox,		SIGNAL(editingFinished()),			this,	SLOT(updateOverlayGrid()));
-	connect(xScaleCheckBox,					SIGNAL(clicked()),					this,	SLOT(updateOverlayGrid()));
-	connect(yScaleCheckBox,					SIGNAL(clicked()),					this,	SLOT(updateOverlayGrid()));
-	connect(gridColorButton,				SIGNAL(clicked()),					this,	SLOT(changeGridColor()));
-	connect(symbolColorButton,				SIGNAL(clicked()),					this,	SLOT(changeSymbolColor()));
-	connect(displayColorScaleCheckBox,		SIGNAL(toggled(bool)),				this,	SLOT(toggleColorScaleDisplay(bool)));
-	connect(updateVolumesPushButton,		SIGNAL(clicked()),					this,	SLOT(updateVolumes()));
+	connect(heightUnitLineEdit,			&QLineEdit::editingFinished, this, &DistanceMapGenerationDlg::updateHeightUnits);
+	
+	connect(exportCloudPushButton,		&QAbstractButton::clicked, this,	&DistanceMapGenerationDlg::exportMapAsCloud);
+	connect(exportMeshPushButton,		&QAbstractButton::clicked, this,	&DistanceMapGenerationDlg::exportMapAsMesh);
+	connect(exportMatrixPushButton,		&QAbstractButton::clicked, this,	&DistanceMapGenerationDlg::exportMapAsGrid);
+	connect(exportImagePushButton,		&QAbstractButton::clicked, this,	&DistanceMapGenerationDlg::exportMapAsImage);
+	connect(loadLabelsPushButton,		&QAbstractButton::clicked, this,	&DistanceMapGenerationDlg::loadOverlaySymbols);
+	connect(clearLabelsPushButton,		&QAbstractButton::clicked, this,	&DistanceMapGenerationDlg::clearOverlaySymbols);
+	
+	connect(symbolSizeSpinBox,			static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &DistanceMapGenerationDlg::overlaySymbolsSizeChanged);
+	connect(fontSizeSpinBox,			static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &DistanceMapGenerationDlg::labelFontSizeChanged);
+	connect(precisionSpinBox,			static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &DistanceMapGenerationDlg::labelPrecisionChanged);
+	connect(colorScaleStepsSpinBox,		static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &DistanceMapGenerationDlg::colorRampStepsChanged);
+	
+	connect(overlayGridGroupBox,		&QGroupBox::toggled,				this,	&DistanceMapGenerationDlg::toggleOverlayGrid);
+	connect(scaleXStepDoubleSpinBox,	&QAbstractSpinBox::editingFinished,	this,	&DistanceMapGenerationDlg::updateOverlayGrid);
+	connect(scaleHStepDoubleSpinBox,	&QAbstractSpinBox::editingFinished,	this,	&DistanceMapGenerationDlg::updateOverlayGrid);
+	connect(scaleLatStepDoubleSpinBox,	&QAbstractSpinBox::editingFinished,	this,	&DistanceMapGenerationDlg::updateOverlayGrid);
+	connect(xScaleCheckBox,				&QAbstractButton::clicked,			this,	&DistanceMapGenerationDlg::updateOverlayGrid);
+	connect(yScaleCheckBox,				&QAbstractButton::clicked,			this,	&DistanceMapGenerationDlg::updateOverlayGrid);
+	connect(gridColorButton,			&QAbstractButton::clicked,			this,	&DistanceMapGenerationDlg::changeGridColor);
+	connect(symbolColorButton,			&QAbstractButton::clicked,			this,	&DistanceMapGenerationDlg::changeSymbolColor);
+	connect(displayColorScaleCheckBox,	&QAbstractButton::toggled,			this,	&DistanceMapGenerationDlg::toggleColorScaleDisplay);
+	connect(updateVolumesPushButton,	&QAbstractButton::clicked,			this,	&DistanceMapGenerationDlg::updateVolumes);
 
 	//DXF profiles export button is only visible/connected if DXF support is enabled!
 	if (DxfProfilesExporter::IsEnabled())
 	{
-		connect(exportImageDXFButton,			SIGNAL(clicked()),					this,	SLOT(exportProfilesAsDXF()));
+		connect(exportImageDXFButton, &QAbstractButton::clicked, this, &DistanceMapGenerationDlg::exportProfilesAsDXF);
 	}
 	else
 	{
@@ -292,8 +295,8 @@ DistanceMapGenerationDlg::DistanceMapGenerationDlg(ccPointCloud* cloud, ccScalar
 	{
 		QPushButton* applyButton = buttonBox->button(QDialogButtonBox::Apply);
 		QPushButton* closeButton = buttonBox->button(QDialogButtonBox::Close);
-		connect(applyButton,				SIGNAL(clicked()),					this,	SLOT(update()));
-		connect(closeButton,				SIGNAL(clicked()),					this,	SLOT(accept()));
+		connect(applyButton, &QAbstractButton::clicked, this, &DistanceMapGenerationDlg::update);
+		connect(closeButton, &QAbstractButton::clicked, this, &QDialog::accept);
 	}
 
 	angularUnitChanged(m_angularUnits); //just to be sure

--- a/plugins/core/Standard/qSRA/distanceMapGenerationDlg.h
+++ b/plugins/core/Standard/qSRA/distanceMapGenerationDlg.h
@@ -99,7 +99,7 @@ public:
 	**/
 	double getScaleYStep(ANGULAR_UNIT unit = ANG_RAD) const;
 
-protected slots:
+protected:
 
 	void projectionModeChanged(int);
 	void angularUnitChanged(int);

--- a/plugins/core/Standard/qSRA/dxfProfilesExportDlg.h
+++ b/plugins/core/Standard/qSRA/dxfProfilesExportDlg.h
@@ -35,7 +35,7 @@ public:
 	//! Returns horiz. profiles output filename (on completion)
 	QString getHorizFilename() const;
 
-protected slots:
+protected:
 
 	//! Called when the vert. 'browse' tool button is pressed
 	void browseVertFile();

--- a/plugins/core/Standard/qSRA/profileImportDlg.h
+++ b/plugins/core/Standard/qSRA/profileImportDlg.h
@@ -44,7 +44,7 @@ public:
 	//! Returns whether the profile heights are absolute or not (i.e. relative to the center)
 	bool absoluteHeightValues() const;
 
-protected slots:
+protected:
 
 	//! Called when the 'browse' tool button is pressed
 	void browseFile();

--- a/plugins/core/Standard/qSRA/qSRA.h
+++ b/plugins/core/Standard/qSRA/qSRA.h
@@ -41,7 +41,7 @@ public:
 	virtual void onNewSelection(const ccHObject::Container& selectedEntities) override;
 	virtual QList<QAction *> getActions() override;
 
-protected slots:
+protected:
 
 	//! Loads profile from a dedicated file
 	void loadProfile() const;

--- a/qCC/ccAdjustZoomDlg.h
+++ b/qCC/ccAdjustZoomDlg.h
@@ -39,7 +39,7 @@ public:
 	//! Returns requested zoom
 	double getZoom() const;
 
-protected slots:
+protected:
 	void onZoomChanged(double);
 	void onPixelSizeChanged(double);
 	void onPixelCountChanged(int);

--- a/qCC/ccAlignDlg.cpp
+++ b/qCC/ccAlignDlg.cpp
@@ -227,7 +227,6 @@ void ccAlignDlg::setColorsAndLabels()
 	MainWindow::RefreshAllGLWindow(false);
 }
 
-//SLOTS
 void ccAlignDlg::swapModelAndData()
 {
 	std::swap(dataObject,modelObject);

--- a/qCC/ccApplyTransformationDlg.h
+++ b/qCC/ccApplyTransformationDlg.h
@@ -36,7 +36,7 @@ public:
 	//! Returns input matrix
 	ccGLMatrixd getTransformation() const;
 
-protected slots:
+protected:
 
 	//! Checks matrix validity and 'accept' dialog if ok
 	void checkMatrixValidityAndAccept();

--- a/qCC/ccBoundingBoxEditorDlg.h
+++ b/qCC/ccBoundingBoxEditorDlg.h
@@ -65,12 +65,12 @@ public:
 	//! Whether to display or not the box axes
 	void showBoxAxes(bool state);
 
-public slots:
+public:
 
 	//overloaded from QDialog
 	virtual int	exec();
 
-protected slots:
+protected:
 
 	void squareModeActivated(bool);
 	void resetToDefault();

--- a/qCC/ccClippingBoxRepeatDlg.h
+++ b/qCC/ccClippingBoxRepeatDlg.h
@@ -38,7 +38,7 @@ public:
 	//! Sets repeat dimension (multiple contour mode only!)
 	void setRepeatDim(unsigned char dim);
 
-protected slots:
+protected:
 
 	//multi-contour mode
 	void onDimChecked(bool);

--- a/qCC/ccClippingBoxTool.h
+++ b/qCC/ccClippingBoxTool.h
@@ -107,7 +107,7 @@ public:
 		bool generateRandomColors = false,
 		ccProgressDialog* progressDialog = 0);
 
-protected slots:
+protected:
 
 	void toggleInteractors(bool);
 	void toggleBox(bool);

--- a/qCC/ccColorFromScalarDlg.h
+++ b/qCC/ccColorFromScalarDlg.h
@@ -46,7 +46,7 @@ public:
 	//update and redraw histograms
 	void updateHistogram(int);
 
-protected slots:
+protected:
 	//events to set scalar fields
 	void onChannelChangedR(int) { updateChannel(0); }
 	void onChannelChangedG(int) { updateChannel(1); }

--- a/qCC/ccColorGradientDlg.h
+++ b/qCC/ccColorGradientDlg.h
@@ -50,7 +50,7 @@ public:
 	//! Returns the ramp dimension
 	unsigned char getDimension() const;
 
-protected slots:
+protected:
 
 	void changeFirstColor();
 	void changeSecondColor();

--- a/qCC/ccColorLevelsDlg.h
+++ b/qCC/ccColorLevelsDlg.h
@@ -36,7 +36,7 @@ public:
 	//! Default constructor
 	ccColorLevelsDlg(QWidget* parent, ccGenericPointCloud* pointCloud);
 
-protected slots:
+protected:
 
 	void onChannelChanged(int);
 	void onApply();

--- a/qCC/ccColorScaleEditorDlg.h
+++ b/qCC/ccColorScaleEditorDlg.h
@@ -55,7 +55,7 @@ public:
 	//! Returns active scale
 	ccColorScale::Shared getActiveScale() { return m_colorScale; }
 
-protected slots:
+protected:
 
 	void colorScaleChanged(int);
 	void relativeModeChanged(int);

--- a/qCC/ccColorScaleEditorWidget.h
+++ b/qCC/ccColorScaleEditorWidget.h
@@ -291,7 +291,7 @@ signals:
 	//! Signal emitted when a slider is modified
 	void stepModified(int index);
 
-protected slots:
+protected:
 
 	//! Slot called when a 'point' is clicked on the color bar 
 	void onPointClicked(double relativePos);

--- a/qCC/ccColorScaleSelector.cpp
+++ b/qCC/ccColorScaleSelector.cpp
@@ -75,13 +75,13 @@ void ccColorScaleSelector::init()
 			m_comboBox->addItem(scale.key(), scale.value());
 		}
 
-		connect(m_comboBox, SIGNAL(activated(int)), this, SIGNAL(colorScaleSelected(int)));
+		connect(m_comboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), this, &ccColorScaleSelector::colorScaleSelected);
 	}
 	//advanced tool button
 	if (m_button)
 	{
 		m_button->disconnect(this);
-		connect(m_button, SIGNAL(clicked()), this, SIGNAL(colorScaleEditorSummoned()));
+		connect(m_button, &QAbstractButton::clicked, this, &ccColorScaleSelector::colorScaleEditorSummoned);
 	}
 }
 

--- a/qCC/ccComparisonDlg.h
+++ b/qCC/ccComparisonDlg.h
@@ -64,12 +64,12 @@ public:
 	//! Returns compared entity
 	ccHObject* getReferenceEntity() { return m_refEnt; }
 
-public slots:
+public:
 	bool computeDistances();
 	void applyAndExit();
 	void cancelAndExit();
 
-protected slots:
+protected:
 	void showHisto();
 	void locaModelChanged(int);
 	void maxDistUpdated();

--- a/qCC/ccConsole.h
+++ b/qCC/ccConsole.h
@@ -90,7 +90,7 @@ public:
 	//! Returns the parent widget (if any)
 	inline QWidget* parentWidget() { return m_parentWidget; }
 
-public slots:
+public:
 
 	//! Refreshes console (display all messages still in queue)
 	void refresh();

--- a/qCC/ccContourExtractorDlg.h
+++ b/qCC/ccContourExtractorDlg.h
@@ -67,7 +67,7 @@ public:
 	//! Returns whether the dialog has been 'skipped' or not
 	bool isSkipped() const;
 
-protected slots:
+protected:
 
 	//! When the skip button is clicked
 	void onSkipButtonClicked();

--- a/qCC/ccEntitySelectionDlg.h
+++ b/qCC/ccEntitySelectionDlg.h
@@ -59,7 +59,7 @@ public:
 								QWidget* parent = 0,
 								QString label = QString());
 
-public slots:
+public:
 
 	//! Selects all entities
 	void selectAll();

--- a/qCC/ccFilterByValueDlg.h
+++ b/qCC/ccFilterByValueDlg.h
@@ -43,7 +43,7 @@ public:
 	//! Returns the selected mode
 	Mode mode() const { return m_mode; }
 	
-protected slots:
+protected:
 
 	void onExport() { m_mode = EXPORT; accept(); }
 	void onSplit() { m_mode = SPLIT; accept(); }

--- a/qCC/ccGraphicalSegmentationTool.h
+++ b/qCC/ccGraphicalSegmentationTool.h
@@ -78,7 +78,7 @@ public:
 	**/
 	void removeAllEntities(bool unallocateVisibilityArrays);
 
-protected slots:
+protected:
 
 	void segmentIn();
 	void segmentOut();

--- a/qCC/ccGraphicalTransformationTool.h
+++ b/qCC/ccGraphicalTransformationTool.h
@@ -72,7 +72,7 @@ public:
 	ccGLMatrixd arbitraryVectorRotation(double angle, const CCVector3d&);
 
 
-protected slots:
+protected:
 
 	//! Applies transformation to selected entities
 	void apply();

--- a/qCC/ccHistogramWindow.h
+++ b/qCC/ccHistogramWindow.h
@@ -234,7 +234,7 @@ public:
 	//! Exports histogram to a CSV file
 	bool exportToCSV(QString filename) const;
 
-protected slots:
+protected:
 
 	//! When the export to CSV file button is pressed
 	void onExportToCSV();

--- a/qCC/ccInterpolationDlg.h
+++ b/qCC/ccInterpolationDlg.h
@@ -39,7 +39,7 @@ public:
 	ccPointCloudInterpolator::Parameters::Algo getInterpolationAlgorithm() const;
 	void setInterpolationAlgorithm(ccPointCloudInterpolator::Parameters::Algo algo);
 
-protected slots:
+protected:
 
 	void onRadiusUpdated(double);
 };

--- a/qCC/ccNormalComputationDlg.h
+++ b/qCC/ccNormalComputationDlg.h
@@ -91,7 +91,7 @@ public:
 	//! Sets the number of neighbors for Minimum Spanning Tree (MST)
 	void setMSTNeighborCount(int n);
 
-protected slots:
+protected:
 
 	//! On local model change
 	void localModelChanged(int index);

--- a/qCC/ccOrderChoiceDlg.h
+++ b/qCC/ccOrderChoiceDlg.h
@@ -47,7 +47,7 @@ public:
 	//! Returns the second entity (new order)
 	ccHObject* getSecondEntity();
 
-protected slots:
+protected:
 
 	//! Swaps the entities
 	void swap();

--- a/qCC/ccOrthoSectionGenerationDlg.h
+++ b/qCC/ccOrthoSectionGenerationDlg.h
@@ -51,7 +51,7 @@ public:
 	//! Returns the sections width
 	double getSectionsWidth() const;
 
-protected slots:
+protected:
 	void onStepChanged(double);
 
 protected:

--- a/qCC/ccPlaneEditDlg.h
+++ b/qCC/ccPlaneEditDlg.h
@@ -55,14 +55,14 @@ public:
 	//! Inherited from ccPickingListener
 	virtual void onItemPicked(const PickedItem& pi);
 
-public slots:
+public:
 
 	void pickPointAsCenter(bool);
 	void onDipDirChanged(double);
 	void onDipDirModified(bool);
 	void onNormalChanged(double);
 
-protected slots:
+protected:
 
 	void saveParamsAndAccept();
 

--- a/qCC/ccPointListPickingDlg.h
+++ b/qCC/ccPointListPickingDlg.h
@@ -44,7 +44,7 @@ public:
 	//! Associates dialog with a cloud or a mesh
 	void linkWithEntity(ccHObject* entity);
 
-protected slots:
+protected:
 
 	//! Applies changes and exit
 	void applyAndExit();

--- a/qCC/ccPointPairRegistrationDlg.h
+++ b/qCC/ccPointPairRegistrationDlg.h
@@ -78,7 +78,7 @@ public:
 	//! Inherited from ccPickingListener
 	void onItemPicked(const PickedItem& pi) override;
 
-protected slots:
+protected:
 
 	//! Slot called to change aligned entities visibility
 	void showAlignedEntities(bool);

--- a/qCC/ccPointPropertiesDlg.h
+++ b/qCC/ccPointPropertiesDlg.h
@@ -44,7 +44,7 @@ public:
 	virtual void stop(bool state) override;
 	virtual bool linkWith(ccGLWindow* win) override;
 
-protected slots:
+protected:
 
 	void onClose();
 	void activatePointPropertiesDisplay();

--- a/qCC/ccPrimitiveDistanceDlg.h
+++ b/qCC/ccPrimitiveDistanceDlg.h
@@ -45,12 +45,12 @@ public:
 	bool signedDistances() { return signedDistCheckBox->isChecked(); }
 	bool flipNormals() { return flipNormalsCheckBox->isChecked(); }
 	bool treatPlanesAsBounded() { return treatPlanesAsBoundedCheckBox->isChecked(); }
-public slots:
+public:
 	void applyAndExit();
 	void cancelAndExit();
 
 
-protected slots:
+protected:
 	void toggleSigned(bool);
 };
 

--- a/qCC/ccPrimitiveFactoryDlg.h
+++ b/qCC/ccPrimitiveFactoryDlg.h
@@ -35,7 +35,7 @@ public:
 	//! Default constructor
 	explicit ccPrimitiveFactoryDlg(MainWindow* win);
 
-protected slots:
+protected:
 
 	//! Creates currently defined primitive
 	void createPrimitive();

--- a/qCC/ccRegistrationDlg.h
+++ b/qCC/ccRegistrationDlg.h
@@ -97,7 +97,7 @@ public:
 	//! Saves parameters for next call
 	void saveParameters() const;
 
-protected slots:
+protected:
 	void swapModelAndData();
 
 protected:

--- a/qCC/ccRenderToFileDlg.h
+++ b/qCC/ccRenderToFileDlg.h
@@ -42,7 +42,7 @@ public:
 	bool renderOverlayItems() const;
 
 
-	protected slots:
+	protected:
 
 		void chooseFile();
 		void updateInfo();

--- a/qCC/ccScalarFieldArithmeticsDlg.h
+++ b/qCC/ccScalarFieldArithmeticsDlg.h
@@ -105,7 +105,7 @@ public:
 	**/
 	static bool Apply(ccPointCloud* cloud, Operation op, int sf1Idx, bool inplace, SF2* sf2 = nullptr, QWidget* parent = nullptr);
 
-protected slots:
+protected:
 	
 	//! Called when the operation combo-box is modified
 	void onOperationIndexChanged(int index);

--- a/qCC/ccScaleDlg.h
+++ b/qCC/ccScaleDlg.h
@@ -48,7 +48,7 @@ public:
 	//! Saves state
 	void saveState();
 
-protected slots:
+protected:
 
 	void allDimsAtOnceToggled(bool);
 	void fxUpdated(double);

--- a/qCC/ccSelectChildrenDlg.h
+++ b/qCC/ccSelectChildrenDlg.h
@@ -59,7 +59,7 @@ public:
 	//! if performing name-match (regex or not)
 	bool getNameMatchIsUsed() const;
 
-protected slots:
+protected:
 	//! Called when the dialog is accepted
 	void onAccept();
 	

--- a/qCC/ccSubsamplingDlg.h
+++ b/qCC/ccSubsamplingDlg.h
@@ -56,7 +56,7 @@ public:
 	//! Enables the SF modulation option (SPATIAL method)
 	void enableSFModulation(ScalarType sfMin, ScalarType sfMax);
 
-protected slots:
+protected:
 
 	void sliderMoved(int sliderPos);
 	void samplingRateChanged(double value);

--- a/qCC/ccTracePolylineTool.h
+++ b/qCC/ccTracePolylineTool.h
@@ -53,7 +53,7 @@ public:
 	virtual bool start() override;
 	virtual void stop(bool accepted) override;
 
-protected slots:
+protected:
 
 	void apply();
 	void cancel();

--- a/qCC/ccUnrollDlg.h
+++ b/qCC/ccUnrollDlg.h
@@ -47,7 +47,7 @@ public:
 	void toPersistentSettings() const;
 	void fromPersistentSettings();
 
-protected slots:
+protected:
 	void shapeTypeChanged(int index);
 	void axisDimensionChanged(int index);
 	void axisAutoStateChanged(int checkState);

--- a/qCC/ccVolumeCalcTool.h
+++ b/qCC/ccVolumeCalcTool.h
@@ -98,7 +98,7 @@ public:
 												bool exportToOriginalCS);
 
 	
-	protected slots:
+	protected:
 
 	//! Accepts the dialog and save settings
 	void saveSettingsAndAccept();

--- a/qCC/ccWaveformDialog.h
+++ b/qCC/ccWaveformDialog.h
@@ -120,7 +120,7 @@ public:
 	//inherited from ccPickingListener
 	virtual void onItemPicked(const PickedItem& pi) override;
 
-protected slots:
+protected:
 
 	void onPointIndexChanged(int);
 	void updateCurrentWaveform();

--- a/qCC/db_tree/matrixDisplayDlg.h
+++ b/qCC/db_tree/matrixDisplayDlg.h
@@ -48,7 +48,7 @@ public:
 	//! Updates dialog with a given (double) matrix
 	void fillDialogWith(const ccGLMatrixd& mat);
 
-public slots:
+public:
 
 	//! Exports current matrix to an ASCII file
 	/** Will display a file selection dialog!

--- a/qCC/db_tree/sfEditDlg.h
+++ b/qCC/db_tree/sfEditDlg.h
@@ -44,7 +44,7 @@ public:
 	//! Updates dialog with a given scalar field
 	void fillDialogWith(ccScalarField* sf);
 
-public slots:
+public:
 
 	void minValSBChanged(double);
 	void maxValSBChanged(double);

--- a/qCC/devices/gamepad/GamepadInput.h
+++ b/qCC/devices/gamepad/GamepadInput.h
@@ -52,7 +52,7 @@ signals:
 
 	void updated();
 
-protected slots:
+protected:
 
 	void updateInternalState();
 

--- a/qCC/mainwindow.h
+++ b/qCC/mainwindow.h
@@ -168,7 +168,7 @@ public:
 	//! Updates the 'Properties' view
 	void updatePropertiesView();
 	
-private slots:
+private:
 	//! Creates a new 3D GL sub-window
 	ccGLWindow* new3DView( bool allowEntitySelection );
 


### PR DESCRIPTION
It's a lot of changed files, but the changes are straightforward:

- convert old-style connects to Qt5-style
- remove old "slot" keyword from headers
- I needed to rename one method in **qM3C2Dialog** to disambiguate ("loadParamsFromFile()" -> "getParamsFromFile()")