### PR TITLE
Make histogram "fill" look smoother

### DIFF
--- a/qCC/ccHistogramWindow.cpp
+++ b/qCC/ccHistogramWindow.cpp
@@ -72,6 +72,7 @@ ccHistogramWindow::ccHistogramWindow(QWidget* parent/*=0*/)
 	setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
 
 	setAutoAddPlottableToLegend(false);
+	setAntialiasedElements(QCP::AntialiasedElement::aeAll);
 
 	//default font for text rendering
 	m_renderingFont.setFamily(QString::fromUtf8("Arial"));
@@ -412,10 +413,13 @@ void ccHistogramWindow::refresh()
 	if (histoSize > 0)
 	{
 		m_histogram = new QCPColoredBars(xAxis, yAxis);
-		addPlottable(m_histogram);
-		// now we can modify properties of myBars:
+
 		m_histogram->setWidth((m_maxVal - m_minVal) / histoSize);
+		m_histogram->setAntialiased(false);
 		m_histogram->setAntialiasedFill(false);
+		
+		addPlottable(m_histogram);
+		
 		QVector<double> keyData(histoSize);
 		QVector<double> valueData(histoSize);
 

--- a/qCC/ccHistogramWindow.h
+++ b/qCC/ccHistogramWindow.h
@@ -23,7 +23,6 @@
 
 //Qt
 #include <QDialog>
-#include <QFont>
 
 //qCC_db
 #include <ccScalarField.h>


### PR DESCRIPTION
Also removes unnecessary include in header.

Before:
<img width="912" alt="Screen Shot 2020-04-07 at 11 25 36 AM" src="https://user-images.githubusercontent.com/391371/78688397-39afcd80-78c3-11ea-9e02-0dffee779734.png">

After:
<img width="912" alt="Screen Shot 2020-04-07 at 11 17 26 AM" src="https://user-images.githubusercontent.com/391371/78688422-3f0d1800-78c3-11ea-8e22-0df76fa725e9.png">
