### PR TITLE
Add finer-grained control over the SF interaction mode in ccHistogramWindow

### DIFF
--- a/qCC/ccColorFromScalarDlg.cpp
+++ b/qCC/ccColorFromScalarDlg.cpp
@@ -298,7 +298,7 @@ void ccColorFromScalarDlg::updateHistogram(int n)
 
 		//and make histogram grey
 		m_histograms[n]->clear();
-		m_histograms[n]->enableSFInteractionMode(false); //disable interactivity
+		m_histograms[n]->setSFInteractionMode(ccHistogramWindow::SFInteractionMode::None); //disable interactivity
 		m_histograms[n]->refresh();
 		m_histograms[n]->setAxisLabels("", "");
 		m_histograms[n]->yAxis->setVisible(false); //disable y-axis
@@ -317,7 +317,7 @@ void ccColorFromScalarDlg::updateHistogram(int n)
 		//clear and build histogram
 		m_histograms[n]->clear();
 		m_histograms[n]->fromSF(m_scalars[n], 255, false, true);
-		m_histograms[n]->enableSFInteractionMode(true); //enable interactivity
+		m_histograms[n]->setSFInteractionMode(ccHistogramWindow::SFInteractionMode::SaturationRange); //disable interactivity
 		m_histograms[n]->refresh();
 
 		//hide axis (not sure why this code HAS to be here, but it does...)

--- a/qCC/ccHistogramWindow.h
+++ b/qCC/ccHistogramWindow.h
@@ -112,9 +112,16 @@ public:
 	inline double maxVal() const { return m_maxVal; }
 
 public: //SF interactor mode
-
+	enum SFInteractionMode {
+		None = 0x0,
+		DisplayRange = 0x01,
+		SaturationRange = 0x02,
+		All = DisplayRange | SaturationRange
+	};
+	Q_DECLARE_FLAGS(SFInteractionModes, SFInteractionMode)
+	
 	//! Enables SF interaction mode
-	void enableSFInteractionMode(bool state) { m_sfInteractionMode = state; }
+	void setSFInteractionMode( SFInteractionModes modes );
 
 	void setMinDispValue(double);
 	void setMaxDispValue(double);
@@ -194,8 +201,8 @@ protected: //attributes
 
 protected: //SF interactor mode
 
-	//! Whether SF interaction mode is enabled or not
-	bool m_sfInteractionMode;
+	//! Which SF interaction modes are enabled
+	SFInteractionModes m_sfInteractionModes;
 
 	//! Selectable items in "SF interaction" mode
 	enum SELECTABLE_ITEMS { NONE, LEFT_AREA, RIGHT_AREA, BOTH_AREAS, LEFT_ARROW, RIGHT_ARROW, BOTH_ARROWS };

--- a/qCC/db_tree/sfEditDlg.cpp
+++ b/qCC/db_tree/sfEditDlg.cpp
@@ -47,7 +47,7 @@ sfEditDlg::sfEditDlg(QWidget* parent/*=0*/)
 		QHBoxLayout* hboxLayout = new QHBoxLayout(histoFrame);
 		hboxLayout->addWidget(m_associatedSFHisto);
 		hboxLayout->setContentsMargins(0, 0, 0, 0);
-		m_associatedSFHisto->enableSFInteractionMode(true);
+		m_associatedSFHisto->setSFInteractionMode(ccHistogramWindow::SFInteractionMode::All);
 		m_associatedSFHisto->xAxis->setTickLabels(false);
 		//m_associatedSFHisto->xAxis->setAutoSubTicks(false);
 		//m_associatedSFHisto->xAxis->setSubTickCount(0);


### PR DESCRIPTION
Sam wanted a way to turn off the tools for adjusting the min/max display on the histogram, but allowing interaction with the saturation tools.

This adds flags to let you enable one, both, or none of the interactions.

It also turns off the min/max display for ccColorFromScalarDlg as requested.