### PR TITLE
Use Ui class as member instead of inheriting

### DIFF
--- a/plugins/core/Standard/qHoughNormals/qHoughNormals.cpp
+++ b/plugins/core/Standard/qHoughNormals/qHoughNormals.cpp
@@ -25,11 +25,12 @@
 #include <ccPointCloud.h>
 
 //Qt
+#include <QCoreApplication>
 #include <QMainWindow>
 #include <QProgressDialog>
 
 //system
-#include <assert.h>
+#include <cassert>
 
 qHoughNormals::qHoughNormals(QObject* parent)
 	: QObject(parent)

--- a/plugins/core/Standard/qHoughNormals/src/CMakeLists.txt
+++ b/plugins/core/Standard/qHoughNormals/src/CMakeLists.txt
@@ -1,6 +1,14 @@
 
 set( CC_PLUGIN_CUSTOM_HEADER_LIST
 	${CC_PLUGIN_CUSTOM_HEADER_LIST} 
+	${CMAKE_CURRENT_SOURCE_DIR}/nanoflann/include/nanoflann.hpp
+	${CMAKE_CURRENT_SOURCE_DIR}/normals_Hough/Normals.h # their cmake file does not add it
 	${CMAKE_CURRENT_SOURCE_DIR}/qHoughNormalsDialog.h
+	PARENT_SCOPE
+)
+
+set( CC_PLUGIN_CUSTOM_SOURCE_LIST
+	${CC_PLUGIN_CUSTOM_SOURCE_LIST} 
+	${CMAKE_CURRENT_SOURCE_DIR}/qHoughNormalsDialog.cpp
 	PARENT_SCOPE
 )

--- a/plugins/core/Standard/qHoughNormals/src/qHoughNormalsDialog.cpp
+++ b/plugins/core/Standard/qHoughNormals/src/qHoughNormalsDialog.cpp
@@ -1,6 +1,6 @@
 //##########################################################################
 //#                                                                        #
-//#                       CLOUDCOMPARE PLUGIN: qHPR                        #
+//#                       CLOUDCOMPARE PLUGIN: qHoughNormals               #
 //#                                                                        #
 //#  This program is free software; you can redistribute it and/or modify  #
 //#  it under the terms of the GNU General Public License as published by  #

--- a/plugins/core/Standard/qHoughNormals/src/qHoughNormalsDialog.cpp
+++ b/plugins/core/Standard/qHoughNormals/src/qHoughNormalsDialog.cpp
@@ -1,0 +1,60 @@
+//##########################################################################
+//#                                                                        #
+//#                       CLOUDCOMPARE PLUGIN: qHPR                        #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 or later of the License.      #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#                  COPYRIGHT: Daniel Girardeau-Montaut                   #
+//#                                                                        #
+//##########################################################################
+
+#include "qHoughNormalsDialog.h"
+#include "ui_qHoughNormalsDlg.h"
+
+#include <cmath>
+
+namespace {
+    constexpr double RadiansToDegrees = 180.0 / M_PI;
+    constexpr double DegreesToRadians = M_PI / 180.0;
+}
+
+qHoughNormalsDialog::qHoughNormalsDialog(QWidget *parent)
+    : QDialog(parent)
+    , m_ui( new Ui::HoughNormalsDialog )
+{
+    m_ui->setupUi(this);
+}
+
+qHoughNormalsDialog::~qHoughNormalsDialog()
+{
+    delete m_ui;
+}
+
+void qHoughNormalsDialog::setParameters( const Parameters &params )
+{
+	m_ui->kSpinBox->setValue(params.K);
+	m_ui->tSpinBox->setValue(params.T);
+	m_ui->nPhiSpinBox->setValue(params.n_phi);
+	m_ui->nRotSpinBox->setValue(params.n_rot);
+	m_ui->tolAngleSpinBox->setValue(params.tol_angle_rad * RadiansToDegrees);
+	m_ui->kDensitySpinBox->setValue(params.k_density);
+	m_ui->useDensityCheckBox->setChecked(params.use_density);
+}
+
+void qHoughNormalsDialog::getParameters( Parameters &params )
+{
+	params.K = m_ui->kSpinBox->value();
+	params.T = m_ui->tSpinBox->value();
+	params.n_phi = m_ui->nPhiSpinBox->value();
+	params.n_rot = m_ui->nRotSpinBox->value();
+	params.tol_angle_rad = m_ui->tolAngleSpinBox->value() * DegreesToRadians;
+	params.k_density = m_ui->kDensitySpinBox->value();
+	params.use_density = m_ui->useDensityCheckBox->isChecked();
+}

--- a/plugins/core/Standard/qHoughNormals/src/qHoughNormalsDialog.cpp
+++ b/plugins/core/Standard/qHoughNormals/src/qHoughNormalsDialog.cpp
@@ -23,20 +23,20 @@ namespace {
 		constexpr double M_PI = 3.14159265358979323846264338327950288;
 	#endif	
 	
-    constexpr double RadiansToDegrees = 180.0 / M_PI;
-    constexpr double DegreesToRadians = M_PI / 180.0;
+	constexpr double RadiansToDegrees = 180.0 / M_PI;
+	constexpr double DegreesToRadians = M_PI / 180.0;
 }
 
 qHoughNormalsDialog::qHoughNormalsDialog(QWidget *parent)
-    : QDialog(parent)
-    , m_ui( new Ui::HoughNormalsDialog )
+	: QDialog(parent)
+	, m_ui( new Ui::HoughNormalsDialog )
 {
-    m_ui->setupUi(this);
+	m_ui->setupUi(this);
 }
 
 qHoughNormalsDialog::~qHoughNormalsDialog()
 {
-    delete m_ui;
+	delete m_ui;
 }
 
 void qHoughNormalsDialog::setParameters( const Parameters &params )

--- a/plugins/core/Standard/qHoughNormals/src/qHoughNormalsDialog.cpp
+++ b/plugins/core/Standard/qHoughNormals/src/qHoughNormalsDialog.cpp
@@ -18,9 +18,11 @@
 #include "qHoughNormalsDialog.h"
 #include "ui_qHoughNormalsDlg.h"
 
-#include <cmath>
-
 namespace {
+	#ifndef M_PI
+		constexpr double M_PI = 3.14159265358979323846264338327950288;
+	#endif	
+	
     constexpr double RadiansToDegrees = 180.0 / M_PI;
     constexpr double DegreesToRadians = M_PI / 180.0;
 }

--- a/plugins/core/Standard/qHoughNormals/src/qHoughNormalsDialog.h
+++ b/plugins/core/Standard/qHoughNormals/src/qHoughNormalsDialog.h
@@ -1,6 +1,6 @@
 //##########################################################################
 //#                                                                        #
-//#                       CLOUDCOMPARE PLUGIN: qHPR                        #
+//#                       CLOUDCOMPARE PLUGIN: qHoughNormals               #
 //#                                                                        #
 //#  This program is free software; you can redistribute it and/or modify  #
 //#  it under the terms of the GNU General Public License as published by  #

--- a/plugins/core/Standard/qHoughNormals/src/qHoughNormalsDialog.h
+++ b/plugins/core/Standard/qHoughNormals/src/qHoughNormalsDialog.h
@@ -18,25 +18,20 @@
 #ifndef QHOUGH_NORMALS_HEADER
 #define QHOUGH_NORMALS_HEADER
 
-#include "ui_qHoughNormalsDlg.h"
-
-//Qt
 #include <QDialog>
 
-//System
-#include <cmath>
+namespace Ui {
+	class HoughNormalsDialog;
+}
 
-//! Dialog for Hough Normals dialog
-class qHoughNormalsDialog : public QDialog, public Ui::HoughNormalsDialog
+class qHoughNormalsDialog : public QDialog
 {
 public:
 
 	//! Default constructor
-	explicit qHoughNormalsDialog(QWidget* parent = 0)
-		: QDialog(parent)
-	{
-		setupUi(this);
-	}
+	explicit qHoughNormalsDialog( QWidget* parent = nullptr );
+	
+	~qHoughNormalsDialog();
 
 	//Settings
 	struct Parameters
@@ -50,27 +45,11 @@ public:
 		int k_density = 5;
 	};
 	
-	void setParameters(const Parameters& params)
-	{
-		kSpinBox->setValue(params.K);
-		tSpinBox->setValue(params.T);
-		nPhiSpinBox->setValue(params.n_phi);
-		nRotSpinBox->setValue(params.n_rot);
-		tolAngleSpinBox->setValue(params.tol_angle_rad * 180.0 / M_PI);
-		kDensitySpinBox->setValue(params.k_density);
-		useDensityCheckBox->setChecked(params.use_density);
-	}
-
-	void getParameters(Parameters& params)
-	{
-		params.K = kSpinBox->value();
-		params.T = tSpinBox->value();
-		params.n_phi = nPhiSpinBox->value();
-		params.n_rot = nRotSpinBox->value();
-		params.tol_angle_rad = tolAngleSpinBox->value() * M_PI / 180.0;
-		params.k_density = kDensitySpinBox->value();
-		params.use_density = useDensityCheckBox->isChecked();
-	}
+	void setParameters( const Parameters& params );
+	void getParameters( Parameters& params );
+	
+private:
+	Ui::HoughNormalsDialog* m_ui;
 };
 
 #endif //QHOUGH_NORMALS_HEADER


### PR DESCRIPTION
This meant moving the dialog code out of the header into a new cpp file.

Also added nanoflann and Hough normals headers to the header list in CMake so they are included in dependencies.