### PR TITLE
Colour from Scalar bugfixes

### DIFF
--- a/qCC/ccColorFromScalarDlg.cpp
+++ b/qCC/ccColorFromScalarDlg.cpp
@@ -169,11 +169,15 @@ ccColorFromScalarDlg::ccColorFromScalarDlg(QWidget* parent, ccPointCloud* pointC
 
 				updateColormaps();
 				
+				//initialise histograms
 				m_prevFixed[c_channelCount - 1] = false;
-				for (unsigned i = 0; i < c_channelCount; i++)
+				updateChannel(0); //init first histogram
+				for (unsigned i = 1; i < c_channelCount; i++) //copy data from this histogram into the next ones
 				{
 					m_scalars[i] = sf;
-					updateChannel(i);
+					setDefaultSatValuePerChannel(i);
+					m_histograms[i]->fromBinArray(m_histograms[0]->histoValues(), m_histograms[0]->minVal(), m_histograms[0]->maxVal());
+					updateHistogram(i);
 				}	
 				
 				sf->setColorScale(m_colors[c_channelCount - 1]); //set grey colour ramp to start with
@@ -450,7 +454,6 @@ void ccColorFromScalarDlg::updateChannel(int n)
 		if (sf)
 		{
 			m_scalars[n] = sf;
-			sf->computeMinAndMax();
 			setDefaultSatValuePerChannel(n);
 			m_histograms[n]->clear(); //clear last histogram
 			m_histograms[n]->fromSF(m_scalars[n], 255, false, true); //generate new one

--- a/qCC/ccColorFromScalarDlg.cpp
+++ b/qCC/ccColorFromScalarDlg.cpp
@@ -582,7 +582,7 @@ void ccColorFromScalarDlg::onApply()
 						col[i] = 255 - col[i];
 					}
 				}
-				m_cloud->setPointColor(p, ccColor::FromQColor(QColor(col[0], col[1], col[2], col[3])));
+				m_cloud->setPointColor(p, ccColor::FromQColora(QColor(col[0], col[1], col[2], col[3])));
 			}
 		}
 		else //map scalar values to HSV (and then to RGB)

--- a/qCC/ccColorFromScalarDlg.h
+++ b/qCC/ccColorFromScalarDlg.h
@@ -44,7 +44,7 @@ public:
 	~ccColorFromScalarDlg();
 
 	static constexpr int c_channelCount = 4;
-	void setupDisplay();
+	void refreshDisplay();
 	//update and redraw histograms
 	void updateHistogram(int);
 


### PR DESCRIPTION
Fixed the following bugs:

(1) Histograms not refreshing/recalculating when scalar field was changed,
(2) Histograms being recalculated more than needed.
(3) Slider positions resetting every time settings (e.g. reversed) changed on any histogram.