### PR TITLE
Fix license on 3 CCLib files

### DIFF
--- a/CC/include/Jacobi.h
+++ b/CC/include/Jacobi.h
@@ -1,10 +1,11 @@
 //##########################################################################
 //#                                                                        #
-//#                              CLOUDCOMPARE                              #
+//#                               CCLIB                                    #
 //#                                                                        #
 //#  This program is free software; you can redistribute it and/or modify  #
-//#  it under the terms of the GNU General Public License as published by  #
-//#  the Free Software Foundation; version 2 or later of the License.      #
+//#  it under the terms of the GNU Library General Public License as       #
+//#  published by the Free Software Foundation; version 2 or later of the  #
+//#  License.                                                              #
 //#                                                                        #
 //#  This program is distributed in the hope that it will be useful,       #
 //#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #

--- a/CC/include/SaitoSquaredDistanceTransform.h
+++ b/CC/include/SaitoSquaredDistanceTransform.h
@@ -1,10 +1,11 @@
 //##########################################################################
 //#                                                                        #
-//#                              CLOUDCOMPARE                              #
+//#                               CCLIB                                    #
 //#                                                                        #
 //#  This program is free software; you can redistribute it and/or modify  #
-//#  it under the terms of the GNU General Public License as published by  #
-//#  the Free Software Foundation; version 2 or later of the License.      #
+//#  it under the terms of the GNU Library General Public License as       #
+//#  published by the Free Software Foundation; version 2 or later of the  #
+//#  License.                                                              #
 //#                                                                        #
 //#  This program is distributed in the hope that it will be useful,       #
 //#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #

--- a/CC/src/SaitoSquaredDistanceTransform.cpp
+++ b/CC/src/SaitoSquaredDistanceTransform.cpp
@@ -1,10 +1,11 @@
 //##########################################################################
 //#                                                                        #
-//#                              CLOUDCOMPARE                              #
+//#                               CCLIB                                    #
 //#                                                                        #
 //#  This program is free software; you can redistribute it and/or modify  #
-//#  it under the terms of the GNU General Public License as published by  #
-//#  the Free Software Foundation; version 2 or later of the License.      #
+//#  it under the terms of the GNU Library General Public License as       #
+//#  published by the Free Software Foundation; version 2 or later of the  #
+//#  License.                                                              #
 //#                                                                        #
 //#  This program is distributed in the hope that it will be useful,       #
 //#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #


### PR DESCRIPTION
These were mistakenly added to CCLib as GPL rather than LGPL.

As they are copyright by the CC project, and only Andy and Daniel have modified them, we are choosing to relicense them as LGPL.

[skip ci]