### PR TITLE
{cmake} Remove policy CMP0020 (linking Qt::WinMain)

### DIFF
--- a/ccViewer/CMakeLists.txt
+++ b/ccViewer/CMakeLists.txt
@@ -49,11 +49,6 @@ target_link_libraries( ${PROJECT_NAME}
     Qt5::Widgets
 )
 
-# FIXME This will go away soon - see policy CMP0020
-if ( WIN32 )
-	target_link_libraries( ${PROJECT_NAME} Qt5::WinMain )
-endif()
-
 # contrib. libraries support
 if ( APPLE )
 	target_link_contrib( ${PROJECT_NAME} ${CLOUDCOMPARE_MAC_FRAMEWORK_DIR} )

--- a/cmake/CMakePolicies.cmake
+++ b/cmake/CMakePolicies.cmake
@@ -1,7 +1,5 @@
 # Eliminate warnings with newer versions of CMake
 if ( WIN32 )
-	# https://cmake.org/cmake/help/v3.0/policy/CMP0020.html
-    cmake_policy(SET CMP0020 NEW)
 	# https://cmake.org/cmake/help/v3.0/policy/CMP0071.html
 	cmake_policy(SET CMP0071 NEW)
 endif()

--- a/libs/qCC_db/CMakeLists.txt
+++ b/libs/qCC_db/CMakeLists.txt
@@ -8,7 +8,6 @@ add_subdirectory( src )
 target_link_libraries( ${PROJECT_NAME}
     CCCoreLib
     CC_FBO_LIB
-    Qt5::OpenGL
     Qt5::Widgets
 )
 

--- a/libs/qCC_io/test/CMakeLists.txt
+++ b/libs/qCC_io/test/CMakeLists.txt
@@ -19,11 +19,6 @@ if ( OPTION_USE_SHAPE_LIB )
         set_target_properties( TestShpFilter PROPERTIES
             WIN32_EXECUTABLE False
         )
-
-        # FIXME This will go away soon - see policy CMP0020
-        target_link_libraries( TestShpFilter
-            Qt5::WinMain
-        )
     endif()
 
     add_test( NAME TestShpFilter COMMAND TestShpFilter )

--- a/qCC/CMakeLists.txt
+++ b/qCC/CMakeLists.txt
@@ -57,11 +57,6 @@ target_link_libraries( ${PROJECT_NAME}
     Qt5::Widgets
 )
 
-# FIXME This will go away soon - see policy CMP0020
-if (WIN32)
-	target_link_libraries( ${PROJECT_NAME} Qt5::WinMain )
-endif()
-
 # contrib. libraries support
 if( APPLE )
 	target_link_contrib( ${PROJECT_NAME} ${CLOUDCOMPARE_MAC_FRAMEWORK_DIR} )


### PR DESCRIPTION
Linking to Qt::WinMain explcitly isn't required when using CMake >= 3.0

https://cmake.org/cmake/help/v3.10/policy/CMP0020.html