### PR TITLE
Graphical Segmentation tool causes visibility issues

### DIFF
--- a/libs/qCC_db/include/ccColorTypes.h
+++ b/libs/qCC_db/include/ccColorTypes.h
@@ -247,7 +247,7 @@ namespace ccColor
 	//! Conversion from Rgb to Rgba
 	inline Rgba FromRgbToRgba(const Rgb& color)
 	{
-		return Rgba(color.r, color.g, color.b, MAX);
+		return Rgba(color, MAX);
 	}
 
 	//! Conversion from Rgbaf to Rgba

--- a/libs/qCC_db/include/ccColorTypes.h
+++ b/libs/qCC_db/include/ccColorTypes.h
@@ -244,6 +244,12 @@ namespace ccColor
 					static_cast<ColorCompType>(color.b * MAX) );
 	}
 	
+	//! Conversion from Rgb to Rgba
+	inline Rgba FromRgbToRgba(const Rgb& color)
+	{
+		return Rgba(color.r, color.g, color.b, MAX);
+	}
+
 	//! Conversion from Rgbaf to Rgba
 	inline Rgba FromRgbafToRgba(const Rgbaf& color)
 	{

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -2736,7 +2736,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 							const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
 							//we force display of points hidden because of their scalar field value
 							//to be sure that the user doesn't miss them (during manual segmentation for instance)
-							glFunc->glColor4ubv(col ? col->rgb : ccColor::lightGreyRGB.rgb);
+							glFunc->glColor4ubv(col ? ccColor::FromRgbToRgba(*col).rgba : ccColor::lightGrey.rgba);
 						}
 						else if (glParams.showColors)
 						{

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -2736,7 +2736,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 							const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
 							//we force display of points hidden because of their scalar field value
 							//to be sure that the user doesn't miss them (during manual segmentation for instance)
-							glFunc->glColor4ubv(col ? ccColor::FromRgbToRgba(*col).rgba : ccColor::lightGrey.rgba);
+							glFunc->glColor3ubv(col ? col->rgb : ccColor::lightGreyRGB.rgb); //Make sure all points are visible. No alpha used on purpose 
 						}
 						else if (glParams.showColors)
 						{


### PR DESCRIPTION

Fixed points disappearing during graphical segmentation that was caused by passing RGB values to OpenGL functions expecting RGBA

See an example of the issue below
![image](https://user-images.githubusercontent.com/7495752/80140502-e3968780-855c-11ea-86e6-fca0813ebedd.png)

![image](https://user-images.githubusercontent.com/7495752/80140534-f01ae000-855c-11ea-86e2-748ab230ecc0.png)

