### PR TITLE
{cmake} Turn off AUTOGEN when not needed

### DIFF
--- a/extern/dxflib/CMakeLists.txt
+++ b/extern/dxflib/CMakeLists.txt
@@ -5,6 +5,12 @@ project( dxflib )
 
 add_library( ${PROJECT_NAME} STATIC )
 
+set_target_properties( ${PROJECT_NAME} PROPERTIES
+    AUTOMOC OFF
+    AUTORCC OFF
+    AUTOUIC OFF
+)
+
 add_subdirectory( src )
 
 if (WIN32)

--- a/extern/shapelib/CMakeLists.txt
+++ b/extern/shapelib/CMakeLists.txt
@@ -5,6 +5,12 @@ project( shapelib )
 
 add_library( ${PROJECT_NAME} STATIC )
 
+set_target_properties( ${PROJECT_NAME} PROPERTIES
+    AUTOMOC OFF
+    AUTORCC OFF
+    AUTOUIC OFF
+)
+
 target_sources( ${PROJECT_NAME}
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/shptree.c

--- a/plugins/core/IO/qE57IO/CMakeLists.txt
+++ b/plugins/core/IO/qE57IO/CMakeLists.txt
@@ -13,6 +13,12 @@ if ( PLUGIN_IO_QE57 )
 
 	add_subdirectory( src )
 	add_subdirectory( extern/libE57Format EXCLUDE_FROM_ALL )
+    
+    set_target_properties( E57Format PROPERTIES
+        AUTOMOC OFF
+        AUTORCC OFF
+        AUTOUIC OFF
+    )
 	
     include( CMakePluginTemplate )
 	

--- a/plugins/core/Standard/qAnimation/src/QTFFmpegWrapper/CMakeLists.txt
+++ b/plugins/core/Standard/qAnimation/src/QTFFmpegWrapper/CMakeLists.txt
@@ -7,6 +7,12 @@ file( GLOB source_list *.cpp )
 
 add_library( ${PROJECT_NAME} STATIC ${header_list} ${source_list} )
 
+set_target_properties( ${PROJECT_NAME} PROPERTIES
+    AUTOMOC OFF
+    AUTORCC OFF
+    AUTOUIC OFF
+)
+
 target_link_libraries( ${PROJECT_NAME}
     Qt5::Gui
 )

--- a/plugins/core/Standard/qPCV/PCV/CMakeLists.txt
+++ b/plugins/core/Standard/qPCV/PCV/CMakeLists.txt
@@ -7,6 +7,12 @@ file( GLOB source_list *.cpp )
 
 add_library( ${PROJECT_NAME} STATIC ${header_list} ${source_list} )
 
+set_target_properties( ${PROJECT_NAME} PROPERTIES
+    AUTOMOC OFF
+    AUTORCC OFF
+    AUTOUIC OFF
+)
+
 target_link_libraries( ${PROJECT_NAME}
     CCCoreLib
     Qt5::Gui


### PR DESCRIPTION
No need to run the auto* tools and this prevents link warnings.