### PR TITLE
{ci} Cache conda environment on Windows

### DIFF
--- a/.ci/conda.yml
+++ b/.ci/conda.yml
@@ -1,0 +1,11 @@
+name: CloudCompareDev
+channels:
+  - conda-forge
+dependencies:
+  - eigen=3.3.* `
+  - ninja `
+  - pcl=1.9.*
+  - pdal=2.0.* `
+  - qt=5.12.* `
+  - xerces-c=3.2.* `
+  - zlib=1.2.* `

--- a/.ci/conda.yml
+++ b/.ci/conda.yml
@@ -2,8 +2,8 @@ name: CloudCompareDev
 channels:
   - conda-forge
 dependencies:
-  - eigen=3.3.*
   - ninja
+  - eigen=3.3.*
   - pcl=1.9.*
   - pdal=2.1.*
   - qt=5.12.*

--- a/.ci/conda.yml
+++ b/.ci/conda.yml
@@ -5,7 +5,7 @@ dependencies:
   - eigen=3.3.*
   - ninja
   - pcl=1.9.*
-  - pdal=2.0.*
+  - pdal=2.1.*
   - qt=5.12.*
   - xerces-c=3.2.*
   - zlib=1.2.*

--- a/.ci/conda.yml
+++ b/.ci/conda.yml
@@ -4,8 +4,8 @@ channels:
 dependencies:
   - eigen=3.3.* `
   - ninja `
-  - pcl=1.9.*
+  - pcl=1.9.* `
   - pdal=2.0.* `
   - qt=5.12.* `
   - xerces-c=3.2.* `
-  - zlib=1.2.* `
+  - zlib=1.2.*

--- a/.ci/conda.yml
+++ b/.ci/conda.yml
@@ -2,10 +2,10 @@ name: CloudCompareDev
 channels:
   - conda-forge
 dependencies:
-  - eigen=3.3.* `
-  - ninja `
-  - pcl=1.9.* `
-  - pdal=2.0.* `
-  - qt=5.12.* `
-  - xerces-c=3.2.* `
+  - eigen=3.3.*
+  - ninja
+  - pcl=1.9.*
+  - pdal=2.0.*
+  - qt=5.12.*
+  - xerces-c=3.2.*
   - zlib=1.2.*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Conda Cache
         uses: actions/cache@v1
         with:
-          path: C:\Miniconda3\envs\CCCoreLib
+          path: C:\Miniconda3\envs\CloudCompareDev
           key: conda-cache-${{ runner.os }}-${{ hashFiles('.ci/conda.yml') }}
 
       - name: Install Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         scalar_double: ["OFF"]
         config:
           - {
-              name: "Windows Latest MSVC",
+              name: "Windows MSVC",
               os: windows-latest,
               generator: "Ninja",
               conda_library_dir: "Library",
@@ -25,7 +25,7 @@ jobs:
               xercesclib_name: xerces-c_3.lib,
            }
           - {
-              name: "macOS Latest Clang",
+              name: "macOS Clang",
               os: macos-latest,
               generator: "Ninja",
               conda_library_dir: ".",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,15 @@ jobs:
         with:
           submodules: true
 
-      - name: Conda Cache
+      - name: Conda Cache (macOS)
+        if:  matrix.config.os == 'macos-latest'
+        uses: actions/cache@v1
+        with:
+          path: /Users/runner/miniconda3/envs/CloudCompareDev
+          key: conda-cache-${{ runner.os }}-${{ hashFiles('.ci/conda.yml') }}
+
+      - name: Conda Cache (Windows)
+        if:  matrix.config.os == 'windows-latest'
         uses: actions/cache@v1
         with:
           path: C:\Miniconda3\envs\CloudCompareDev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,26 +41,19 @@ jobs:
         with:
           submodules: true
 
-      - uses: goanpeca/setup-miniconda@v1
+      - name: Conda Cache
+        uses: actions/cache@v1
         with:
+          path: C:\Miniconda3\envs\CCCoreLib
+          key: conda-cache-${{ runner.os }}-${{ hashFiles('.ci/conda.yml') }}
+
+      - name: Install Dependencies
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          activate-environment: CloudCompareDev
+          auto-activate-base: false
+          environment-file: .ci/conda.yml
           miniconda-version: 'latest'
-          activate-environment: ccenv
-          auto-update-conda: true
-
-      - name: Install dependencies
-        shell: pwsh
-        run: conda install -y -c conda-forge `
-          qt=5.12.* `
-          pdal=2.0.* `
-          xerces-c=3.2.* `
-          zlib=1.2.* `
-          eigen=3.3.* `
-          ninja `
-          pcl=1.9.*
-
-      - name: Install Dependencies (macOS)
-        if: matrix.config.os == 'macos-latest'
-        run: brew install xerces-c
 
       - name: Configure MSVC console (Windows)
         if:  matrix.config.os == 'windows-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,10 @@ jobs:
           environment-file: .ci/conda.yml
           miniconda-version: 'latest'
 
+      - name: Install Dependencies (macOS)
+        if: matrix.config.os == 'macos-latest'
+        run: brew install xerces-c
+
       - name: Configure MSVC console (Windows)
         if:  matrix.config.os == 'windows-latest'
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,12 +41,13 @@ jobs:
         with:
           submodules: true
 
-      - name: Conda Cache (macOS)
-        if:  matrix.config.os == 'macos-latest'
-        uses: actions/cache@v1
-        with:
-          path: /Users/runner/miniconda3/envs/CloudCompareDev
-          key: conda-cache-${{ runner.os }}-${{ hashFiles('.ci/conda.yml') }}
+      # Turn off for now since GitHub Actions is broken (will eventually move to brew anyways) 
+      # - name: Conda Cache (macOS)
+      #   if:  matrix.config.os == 'macos-latest'
+      #   uses: actions/cache@v1
+      #   with:
+      #     path: /Users/runner/miniconda3/envs/CloudCompareDev
+      #     key: conda-cache-${{ runner.os }}-${{ hashFiles('.ci/conda.yml') }}
 
       - name: Conda Cache (Windows)
         if:  matrix.config.os == 'windows-latest'


### PR DESCRIPTION
Only saves 2-3 minutes per run, but since GitHub Actions fails a lot, this will add up.