### PR TITLE
{cmake} Make sure extern libs do not install themselves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ include( CMakeInclude )
 include( Install )
 
 # Add external libraries
-add_subdirectory( extern/CCCoreLib )
+add_subdirectory( extern/CCCoreLib EXCLUDE_FROM_ALL )
 include( CMakeExternalLibs )
 
 # Contrib. libraries (mainly for I/O)

--- a/plugins/core/IO/qE57IO/CMakeLists.txt
+++ b/plugins/core/IO/qE57IO/CMakeLists.txt
@@ -8,7 +8,7 @@ if ( PLUGIN_IO_QE57 )
 
 	add_subdirectory( include )
 	add_subdirectory( src )
-	add_subdirectory( extern/libE57Format )
+	add_subdirectory( extern/libE57Format EXCLUDE_FROM_ALL )
 	
 	set_target_properties( E57Format PROPERTIES
 		AUTOMOC OFF

--- a/plugins/core/IO/qPhotoscanIO/CMakeLists.txt
+++ b/plugins/core/IO/qPhotoscanIO/CMakeLists.txt
@@ -8,7 +8,7 @@ if( PLUGIN_IO_QPHOTOSCAN )
 	add_subdirectory( include )
 	add_subdirectory( src )
 
-	add_subdirectory( extern/quazip )
+	add_subdirectory( extern/quazip EXCLUDE_FROM_ALL )
 	
 	target_link_libraries( ${PROJECT_NAME} quazip )
 	

--- a/plugins/core/Standard/qAnimation/CMakeLists.txt
+++ b/plugins/core/Standard/qAnimation/CMakeLists.txt
@@ -12,7 +12,7 @@ if( PLUGIN_STANDARD_QANIMATION )
 	add_subdirectory( ui )
 
 	if( QANIMATION_WITH_FFMPEG_SUPPORT )
-		add_subdirectory( extern/QTFFmpegWrapper )
+		add_subdirectory( extern/QTFFmpegWrapper EXCLUDE_FROM_ALL )
 
 		target_link_libraries( ${PROJECT_NAME} QTFFMPEG_LIB )
 		target_compile_definitions( ${PROJECT_NAME} PRIVATE QFFMPEG_SUPPORT )

--- a/plugins/core/Standard/qHPR/CMakeLists.txt
+++ b/plugins/core/Standard/qHPR/CMakeLists.txt
@@ -5,7 +5,7 @@ if( PLUGIN_STANDARD_QHPR )
 		
 	AddPlugin( NAME ${PROJECT_NAME} )
 	
-	add_subdirectory( extern/qhull )
+	add_subdirectory( extern/qhull EXCLUDE_FROM_ALL )
 	add_subdirectory( include )
 	add_subdirectory( src )
 	add_subdirectory( ui )

--- a/plugins/core/Standard/qPoissonRecon/CMakeLists.txt
+++ b/plugins/core/Standard/qPoissonRecon/CMakeLists.txt
@@ -5,7 +5,7 @@ if( PLUGIN_STANDARD_QPOISSON_RECON )
 		
 	AddPlugin( NAME ${PROJECT_NAME} )
 
-	add_subdirectory( extern/PoissonRecon )
+	add_subdirectory( extern/PoissonRecon EXCLUDE_FROM_ALL )
 	add_subdirectory( include )
 	add_subdirectory( src )
 	add_subdirectory( ui )

--- a/plugins/core/Standard/qRANSAC_SD/CMakeLists.txt
+++ b/plugins/core/Standard/qRANSAC_SD/CMakeLists.txt
@@ -5,7 +5,7 @@ if( PLUGIN_STANDARD_QRANSAC_SD )
 
 	AddPlugin( NAME ${PROJECT_NAME} )
 
-	add_subdirectory( extern/RANSAC_SD )
+	add_subdirectory( extern/RANSAC_SD EXCLUDE_FROM_ALL )
 	add_subdirectory( include )
 	add_subdirectory( src )
 	add_subdirectory( ui )

--- a/qCC/CMakeLists.txt
+++ b/qCC/CMakeLists.txt
@@ -21,7 +21,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../common ${CMAKE_CURRENT_BINARY_DI
 add_subdirectory( db_tree )
 add_subdirectory( pluginManager )
 
-add_subdirectory( extern/QCustomPlot )
+add_subdirectory( extern/QCustomPlot EXCLUDE_FROM_ALL )
 
 # 3DX support (3dConnexion devices)
 if ( ${OPTION_SUPPORT_3DCONNEXION_DEVICES} )


### PR DESCRIPTION
Any project that has its own install target and is included via add_subdirectory needs to set EXCLUDE_FROM_ALL so it doesn't install itself as well.