### PR TITLE
Ensure plugins are recognized across library boundaries

### DIFF
--- a/libs/CCAppCommon/src/ccPluginManager.cpp
+++ b/libs/CCAppCommon/src/ccPluginManager.cpp
@@ -133,7 +133,7 @@ void ccPluginManager::loadPlugins()
 	
 	for ( QObject* plugin : pluginInstances )
 	{
-		ccPluginInterface* ccPlugin = dynamic_cast<ccPluginInterface*>(plugin);
+		ccPluginInterface* ccPlugin = qobject_cast<ccPluginInterface*>(plugin);
 		
 		if (ccPlugin == nullptr)
 		{
@@ -316,7 +316,7 @@ void ccPluginManager::loadFromPathsAndAddToList()
 			}
 			
 			QObject* plugin = loader->instance();
-			ccPluginInterface* ccPlugin = dynamic_cast<ccPluginInterface*>(plugin);
+			ccPluginInterface* ccPlugin = qobject_cast<ccPluginInterface*>(plugin);
 			
 			if ( (plugin == nullptr) || (ccPlugin == nullptr) )
 			{				
@@ -354,7 +354,7 @@ void ccPluginManager::loadFromPathsAndAddToList()
 			// If we have already loaded a plugin with this IID, unload it and replace the interface in the plugin list
 			if ( previousLoader != nullptr )
 			{
-				ccPluginInterface* pluginInterface = dynamic_cast<ccPluginInterface *>( previousLoader->instance() );
+				ccPluginInterface* pluginInterface = qobject_cast<ccPluginInterface *>( previousLoader->instance() );
 				
 				// maintain the order of the plugin list
 				const int index = m_pluginList.indexOf( pluginInterface );

--- a/libs/CCPluginStub/include/ccDefaultPluginInterface.h
+++ b/libs/CCPluginStub/include/ccDefaultPluginInterface.h
@@ -40,7 +40,14 @@ public:
 	ReferenceList getReferences() const override;
 	ContactList getAuthors() const override;
 	ContactList getMaintainers() const override;
-
+	
+	bool start() override { return true; }
+	void stop() override {}
+	
+	ccExternalFactory *getCustomObjectsFactory() const override { return nullptr; }
+	
+	void registerCommands(ccCommandLineInterface *cmd) override { Q_UNUSED( cmd ); }
+	
 protected:
 	ccDefaultPluginInterface( const QString &resourcePath = QString() );
 	

--- a/libs/CCPluginStub/include/ccPluginInterface.h
+++ b/libs/CCPluginStub/include/ccPluginInterface.h
@@ -46,7 +46,7 @@ class ccPluginInterface
 public:	
 	// Contact represents a person and is used for authors and maintainer lists
 	struct Contact
-   {
+	{
 		QString name;
 		QString email;
 	};
@@ -56,7 +56,7 @@ public:
 	// Reference represents a journal article or online post about the plugin where
 	// the user can find more information.
 	struct Reference
-   {
+	{
 		QString article;
 		QString	url;
 	};
@@ -82,38 +82,38 @@ public:
 	//! Returns icon
 	/** Should be reimplemented if necessary
 	**/
-	virtual QIcon getIcon() const { return QIcon(); }
+	virtual QIcon getIcon() const = 0;
 	
 	//! Returns a list of references (articles and websites) for the plugin
 	//! This is optional.
 	//! See qDummyPlugin for a real example.
 	//! Added in v3.1 of the plugin interface.
-	virtual ReferenceList getReferences() const { return ReferenceList{}; }
+	virtual ReferenceList getReferences() const = 0;
 	
 	//! Returns a list of the authors' names and email addresses
 	//! This is optional.
 	//! See qDummyPlugin for a real example.
 	//! Added in v3.1 of the plugin interface.
-	virtual ContactList getAuthors() const { return ContactList{}; }
+	virtual ContactList getAuthors() const = 0;
 	
 	//! Returns a list of the maintainers' names and email addresses
 	//! This is optional.
 	//! See qDummyPlugin for a real example.
 	//! Added in v3.1 of the plugin interface.
-	virtual ContactList getMaintainers() const { return ContactList{}; }
+	virtual ContactList getMaintainers() const = 0;
 	
 	//! Starts the plugin
 	/** Should be reimplemented if necessary.
 		Used when 'starting' a plugin from the command line
 		(to start a background service, a thread, etc.)
 	**/
-	virtual bool start() { return true; }
+	virtual bool start() = 0;
 
 	//! Stops the plugin
 	/** Should be reimplemented if necessary.
 		Used to stop a plugin previously started (see ccPluginInterface::start).
 	**/
-	virtual void stop() { }
+	virtual void stop() = 0;
 
 	//! Returns the plugin's custom object factory (if any)
 	/** Plugins may provide a factory to build custom objects.
@@ -121,14 +121,14 @@ public:
 		objects stream in BIN files. Custom objects must inherit the
 		ccCustomHObject or ccCustomLeafObject interfaces.
 	**/
-	virtual ccExternalFactory* getCustomObjectsFactory() const { return nullptr; }
+	virtual ccExternalFactory* getCustomObjectsFactory() const = 0;
 
 	//! Optional: registers commands (for the command line mode)
 	/** Does nothing by default.
 		\warning: don't use keywords that are already used by the main application or other plugins!
 			(use a unique prefix for all commands if possible)
 	**/
-	virtual void registerCommands(ccCommandLineInterface* cmd) { Q_UNUSED( cmd ); }
+	virtual void registerCommands(ccCommandLineInterface* cmd) = 0;
 	
 protected:	
 	friend class ccPluginManager;

--- a/plugins/core/GL/qEDL/include/qEDL.h
+++ b/plugins/core/GL/qEDL/include/qEDL.h
@@ -24,8 +24,9 @@
 class qEDL : public QObject, public ccGLPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(ccGLPluginInterface)
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qEDL" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccGLPluginInterface )
+	
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qEDL" FILE "../info.json" )
 
 public:
 	explicit qEDL( QObject *parent = nullptr );

--- a/plugins/core/GL/qSSAO/include/qSSAO.h
+++ b/plugins/core/GL/qSSAO/include/qSSAO.h
@@ -24,8 +24,9 @@
 class qSSAO : public QObject, public ccGLPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(ccGLPluginInterface)
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qSSAO" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccGLPluginInterface )
+	
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qSSAO" FILE "../info.json" )
 
 public:
 	explicit qSSAO(QObject* parent = nullptr);

--- a/plugins/core/IO/qAdditionalIO/include/qAdditionalIO.h
+++ b/plugins/core/IO/qAdditionalIO/include/qAdditionalIO.h
@@ -24,9 +24,9 @@
 class qAdditionalIO : public QObject, public ccIOPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(ccIOPluginInterface)
+	Q_INTERFACES( ccPluginInterface ccIOPluginInterface )
 
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qAdditionalIO" FILE "../info.json")
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qAdditionalIO" FILE "../info.json" )
 
 public:
 	explicit qAdditionalIO( QObject* parent = nullptr );

--- a/plugins/core/IO/qCSVMatrixIO/include/qCSVMatrixIO.h
+++ b/plugins/core/IO/qCSVMatrixIO/include/qCSVMatrixIO.h
@@ -24,8 +24,9 @@
 class qCSVMatrixIO : public QObject, public ccIOPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(ccIOPluginInterface)
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qCSVMatrixIO" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccIOPluginInterface )
+
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qCSVMatrixIO" FILE "../info.json" )
 
 public:
 	qCSVMatrixIO(QObject* parent = nullptr);

--- a/plugins/core/IO/qCoreIO/include/qCoreIO.h
+++ b/plugins/core/IO/qCoreIO/include/qCoreIO.h
@@ -23,9 +23,9 @@
 class qCoreIO : public QObject, public ccIOPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES( ccIOPluginInterface )
+	Q_INTERFACES( ccPluginInterface ccIOPluginInterface )
 
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qCoreIO" FILE "../info.json")
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qCoreIO" FILE "../info.json" )
 
 public:
 	explicit qCoreIO( QObject *parent = nullptr );

--- a/plugins/core/IO/qE57IO/include/qE57IO.h
+++ b/plugins/core/IO/qE57IO/include/qE57IO.h
@@ -23,7 +23,7 @@
 class qE57IO : public QObject, public ccIOPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES( ccIOPluginInterface )
+	Q_INTERFACES( ccPluginInterface ccIOPluginInterface )
 
 	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qE57IO" FILE "../info.json" )
 

--- a/plugins/core/IO/qFBXIO/include/qFBXIO.h
+++ b/plugins/core/IO/qFBXIO/include/qFBXIO.h
@@ -23,7 +23,7 @@
 class qFBXIO : public QObject, public ccIOPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES( ccIOPluginInterface )
+	Q_INTERFACES( ccPluginInterface ccIOPluginInterface )
 
 	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qFBXIO" FILE "../info.json" )
 

--- a/plugins/core/IO/qLASFWFIO/include/qLASFWFIO.h
+++ b/plugins/core/IO/qLASFWFIO/include/qLASFWFIO.h
@@ -26,8 +26,9 @@
 class qLASFWFIO : public QObject, public ccIOPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES( ccIOPluginInterface )
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qLAS_FWF_IO" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccIOPluginInterface )
+	
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qLAS_FWF_IO" FILE "../info.json" )
 
 public:
 	//! Default constructor

--- a/plugins/core/IO/qPDALIO/include/qPDALIO.h
+++ b/plugins/core/IO/qPDALIO/include/qPDALIO.h
@@ -23,7 +23,7 @@
 class qPDALIO : public QObject, public ccIOPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES( ccIOPluginInterface )
+	Q_INTERFACES( ccPluginInterface ccIOPluginInterface )
 
 	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qPDALIO" FILE "../info.json" )
 

--- a/plugins/core/IO/qPhotoscanIO/include/qPhotoscanIO.h
+++ b/plugins/core/IO/qPhotoscanIO/include/qPhotoscanIO.h
@@ -24,8 +24,9 @@
 class qPhotoscanIO : public QObject, public ccIOPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES( ccIOPluginInterface )
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qPhotoscanIO" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccIOPluginInterface )
+
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qPhotoscanIO" FILE "../info.json" )
 
 public:
 	explicit qPhotoscanIO( QObject *parent = nullptr );

--- a/plugins/core/Standard/qAnimation/include/qAnimation.h
+++ b/plugins/core/Standard/qAnimation/include/qAnimation.h
@@ -30,9 +30,9 @@ class ccGLWindow;
 class qAnimation : public QObject, public ccStdPluginInterface
 {
 	Q_OBJECT
+	Q_INTERFACES( ccPluginInterface ccStdPluginInterface )
 
-	Q_INTERFACES(ccStdPluginInterface)
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qAnimation" FILE "../info.json")
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qAnimation" FILE "../info.json" )
 
 public:
 

--- a/plugins/core/Standard/qBroom/include/qBroom.h
+++ b/plugins/core/Standard/qBroom/include/qBroom.h
@@ -24,8 +24,9 @@
 class qBroom : public QObject, public ccStdPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(ccStdPluginInterface)
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qBroom" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccStdPluginInterface )
+	
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qBroom" FILE "../info.json" )
 
 public:
 

--- a/plugins/core/Standard/qCSF/include/qCSF.h
+++ b/plugins/core/Standard/qCSF/include/qCSF.h
@@ -38,8 +38,9 @@
 class qCSF : public QObject, public ccStdPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(ccStdPluginInterface)
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qCSF" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccStdPluginInterface )
+	
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qCSF" FILE "../info.json" )
 
 public:
 

--- a/plugins/core/Standard/qCanupo/include/qCanupo.h
+++ b/plugins/core/Standard/qCanupo/include/qCanupo.h
@@ -31,8 +31,9 @@
 class qCanupoPlugin : public QObject, public ccStdPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(ccStdPluginInterface)
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qCanupo" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccStdPluginInterface )
+
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qCanupo" FILE "../info.json" )
 
 public:
 

--- a/plugins/core/Standard/qCompass/include/ccCompass.h
+++ b/plugins/core/Standard/qCompass/include/ccCompass.h
@@ -38,8 +38,9 @@ class ccSNECloud;
 class ccCompass : public QObject, public ccStdPluginInterface, public ccPickingListener
 {
 	Q_OBJECT
-		Q_INTERFACES(ccStdPluginInterface)
-		Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.ccCompass" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccStdPluginInterface )
+	
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.ccCompass" FILE "../info.json" )
 
 public:
 	//! Default constructor

--- a/plugins/core/Standard/qCork/include/qCork.h
+++ b/plugins/core/Standard/qCork/include/qCork.h
@@ -32,8 +32,9 @@ class QAction;
 class qCork : public QObject, public ccStdPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(ccStdPluginInterface)
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qCork" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccStdPluginInterface )
+
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qCork" FILE "../info.json" )
 
 public:
 

--- a/plugins/core/Standard/qFacets/include/qFacets.h
+++ b/plugins/core/Standard/qFacets/include/qFacets.h
@@ -48,8 +48,9 @@ class StereogramDialog;
 class qFacets : public QObject, public ccStdPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(ccStdPluginInterface)
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qFacets" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccStdPluginInterface )
+
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qFacets" FILE "../info.json" )
 
 public:
 

--- a/plugins/core/Standard/qHPR/include/qHPR.h
+++ b/plugins/core/Standard/qHPR/include/qHPR.h
@@ -31,8 +31,9 @@
 class qHPR : public QObject, public ccStdPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(ccStdPluginInterface)
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qHPR" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccStdPluginInterface )
+
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qHPR" FILE "../info.json" )
 
 public:
 

--- a/plugins/core/Standard/qHoughNormals/include/qHoughNormals.h
+++ b/plugins/core/Standard/qHoughNormals/include/qHoughNormals.h
@@ -27,8 +27,9 @@
 class qHoughNormals : public QObject, public ccStdPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(ccStdPluginInterface)
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qHoughNormals" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccStdPluginInterface )
+	
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qHoughNormals" FILE "../info.json" )
 
 public:
 

--- a/plugins/core/Standard/qM3C2/include/qM3C2.h
+++ b/plugins/core/Standard/qM3C2/include/qM3C2.h
@@ -33,8 +33,9 @@
 class qM3C2Plugin : public QObject, public ccStdPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(ccStdPluginInterface)
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qM3C2" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccStdPluginInterface )
+
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qM3C2" FILE "../info.json" )
 
 public:
 

--- a/plugins/core/Standard/qPCL/PclIO/include/qPclIO.h
+++ b/plugins/core/Standard/qPCL/PclIO/include/qPclIO.h
@@ -27,8 +27,9 @@
 class qPclIO : public QObject, public ccIOPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES( ccIOPluginInterface )
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qPclIO" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccIOPluginInterface )
+	
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qPclIO" FILE "../info.json" )
 
 public:
 

--- a/plugins/core/Standard/qPCL/include/qPCL.h
+++ b/plugins/core/Standard/qPCL/include/qPCL.h
@@ -30,8 +30,9 @@ class BaseFilter;
 class qPCL : public QObject, public ccStdPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(ccStdPluginInterface)
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qPCL" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccStdPluginInterface )
+
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qPCL" FILE "../info.json" )
 
 public:
 

--- a/plugins/core/Standard/qPCV/include/qPCV.h
+++ b/plugins/core/Standard/qPCV/include/qPCV.h
@@ -29,8 +29,9 @@
 class qPCV : public QObject, public ccStdPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(ccStdPluginInterface)
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qPCV" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccStdPluginInterface )
+	
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qPCV" FILE "../info.json" )
 
 public:
 	//! Default constructor

--- a/plugins/core/Standard/qPoissonRecon/include/qPoissonRecon.h
+++ b/plugins/core/Standard/qPoissonRecon/include/qPoissonRecon.h
@@ -28,8 +28,9 @@
 class qPoissonRecon : public QObject, public ccStdPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(ccStdPluginInterface)
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qPoissonRecon" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccStdPluginInterface )
+	
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qPoissonRecon" FILE "../info.json" )
 
 public:
 

--- a/plugins/core/Standard/qRANSAC_SD/include/qRANSAC_SD.h
+++ b/plugins/core/Standard/qRANSAC_SD/include/qRANSAC_SD.h
@@ -29,8 +29,9 @@
 class qRansacSD : public QObject, public ccStdPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(ccStdPluginInterface)
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qRansacSD" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccStdPluginInterface )
+	
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qRansacSD" FILE "../info.json" )
 
 public:
 	enum RANSAC_PRIMITIVE_TYPES

--- a/plugins/core/Standard/qSRA/include/qSRA.h
+++ b/plugins/core/Standard/qSRA/include/qSRA.h
@@ -27,8 +27,9 @@ class ccPolyline;
 class qSRA : public QObject, public ccStdPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES(ccStdPluginInterface)
-	Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.qSRA" FILE "../info.json")
+	Q_INTERFACES( ccPluginInterface ccStdPluginInterface )
+	
+	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.qSRA" FILE "../info.json" )
 
 public:
 

--- a/plugins/example/ExampleGLPlugin/include/ExampleGLPlugin.h
+++ b/plugins/example/ExampleGLPlugin/include/ExampleGLPlugin.h
@@ -33,7 +33,8 @@
 class ExampleGLPlugin : public QObject, public ccGLPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES( ccGLPluginInterface )
+	Q_INTERFACES( ccPluginInterface ccGLPluginInterface )
+	
 	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.ExampleGL" FILE "../info.json" )
 
 public:

--- a/plugins/example/ExampleIOPlugin/include/ExampleIOPlugin.h
+++ b/plugins/example/ExampleIOPlugin/include/ExampleIOPlugin.h
@@ -33,7 +33,7 @@
 class ExampleIOPlugin : public QObject, public ccIOPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES( ccIOPluginInterface )
+	Q_INTERFACES( ccPluginInterface ccIOPluginInterface )
 
 	Q_PLUGIN_METADATA( IID "cccorp.cloudcompare.plugin.ExampleIO" FILE "../info.json" )
 

--- a/plugins/example/ExamplePlugin/include/ExamplePlugin.h
+++ b/plugins/example/ExamplePlugin/include/ExamplePlugin.h
@@ -40,7 +40,7 @@
 class ExamplePlugin : public QObject, public ccStdPluginInterface
 {
 	Q_OBJECT
-	Q_INTERFACES( ccStdPluginInterface )
+	Q_INTERFACES( ccPluginInterface ccStdPluginInterface )
 
 	// Replace "Example" by your plugin name (IID should be unique - let's hope your plugin name is unique ;)
 	// The info.json file provides information about the plugin to the loading system and


### PR DESCRIPTION
- make ccPluginInterface a pure virtual interface
- use qobject_cast instead of dynamic_cast when working with ccPluginInterface
- all plugins must include "ccPluginInterface" in Q_INTERFACES (including only the derived interface is not correct)