### PR TITLE
Add logging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,9 +124,9 @@ jobs:
             $i = 0
             $Output | % {
               if ($_.GetType().Name -eq 'ErrorRecord') {
-                Write-Host "${i}: $_.Exception.Message"
+                Write-Host "${i}: ERR $_.Exception.Message"
               } else {
-                Write-Host "${i}: $_"
+                Write-Host "${i}: OUT $_"
               }
               $i++
             }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,11 +124,26 @@ jobs:
             $i = 0
             $Output | % {
               if ($_.GetType().Name -eq 'ErrorRecord') {
-                Write-Host "${i}: ERR $_.Exception.Message"
+                Write-Host "E ${i}: $_.Exception.Message"
               } else {
-                Write-Host "${i}: OUT $_"
+                Write-Host "  ${i}: $_"
               }
               $i++
+            }
+            Write-Host
+            Write-Host "CMake Errors:"
+            $i = 0
+            $Output | % {
+              if ($_.GetType().Name -eq 'ErrorRecord') {
+                Write-Host "${i}: $_.Exception.Message"
+                $i++
+              }
+            }
+            if ($i -gt 0) {
+              Write-Host "Abort because of stderr output"
+              Exit 88
+            } else {
+              Write-Host "No CMake errors."
             }
           }catch {
             Write-Host "CMake fails"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,27 +120,18 @@ jobs:
             -DPLUGIN_STANDARD_QRANSAC_SD=${{ matrix.config.compile_qransac }} `
             -DPLUGIN_STANDARD_QPCL=${{ matrix.config.compile_qpcl }} `
             . 2>&1 | set-variable Output
-            Write-Host "Output:"
+            Write-Host "CMake Output:"
             $i = 0
             $Output | % {
-              Write-Host ( $i + ": "  + $_.Exception)
+              Write-Host "${i}: ${_.Exception}"
               $i++
             }
           }catch {
-            echo "CMake fails"
+            Write-Host "CMake fails"
             $Error
-            echo "---"
-            $_
-            echo "^^^^" 
-            Write-Host " => An error occurred:"
-            Write-Host $_
-            Write-Host " => Stack:"
-            Write-Host $_.ScriptStackTrace
-            Write-Host " => Details:"
-            Write-Host $_.ErrorDetails
             cd build
             cd CMakeFiles
-            Write-Host " => CMakeFilse:"
+            Write-Host " => CMakeFiles:"
             dir
             Write-Host " => CMakeOutput.log:"
             Get-Content CMakeOutput.log

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,11 @@ jobs:
             Write-Host "CMake Output:"
             $i = 0
             $Output | % {
-              Write-Host "${i}: ${_.Exception}"
+              if ($_.GetType().Name -eq 'ErrorRecord') {
+                Write-Host "${i}: $_.Exception.Message"
+              } else {
+                Write-Host "${i}: $_"
+              }
               $i++
             }
           }catch {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,8 +123,7 @@ jobs:
             Write-Host "Output:"
             $i = 0
             $Output | % {
-              Write-Host ("--- " + $i + ": "  + $_.GetType() +  " ------------------------")
-              Write-Host ($_ | Format-List -Force | Out-String)
+              Write-Host ( $i + ": "  + $_.Exception)
               $i++
             }
           }catch {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,17 +23,17 @@ jobs:
               compile_qransac: "ON",
               zlib_name: z.lib,
               xercesclib_name: xerces-c_3.lib,
-           }
-#          - {
-#              name: "macOS Latest Clang",
-#              os: macos-latest,
-#              generator: "Ninja",
-#              conda_library_dir: ".",
-#              compile_qpcl: "OFF",
-#              compile_qransac: "OFF",
-#              zlib_name: libz.a,
-#              xercesclib_name: libxerces-c-3.2.dylib
-#            }
+            }
+          - {
+              name: "macOS Latest Clang",
+              os: macos-latest,
+              generator: "Ninja",
+              conda_library_dir: ".",
+              compile_qpcl: "OFF",
+              compile_qransac: "OFF",
+              zlib_name: libz.a,
+              xercesclib_name: libxerces-c-3.2.dylib
+            }
 
     steps:
       - name: Checkout
@@ -148,6 +148,6 @@ jobs:
             Exit 99
           }
 
-#      - name: Build
-#        run: |
-#          cmake --build build
+      - name: Build
+        run: |
+          cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,107 +2,106 @@ cmake_minimum_required( VERSION 3.10 )
 
 project( CloudCompareProjects )
 
-## One shouldn't generate the BUILD project directly in the SOURCES folder!
-#if ( ${CMAKE_CURRENT_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR} )
-#	if ( NOT SAME_BUILD_AND_SOURCE_FOLDER_WARNING_ALREADY_ISSUED )
-#		message(FATAL_ERROR "It is not advised to BUILD the binaries directly in the SOURCE folder!\n If you want to proceed with this option, just CONFIGURE the project once again" )
-#		set( SAME_BUILD_AND_SOURCE_FOLDER_WARNING_ALREADY_ISSUED TRUE )
-#	endif()
-#endif()
-#
-## Add our cmake module path so we don't need relative paths for these
-#list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/" )
-#
-#include( CMakePolicies )
-#include( CMakeSetCompilerOptions )
-#
-## CCViewer
-#option( OPTION_BUILD_CCVIEWER "Check to compile CCViewer project" ON )
-#
-## Quad buffer stereo support
-#option( OPTION_GL_QUAD_BUFFER_SUPPORT "Check to compile CloudCompare and ccViewer with Quad Buffer support" OFF )
-#
-#if ( OPTION_GL_QUAD_BUFFER_SUPPORT )
-#    # Add the define for all libs and applications
-#	add_definitions( -DCC_GL_WINDOW_USE_QWINDOW )
-#endif()
-#
-## Testing
-#option( BUILD_TESTING "Build tests for CC" OFF )
-#if ( BUILD_TESTING )
-#	include( CTest )
-#endif()
-#
-## Default debug suffix for libraries.
-#set( CMAKE_DEBUG_POSTFIX "d" )
-#
-## Default install folders
-## (on Windows - msvc generator - the '_debug' suffix is automatically added for debug configurations)
-#set( INSTALL_DESTINATIONS CloudCompare )
-#
-## RPATH Linux/Unix: (dynamic) libs are put in a subdir of prefix/lib,
-## since they are only used by qCC/ccViewer
-#if( UNIX AND NOT APPLE )
-#	include( GNUInstallDirs )
-#	set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}/cloudcompare")
-#endif()
-#
-## Define target folders
-## (now that ccViewer can have its own plugins, qCC and ccViewer must fall in separate folders!
-#if(WIN32 OR APPLE) 
-#	set( CLOUDCOMPARE_DEST_FOLDER CloudCompare )
-#	set( CCVIEWER_DEST_FOLDER ccViewer )
-#	if (OPTION_GL_QUAD_BUFFER_SUPPORT)
-#		set ( CLOUDCOMPARE_DEST_FOLDER ${CLOUDCOMPARE_DEST_FOLDER}Stereo )
-#		set ( CCVIEWER_DEST_FOLDER ${CCVIEWER_DEST_FOLDER}Stereo )
-#	endif()
-#else()
-#	set( CLOUDCOMPARE_DEST_FOLDER bin )
-#	set( CCVIEWER_DEST_FOLDER bin )
-#endif()
-#
-## set default install folders
-#if( WIN32 )
-#    # (on Windows - msvc generator - the '_debug' suffix is automatically added for debug configurations)
-#    set( INSTALL_DESTINATIONS ${CLOUDCOMPARE_DEST_FOLDER} )
-#    
-#    if( ${OPTION_BUILD_CCVIEWER} )
-#        list( APPEND INSTALL_DESTINATIONS ${CCVIEWER_DEST_FOLDER} )
-#    endif()
-#elseif( APPLE )
-#	set( INSTALL_DESTINATIONS "${CLOUDCOMPARE_MAC_FRAMEWORK_DIR}" )
-#    
-#    if( ${OPTION_BUILD_CCVIEWER} )
-#        list( APPEND INSTALL_DESTINATIONS "${CCVIEWER_MAC_FRAMEWORK_DIR}" )
-#    endif()
-#elseif( UNIX )
-#	set( INSTALL_DESTINATIONS ${CMAKE_INSTALL_PREFIX}/bin )
-#endif()
-#
-## Load advanced scripts
-#include( CMakeInclude )
-#
-## Add external libraries
-#add_subdirectory( extern/CCCoreLib )
-#include( CMakeExternalLibs )
-#
-## Contrib. libraries (mainly for I/O)
-#include( AllSupport )
-#
-## Internal libs used by both CloudCompare & ccViewer
-#add_subdirectory( libs )
-#
-## Plugins
-#add_subdirectory( plugins )
-#
-## qCC
-#add_subdirectory( qCC )
-#
-## CCViewer
-#if( OPTION_BUILD_CCVIEWER )
-#	add_subdirectory( ccViewer )
-#endif()
-#
-## Install
-#include( InstallCCCoreLib )
-#
+# One shouldn't generate the BUILD project directly in the SOURCES folder!
+if ( ${CMAKE_CURRENT_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR} )
+	if ( NOT SAME_BUILD_AND_SOURCE_FOLDER_WARNING_ALREADY_ISSUED )
+		message(FATAL_ERROR "It is not advised to BUILD the binaries directly in the SOURCE folder!\n If you want to proceed with this option, just CONFIGURE the project once again" )
+		set( SAME_BUILD_AND_SOURCE_FOLDER_WARNING_ALREADY_ISSUED TRUE )
+	endif()
+endif()
+
+# Add our cmake module path so we don't need relative paths for these
+list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/" )
+
+include( CMakePolicies )
+include( CMakeSetCompilerOptions )
+
+# CCViewer
+option( OPTION_BUILD_CCVIEWER "Check to compile CCViewer project" ON )
+
+# Quad buffer stereo support
+option( OPTION_GL_QUAD_BUFFER_SUPPORT "Check to compile CloudCompare and ccViewer with Quad Buffer support" OFF )
+
+if ( OPTION_GL_QUAD_BUFFER_SUPPORT )
+    # Add the define for all libs and applications
+	add_definitions( -DCC_GL_WINDOW_USE_QWINDOW )
+endif()
+
+# Testing
+option( BUILD_TESTING "Build tests for CC" OFF )
+if ( BUILD_TESTING )
+	include( CTest )
+endif()
+
+# Default debug suffix for libraries.
+set( CMAKE_DEBUG_POSTFIX "d" )
+
+# Default install folders
+# (on Windows - msvc generator - the '_debug' suffix is automatically added for debug configurations)
+set( INSTALL_DESTINATIONS CloudCompare )
+
+# RPATH Linux/Unix: (dynamic) libs are put in a subdir of prefix/lib,
+# since they are only used by qCC/ccViewer
+if( UNIX AND NOT APPLE )
+	include( GNUInstallDirs )
+	set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}/cloudcompare")
+endif()
+
+# Define target folders
+# (now that ccViewer can have its own plugins, qCC and ccViewer must fall in separate folders!
+if(WIN32 OR APPLE) 
+	set( CLOUDCOMPARE_DEST_FOLDER CloudCompare )
+	set( CCVIEWER_DEST_FOLDER ccViewer )
+	if (OPTION_GL_QUAD_BUFFER_SUPPORT)
+		set ( CLOUDCOMPARE_DEST_FOLDER ${CLOUDCOMPARE_DEST_FOLDER}Stereo )
+		set ( CCVIEWER_DEST_FOLDER ${CCVIEWER_DEST_FOLDER}Stereo )
+	endif()
+else()
+	set( CLOUDCOMPARE_DEST_FOLDER bin )
+	set( CCVIEWER_DEST_FOLDER bin )
+endif()
+
+# set default install folders
+if( WIN32 )
+    # (on Windows - msvc generator - the '_debug' suffix is automatically added for debug configurations)
+    set( INSTALL_DESTINATIONS ${CLOUDCOMPARE_DEST_FOLDER} )
+    
+    if( ${OPTION_BUILD_CCVIEWER} )
+        list( APPEND INSTALL_DESTINATIONS ${CCVIEWER_DEST_FOLDER} )
+    endif()
+elseif( APPLE )
+	set( INSTALL_DESTINATIONS "${CLOUDCOMPARE_MAC_FRAMEWORK_DIR}" )
+    
+    if( ${OPTION_BUILD_CCVIEWER} )
+        list( APPEND INSTALL_DESTINATIONS "${CCVIEWER_MAC_FRAMEWORK_DIR}" )
+    endif()
+elseif( UNIX )
+	set( INSTALL_DESTINATIONS ${CMAKE_INSTALL_PREFIX}/bin )
+endif()
+
+# Load advanced scripts
+include( CMakeInclude )
+
+# Add external libraries
+add_subdirectory( extern/CCCoreLib )
+include( CMakeExternalLibs )
+
+# Contrib. libraries (mainly for I/O)
+include( AllSupport )
+
+# Internal libs used by both CloudCompare & ccViewer
+add_subdirectory( libs )
+
+# Plugins
+add_subdirectory( plugins )
+
+# qCC
+add_subdirectory( qCC )
+
+# CCViewer
+if( OPTION_BUILD_CCVIEWER )
+	add_subdirectory( ccViewer )
+endif()
+
+# Install
+include( InstallCCCoreLib )


### PR DESCRIPTION
The key changes:

https://github.com/dsame/CloudCompare/blob/f19658228050c83f193a45e4af22b89e015b1332/.github/workflows/build.yml#L79 - Ensure the execution is not aborted on the first stderr write

https://github.com/dsame/CloudCompare/blob/f19658228050c83f193a45e4af22b89e015b1332/.github/workflows/build.yml#L122 - `2>&1` - don't interrupt normal execution even if something is written to stderr

https://github.com/dsame/CloudCompare/blob/f19658228050c83f193a45e4af22b89e015b1332/.github/workflows/build.yml#L125 - print ErrorRecords in readable format

Also there's `catch` block that is not expected to be run normally, but just in case there's a code to  show the cmake logs