### PR TITLE
Change dependency in CCPluginStub

### DIFF
--- a/libs/CCPluginStub/CMakeLists.txt
+++ b/libs/CCPluginStub/CMakeLists.txt
@@ -13,5 +13,5 @@ add_subdirectory( src )
 
 target_link_libraries( ${PROJECT_NAME}
 	PRIVATE
-		QCC_IO_LIB
+		QCC_DB_LIB
 )


### PR DESCRIPTION
Unfortunately CCPluginStub needs ccLog which is in QCC_DB_LIB. So link to it instead of QCC_IO_LIB.