### PR TITLE
fix incorrect openGL color function 2.11.x

### DIFF
--- a/libs/qCC_db/ccPointCloud.cpp
+++ b/libs/qCC_db/ccPointCloud.cpp
@@ -2737,7 +2737,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 							const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
 							//we force display of points hidden because of their scalar field value
 							//to be sure that the user doesn't miss them (during manual segmentation for instance)
-							glFunc->glColor4ubv(col ? col->rgb : ccColor::lightGreyRGB.rgb);
+							glFunc->glColor3ubv(col ? col->rgb : ccColor::lightGreyRGB.rgb);
 						}
 						else if (glParams.showColors)
 						{


### PR DESCRIPTION
This is essentially the same as https://github.com/CloudCompare/CloudCompare/pull/1163/commits/2112ac3c3a9083b1c987f5b22ca74babb0f79afb but I had issues Cherry Picking that commit so I recreated it here.

This fixes http://cloudcompare.org/forum/viewtopic.php?f=10&t=4578 on v2.11.x, already fixed on master.