### PR TITLE
switching to malloc on OSX

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
               conda_library_dir: ".",
               compile_qanimation_with_ffmpeg: "OFF",
               compile_qpcl: "OFF",
-              compile_qransac: "OFF",
+              compile_qransac: "ON",
             }
 
     steps:

--- a/plugins/core/Standard/qRANSAC_SD/extern/RANSAC_SD/GfxTL/FlatCopyVector.h
+++ b/plugins/core/Standard/qRANSAC_SD/extern/RANSAC_SD/GfxTL/FlatCopyVector.h
@@ -15,12 +15,12 @@
 
 #ifdef _mm_malloc
 #ifndef a_malloc
-#define a_malloc(sz, align) _mm_malloc((sz), (align))
+#define a_malloc(sz, align) malloc(sz)//_mm_malloc((sz), (align))
 #endif // !a_malloc
 #endif // !_mm_malloc
 #ifdef _mm_free
 #ifndef a_free
-#define a_free(ptr)  _mm_free((ptr))
+#define a_free(ptr)  free(ptr)//_mm_free((ptr))
 #endif // !a_free
 #endif // !_mm_free
 
@@ -28,7 +28,11 @@
 #define a_free(a)      free(a) 
 #endif // !_mm_free
 #ifndef a_malloc
+#ifndef __APPLE__
 #define a_malloc(sz, align) aligned_alloc((align), (sz))
+#else
+#define a_malloc(sz, align) malloc(sz) // OSX aligns all allocations to 16 byte boundaries (except valloc which aligns to page boundaries) - so specific alignment requests are ignored.
+#endif
 #endif // !_mm_malloc
 
 namespace GfxTL

--- a/plugins/core/Standard/qRANSAC_SD/extern/RANSAC_SD/MiscLib/AlignedAllocator.h
+++ b/plugins/core/Standard/qRANSAC_SD/extern/RANSAC_SD/MiscLib/AlignedAllocator.h
@@ -26,7 +26,11 @@
 #define a_free(a)      free(a) 
 #endif // !_mm_free
 #ifndef a_malloc
+#ifndef __APPLE__
 #define a_malloc(sz, align) aligned_alloc((align), (sz))
+#else
+#define a_malloc(sz, align) malloc(sz) // OSX aligns all allocations to 16 byte boundaries (except valloc which aligns to page boundaries) - so specific alignment requests are ignored.
+#endif
 #endif // !_mm_malloc
 
 


### PR DESCRIPTION
Because aligned_alloc is not available and OSX apparently ignores posix_memalign requests

Would you mind trying to see if this compiles @asmaloney ?