### PR TITLE
Forgot to revert FlatCopyVector to _mm_malloc for windows version.

### DIFF
--- a/plugins/core/Standard/qRANSAC_SD/extern/RANSAC_SD/GfxTL/FlatCopyVector.h
+++ b/plugins/core/Standard/qRANSAC_SD/extern/RANSAC_SD/GfxTL/FlatCopyVector.h
@@ -15,12 +15,12 @@
 
 #ifdef _mm_malloc
 #ifndef a_malloc
-#define a_malloc(sz, align) malloc(sz)//_mm_malloc((sz), (align))
+#define a_malloc(sz, align) _mm_malloc((sz), (align))
 #endif // !a_malloc
 #endif // !_mm_malloc
 #ifdef _mm_free
 #ifndef a_free
-#define a_free(ptr)  free(ptr)//_mm_free((ptr))
+#define a_free(ptr) _mm_free((ptr))
 #endif // !a_free
 #endif // !_mm_free
 


### PR DESCRIPTION
Originally tested using malloc on windows to simulate MacOs.