### PR TITLE
[macOS] Fix opening a file in the GUI from the command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CloudCompare Version History
 ============================
 
+v2.11.1 (Anoia) - (In development)
+----------------------
+- Bug fixes:
+  - [macOS] Fix determination of command line use so opening a file in the GUI using the command line works (#1296).
+
+
 v2.11.0 (Anoia) - 14/06/2020
 ----------------------
 

--- a/qCC/main.cpp
+++ b/qCC/main.cpp
@@ -51,13 +51,9 @@
 #include "ccPluginManager.h"
 
 #ifdef USE_VLD
-//VLD
 #include <vld.h>
 #endif
 
-#ifdef Q_OS_MAC
-#include <unistd.h>
-#endif
 
 int main(int argc, char **argv)
 {
@@ -74,7 +70,21 @@ int main(int argc, char **argv)
 #endif
 
 #ifdef Q_OS_MAC
-	bool commandLine = isatty( fileno( stdin ) );
+	// On macOS, when double-clicking the application, the Finder (sometimes!) adds a command-line parameter
+	// like "-psn_0_582385" which is a "process serial number".
+	// We need to recognize this and discount it when determining if we are running on the command line or not.
+
+	int numRealArgs = argc;
+	
+	for ( int i = 1; i < argc; ++i )
+	{
+		if ( strncmp( argv[i], "-psn_", 5 ) == 0 )
+		{
+			--numRealArgs;
+		}
+	}
+	
+	bool commandLine = (numRealArgs > 1) && (argv[1][0] == '-');
 #else
 	bool commandLine = (argc > 1) && (argv[1][0] == '-');
 #endif


### PR DESCRIPTION
Commit b9888cd3d39eda2e15b0210039960949864eaad0 fixed double-clicking the application to open it, but prevented opening a file from the command line.

This change checks for the "process serial number" explicitly and discounts it when determining if we are running on the command line or not.

Fixes #1296