### PR TITLE
Fix build with pcl 1.11+

### DIFF
--- a/plugins/core/Standard/qPCL/PclUtils/utils/my_point_types.h
+++ b/plugins/core/Standard/qPCL/PclUtils/utils/my_point_types.h
@@ -21,6 +21,7 @@
 //PCL
 #include <pcl/register_point_struct.h>
 #include <pcl/point_types.h>
+#include <boost/cstdint.hpp>
 
 //! PCL custom point type used for reading RGB data
 struct OnlyRGB


### PR DESCRIPTION
Add missing include of boost/cstdint.hpp

    In file included from /builddir/build/BUILD/CloudCompare-2.9.1/plugins/qPCL/PclUtils/utils/cc2sm.cpp:21:
    /builddir/build/BUILD/CloudCompare-2.9.1/plugins/qPCL/PclUtils/utils/my_point_types.h:34:12: error: 'uint8_t' in namespace 'boost' does not name a type
       34 |     boost::uint8_t b;
          |            ^~~~~~~
    ...
    /builddir/build/BUILD/CloudCompare-2.9.1/plugins/qPCL/PclUtils/utils/cc2sm.cpp: In member function 'pcl::PCLPointCloud2::Ptr cc2smReader::getColors() const':
    /builddir/build/BUILD/CloudCompare-2.9.1/plugins/qPCL/PclUtils/utils/cc2sm.cpp:275:21: error: 'struct OnlyRGB' has no member named 'r'
      275 |    pcl_cloud->at(i).r = static_cast<uint8_t>(rgb[0]);
          |                     ^
    /builddir/build/BUILD/CloudCompare-2.9.1/plugins/qPCL/PclUtils/utils/cc2sm.cpp:276:21: error: 'struct OnlyRGB' has no member named 'g'
      276 |    pcl_cloud->at(i).g = static_cast<uint8_t>(rgb[1]);
          |                     ^
    /builddir/build/BUILD/CloudCompare-2.9.1/plugins/qPCL/PclUtils/utils/cc2sm.cpp:277:21: error: 'struct OnlyRGB' has no member named 'b'
      277 |    pcl_cloud->at(i).b = static_cast<uint8_t>(rgb[2]);
          |