### PR TITLE
Crash Fix

### DIFF
--- a/libs/qCC_db/ccPointCloud.cpp
+++ b/libs/qCC_db/ccPointCloud.cpp
@@ -4923,7 +4923,7 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 							for (int j = 0; j < chunkSize; j++, _sf++)
 							{
 								//we need to convert scalar value to color into a temporary structure
-								const ccColor::Rgb* col = m_vboManager.sourceSF->getColor(*_sf);
+								const ccColor::Rgb* col = _sf ? m_vboManager.sourceSF->getColor(*_sf) : nullptr;
 								if (!col)
 									col = &ccColor::lightGreyRGB;
 								*_sfColors++ = col->r;

--- a/qCC/ccHistogramWindow.cpp
+++ b/qCC/ccHistogramWindow.cpp
@@ -156,7 +156,7 @@ void ccHistogramWindow::fromSF(	ccScalarField* sf,
 								bool numberOfClassesCanBeChanged/*=true*/,
 								bool showNaNValuesInGrey/*=true*/)
 {
-	if (m_associatedSF != sf)
+	if (sf && m_associatedSF != sf)
 	{
 		if (m_associatedSF)
 			m_associatedSF->release();


### PR DESCRIPTION
Noticed an occasional crash when rapidly changing point clouds or scalar fields with accelerator keys in the db tree window. I believe the messages were created while one point cloud or scalar field was selected but then applied to another. debugging lead me to two separate locations which could crash in this situation.

The fix on ccHistogramWindow has one adverse effect, if the situation happens that this code prevents a crash, it will not populate the ccHistogramWindow until you change scalar field or point cloud selection because the message to start it will not be resent. I'm not sure it's worth the effort to have a delay timer or some other mechanism to re-trigger.


