### PR TITLE
PBO pixel (depth) picking

### DIFF
--- a/libs/qCC_glWindow/include/ccGLWindow.h
+++ b/libs/qCC_glWindow/include/ccGLWindow.h
@@ -1009,10 +1009,10 @@ protected: //other methods
 	//! Returns the (relative) depth value at a given pixel position
 	/** \return the (relative) depth or 1.0 if none is defined
 	**/
-	GLfloat getGLDepth(int x, int y, bool extendToNeighbors = false);
+	GLfloat getGLDepth(int x, int y, bool extendToNeighbors = false, bool usePBO = false);
 
 	//! Returns the approximate 3D position of the clicked pixel
-	bool getClick3DPos(int x, int y, CCVector3d& P3D);
+	bool getClick3DPos(int x, int y, CCVector3d& P3D, bool usePBO);
 
 protected: //members
 
@@ -1325,6 +1325,12 @@ protected: //members
 
 		//! PBO object
 		QOpenGLBuffer* glBuffer = nullptr;
+
+		//! Last read operation timestamp
+		qint64 lastReadTime_ms = 0;
+
+		//! Elapsed timer
+		QElapsedTimer timer;
 
 		bool init();
 		void release();

--- a/libs/qCC_glWindow/include/ccGLWindow.h
+++ b/libs/qCC_glWindow/include/ccGLWindow.h
@@ -44,6 +44,7 @@
 #include <unordered_set>
 
 class QOpenGLDebugMessage;
+class QOpenGLBuffer;
 
 class ccBBox;
 class ccColorRampShader;
@@ -1315,6 +1316,22 @@ protected: //members
 
 	//! Last texture pool index
 	size_t m_texturePoolLastIndex;
+
+	//! Fast pixel reading mechanism with PBO
+	struct PBOPicking
+	{
+		//! Whether the picking PBO seems supported or not
+		bool supported = true;
+
+		//! PBO object
+		QOpenGLBuffer* glBuffer = nullptr;
+
+		bool init();
+		void release();
+	};
+
+	//! Fast pixel reading mechanism with PBO
+	PBOPicking m_pickingPBO;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(ccGLWindow::INTERACTION_FLAGS);

--- a/libs/qCC_glWindow/src/ccGLWindow.cpp
+++ b/libs/qCC_glWindow/src/ccGLWindow.cpp
@@ -7106,7 +7106,7 @@ GLfloat ccGLWindow::getGLDepth(int x, int y, bool extendToNeighbors/*=false*/, b
 		m_pickingPBO.lastReadTime_ms = readTime_ms;
 	}
 
-	glFunc->glReadPixels(x, y, kernel[0], kernel[1], GL_DEPTH_COMPONENT, GL_FLOAT, m_pickingPBO.glBuffer ? nullptr : depthPickingBuffer);
+	glFunc->glReadPixels(x, y, kernel[0], kernel[1], GL_DEPTH_COMPONENT, GL_FLOAT, usePBO && m_pickingPBO.glBuffer ? nullptr : depthPickingBuffer);
 
 	if (usePBO && m_pickingPBO.glBuffer)
 	{
@@ -7157,10 +7157,10 @@ GLfloat ccGLWindow::getGLDepth(int x, int y, bool extendToNeighbors/*=false*/, b
 	return minZ;
 }
 
-bool ccGLWindow::getClick3DPos(int x, int y, CCVector3d& P3D, bool useFBO)
+bool ccGLWindow::getClick3DPos(int x, int y, CCVector3d& P3D, bool usePBO)
 {
 	y = m_glViewport.height() - 1 - y;
-	GLfloat glDepth = getGLDepth(x, y, false, useFBO);
+	GLfloat glDepth = getGLDepth(x, y, false, usePBO);
 	if (glDepth == INVALID_DEPTH)
 	{
 		return false;


### PR DESCRIPTION
When the "auto-pick rotation center" feature is enabled, the central pixel depth picking take a lot of time. Here we use a PBO for asynchronous transfer of the depth buffer (and we read the previous frame buffer when possible) to almost completely remove the picking duration.