### PR TITLE
CI: Use conda-incubator/setup-miniconda@v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           key: conda-cache-${{ runner.os }}-${{ hashFiles('.ci/conda.yml') }}
 
       - name: Install Dependencies
-        uses: goanpeca/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: CloudCompareDev
           auto-activate-base: false
@@ -73,8 +73,9 @@ jobs:
         if:  matrix.config.os == 'windows-latest'
         run: |
           # Set these env vars so cmake picks the correct compiler
-          echo "::set-env name=CXX::cl.exe"
-          echo "::set-env name=CC::cl.exe"
+          # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files
+          echo "CXX=cl.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "CC=cl.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Configure CMake
         shell: bash -l {0}


### PR DESCRIPTION
And use newer thing to set environment variable

Fixes the CI that was failing due to recent changes on the ::set-env commands

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/