### PR TITLE
bug fix orientation matrix for TLS/GBL sensor during PCD file load

### DIFF
--- a/plugins/core/Standard/qPCL/PclIO/src/PcdFilter.cpp
+++ b/plugins/core/Standard/qPCL/PclIO/src/PcdFilter.cpp
@@ -206,10 +206,10 @@ CC_FILE_ERROR PcdFilter::loadFile(const QString& filename, ccHObject& container,
 			float* X = ccRot.getColumn(0);
 			float* Y = ccRot.getColumn(1);
 			float* Z = ccRot.getColumn(2);
-			//Warning: Y and Z are inverted
-			X[0] =  eigrot(0,0); X[1] =  eigrot(1,0); X[2] =  eigrot(2,0);
-			Y[0] = -eigrot(0,2); Y[1] = -eigrot(1,2); Y[2] = -eigrot(2,2);
-			Z[0] =  eigrot(0,1); Z[1] =  eigrot(1,1); Z[2] =  eigrot(2,1);
+			
+			X[0] = eigrot(0,0); X[1] = eigrot(1,0); X[2] = eigrot(2,0);
+			Y[0] = eigrot(0,1); Y[1] = eigrot(1,1); Y[2] = eigrot(2,1);
+			Z[0] = eigrot(0,2); Z[1] = eigrot(1,2); Z[2] = eigrot(2,2);
 
 			ccRot.getColumn(3)[3] = 1.0f;
 			ccRot.setTranslation(origin.data());


### PR DESCRIPTION
This works for me loading/saving multiple times while changing the translation and orientation arbitrarily, gives expected results.

I also confirmed after opening and saving a PCD the original and new file will be unchanged when viewed through pcl_viewer