### PR TITLE
Add GBL/Camera sensor cloning support

### DIFF
--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -7778,6 +7778,32 @@ void MainWindow::doActionClone()
 				ccConsole::Error(QString("An error occurred while cloning facet %1").arg(entity->getName()));
 			}
 		}
+		else if (entity->isA(CC_TYPES::CAMERA_SENSOR))
+		{
+			ccCameraSensor* camera = ccHObjectCaster::ToCameraSensor(entity);
+			if (camera)
+			{
+				ccCameraSensor* cloned = new ccCameraSensor(*camera);
+				clone = (cloned ? cloned : nullptr);
+			}
+			if (!clone)
+			{
+				ccConsole::Error(QString("An error occurred while cloning camera sensor %1").arg(entity->getName()));
+			}
+		}
+		else if (entity->isA(CC_TYPES::GBL_SENSOR))
+		{
+			ccGBLSensor* sensor = ccHObjectCaster::ToGBLSensor(entity);
+			if (sensor)
+			{
+				ccGBLSensor* cloned = new ccGBLSensor(*sensor);
+				clone = (cloned ? cloned : nullptr);
+			}
+			if (!clone)
+			{
+				ccConsole::Error(QString("An error occurred while cloning GBL sensor %1").arg(entity->getName()));
+			}
+		}
 		else
 		{
 			ccLog::Warning(QString("Entity '%1' can't be cloned (type not supported yet!)").arg(entity->getName()));


### PR DESCRIPTION
Recently while helping someone with camera sensor manipulations on the [forum](http://cloudcompare.org/forum/viewtopic.php?f=9&t=4979&p=22646#p22646) I needed multiple copies of a camera sensor, and needed to create it multiple times or to save it to a file and reload it multiple times.
This PR just adds Camera & GBL sensors to the list of entities which can be cloned via the clone button.