### PR TITLE
Translation command line bug fix

### DIFF
--- a/libs/CCAppCommon/include/ccTranslationManager.h
+++ b/libs/CCAppCommon/include/ccTranslationManager.h
@@ -44,6 +44,11 @@ public:
 	//! Using the translation file prefixes that were registered, load the actual translations
 	void loadTranslations();
 	
+	/** Using the translation file prefixes that were registered, load the actual
+	 * translation by the 2-letter ISO 639 language code in lowercase.
+	*/
+	void loadTranslation(QString language);
+	
 	//! Populate the menu with a list of languages found using files in 'pathToTranslationFiles'
 	void populateMenu( QMenu *menu, const QString &pathToTranslationFiles );
 	

--- a/libs/CCAppCommon/src/ccTranslationManager.cpp
+++ b/libs/CCAppCommon/src/ccTranslationManager.cpp
@@ -64,6 +64,29 @@ void ccTranslationManager::loadTranslations()
 	}
 }
 
+void ccTranslationManager::loadTranslation(QString language)
+{
+	const QLocale	locale(language);
+
+	const auto& info = mTranslatorFileInfo;
+
+	for (const auto& fileInfo : info)
+	{
+		auto translator = new QTranslator(ccApp);
+
+		bool loaded = translator->load(locale, fileInfo.prefix, QStringLiteral("_"), fileInfo.path);
+
+		if (loaded)
+		{
+			ccApp->installTranslator(translator);
+		}
+		else
+		{
+			delete translator;
+		}
+	}
+}
+
 void ccTranslationManager::populateMenu( QMenu *menu, const QString &pathToTranslationFiles )
 {
 	const LanguageList	cList = availableLanguages( QStringLiteral( "CloudCompare" ), pathToTranslationFiles );

--- a/qCC/main.cpp
+++ b/qCC/main.cpp
@@ -45,6 +45,7 @@
 #include "ccGuiParameters.h"
 #include "ccPersistentSettings.h"
 #include "mainwindow.h"
+#include "ccTranslationManager.h"
 
 //plugins
 #include "ccPluginInterface.h"
@@ -89,14 +90,11 @@ int main(int argc, char **argv)
 	bool commandLine = (argc > 1) && (argv[1][0] == '-');
 #endif
    
-	if ( !commandLine )
-	{
-		ccApplication::initOpenGL();
+	ccApplication::initOpenGL();
 
 #ifdef CC_GAMEPAD_SUPPORT
-		QGamepadManager::instance(); //potential workaround to bug https://bugreports.qt.io/browse/QTBUG-61553
+	QGamepadManager::instance(); //potential workaround to bug https://bugreports.qt.io/browse/QTBUG-61553
 #endif
-	}
 	
 	ccApplication app(argc, argv, commandLine);
 
@@ -119,7 +117,6 @@ int main(int argc, char **argv)
 
 	//specific commands
 	int lastArgumentIndex = 1;
-	QTranslator translator;
 	if (commandLine)
 	{
 		//translation file selection
@@ -127,15 +124,7 @@ int main(int argc, char **argv)
 		{
 			QString langFilename = QString::fromLocal8Bit(argv[2]);
 
-			//Load translation file
-			if (translator.load(langFilename, QCoreApplication::applicationDirPath()))
-			{
-				qApp->installTranslator(&translator);
-			}
-			else
-			{
-				QMessageBox::warning(nullptr, QObject::tr("Translation"), QObject::tr("Failed to load language file '%1'").arg(langFilename));
-			}
+			ccTranslationManager::get().loadTranslation(langFilename);
 			commandLine = false;
 			lastArgumentIndex += 2;
 		}


### PR DESCRIPTION
call `ccApplication::initOpenGL();` whether or not in command line mode.

Also adds `ccTranslationManager::loadTranslation(QString language);` to simplify loading language from the command prompt

`C:\Program Files\CloudCompare>CloudCompare.exe -LANG translations\cloudcompare_fr`

was the previous command for french

`C:\Program Files\CloudCompare>CloudCompare.exe -LANG fr`

is the new way handled by the translation manager