### PR TITLE
Single click picking option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CloudCompare Version History
 v2.12 (???) - (in development)
 ----------------------
 - Improvements
+    - Single Click Picking option added to display options menu
+      - Single click picking can be disabled (can be very slow for very large point clouds) 
     - CommandLine mode new features
       - Added N_SIGMA_MIN and N_SIGMA_MAX options to the FILTER_SF command. Specify the option followed by a numeric value to filter by N * standardDeviation around the mean.
 	- Clipping box tool:

--- a/libs/CCAppCommon/src/ccDisplayOptionsDlg.cpp
+++ b/libs/CCAppCommon/src/ccDisplayOptionsDlg.cpp
@@ -56,6 +56,7 @@ ccDisplayOptionsDlg::ccDisplayOptionsDlg(QWidget* parent)
 	connect(m_ui->decimateMeshBox,                 &QCheckBox::toggled, this, [&](bool state) { parameters.decimateMeshOnMove = state; });
 	connect(m_ui->decimateCloudBox,                &QCheckBox::toggled, this, [&](bool state) { parameters.decimateCloudOnMove = state; });
 	connect(m_ui->drawRoundedPointsCheckBox,       &QCheckBox::toggled, this, [&](bool state) { parameters.drawRoundedPoints = state; });
+	connect(m_ui->singleClickPickingCheckBox,	   &QCheckBox::toggled, this, [&](bool state) { parameters.singleClickPicking = state; });
 	connect(m_ui->autoDisplayNormalsCheckBox,      &QCheckBox::toggled, this, [&](bool state) { options.normalsDisplayedByDefault = state; });
 	connect(m_ui->useNativeDialogsCheckBox,        &QCheckBox::toggled, this, [&](bool state) { options.useNativeDialogs = state; });
 
@@ -153,6 +154,7 @@ void ccDisplayOptionsDlg::refresh()
 	m_ui->maxCloudSizeDoubleSpinBox->setValue(parameters.minLoDCloudSize / 1000000.0);
 	m_ui->useVBOCheckBox->setChecked(parameters.useVBOs);
 	m_ui->showCrossCheckBox->setChecked(parameters.displayCross);
+	m_ui->singleClickPickingCheckBox->setChecked(parameters.singleClickPicking);
 
 	m_ui->colorScaleShowHistogramCheckBox->setChecked(parameters.colorScaleShowHistogram);
 	m_ui->useColorScaleShaderCheckBox->setChecked(parameters.colorScaleUseShader);

--- a/libs/CCAppCommon/ui/displayOptionsDlg.ui
+++ b/libs/CCAppCommon/ui/displayOptionsDlg.ui
@@ -34,8 +34,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>493</width>
-        <height>349</height>
+        <width>496</width>
+        <height>411</height>
        </rect>
       </property>
       <attribute name="label">
@@ -374,8 +374,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>490</width>
-        <height>364</height>
+        <width>496</width>
+        <height>411</height>
        </rect>
       </property>
       <attribute name="label">
@@ -459,8 +459,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>490</width>
-        <height>364</height>
+        <width>496</width>
+        <height>411</height>
        </rect>
       </property>
       <attribute name="label">
@@ -602,8 +602,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>490</width>
-        <height>364</height>
+        <width>496</width>
+        <height>411</height>
        </rect>
       </property>
       <attribute name="label">
@@ -891,6 +891,16 @@
         <widget class="QCheckBox" name="autoDisplayNormalsCheckBox">
          <property name="text">
           <string>Automatically display normals at loading time (when available)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="singleClickPickingCheckBox">
+         <property name="text">
+          <string>Single Click Object Picking (Can be slow on large point clouds)</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
          </property>
         </widget>
        </item>

--- a/libs/qCC_glWindow/include/ccGuiParameters.h
+++ b/libs/qCC_glWindow/include/ccGuiParameters.h
@@ -116,6 +116,10 @@ public:
 		//! Whether to draw rounded points (slower) or not
 		bool drawRoundedPoints;
 
+		//! Whether to pick objects by single clicking in the GUI 
+		//! can be slow with large point clouds/large number of objects
+		bool singleClickPicking;
+
 		//! Default constructor
 		ParamStruct();
 

--- a/libs/qCC_glWindow/src/ccGLWindow.cpp
+++ b/libs/qCC_glWindow/src/ccGLWindow.cpp
@@ -4370,7 +4370,11 @@ void ccGLWindow::mouseReleaseEvent(QMouseEvent *event)
 				if (!processClickableItems(x, y))
 				{
 					m_lastMousePos = event->pos(); //just in case (it should be already at this position)
-					m_deferredPickingTimer.start();
+					const ccGui::ParamStruct& displayParams = getDisplayParameters();
+					if (displayParams.singleClickPicking)
+					{
+						m_deferredPickingTimer.start();
+					}
 					//doPicking();
 				}
 			}

--- a/libs/qCC_glWindow/src/ccGuiParameters.cpp
+++ b/libs/qCC_glWindow/src/ccGuiParameters.cpp
@@ -108,6 +108,8 @@ void ccGui::ParamStruct::reset()
 	zoomSpeed					= 1.0;
 
 	autoComputeOctree			= ASK_USER;
+
+	singleClickPicking			= true;
 }
 
 static int c_fColorArraySize  = sizeof(float) * 4;
@@ -151,7 +153,7 @@ void ccGui::ParamStruct::fromPersistentSettings()
 	labelOpacity				= static_cast<unsigned>(std::max(0,    settings.value("labelOpacity",             75  ).toInt()));
 	zoomSpeed					=                                      settings.value("zoomSpeed",                1.0 ).toDouble();
 	autoComputeOctree			= static_cast<ComputeOctreeForPicking>(settings.value("autoComputeOctree",   ASK_USER ).toInt());
-
+	singleClickPicking			=									   settings.value("singleClickPicking",		 true ).toBool();
 	settings.endGroup();
 }
 
@@ -191,7 +193,7 @@ void ccGui::ParamStruct::toPersistentSettings() const
 	settings.setValue("labelOpacity",             labelOpacity);
 	settings.setValue("zoomSpeed",                zoomSpeed);
 	settings.setValue("autoComputeOctree",        static_cast<int>(autoComputeOctree));
-
+	settings.setValue("singleClickPicking",		  singleClickPicking);
 	settings.endGroup();
 }
 


### PR DESCRIPTION
Adding an option to disable single click picking. 
Single click picking can be really slow on large clouds.
See forum request [Problems with a single click](http://cloudcompare.org/forum/viewtopic.php?f=9&t=5018&p=22891#p22891)