### PR TITLE
Don't set a default color for console message item

### DIFF
--- a/qCC/ccConsole.cpp
+++ b/qCC/ccConsole.cpp
@@ -278,16 +278,11 @@ void ccConsole::refresh()
 					if (m_parentWindow)
 						m_parentWindow->forceConsoleDisplay();
 				}
-				//Standard
-				else
-				{
 #ifdef QT_DEBUG
-					if (debugMessage)
-						item->setForeground(Qt::blue);
-					else
-#endif
-						item->setForeground(Qt::black);
+				else if (debugMessage) {
+					item->setForeground(Qt::blue);
 				}
+#endif
 
 				m_textDisplay->addItem(item);
 			}


### PR DESCRIPTION
The color used will be the default one for the current theme.

Otherwise setting the color to black overrides the default color of the
theme and it doesn't play well with dark themes.