### PR TITLE
Remove about dialog custom stylesheet

### DIFF
--- a/qCC/ui_templates/aboutDlg.ui
+++ b/qCC/ui_templates/aboutDlg.ui
@@ -16,10 +16,6 @@
   <property name="windowTitle">
    <string>About CloudCompare</string>
   </property>
-  <property name="styleSheet">
-   <string notr="true">background-color:white;
-color:black;</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">


### PR DESCRIPTION
So that it respects the global stylesheet.

Related to #1415.

Commit #2ae7b490d9b07cdc2544b1dd117075cc9189f7ed forced the font color
to black, which indeed fixes the probleme of white text on white
background, but I think it is better the let the dialog use the 'global'
stylesheet so that if the theme is dark, the about window also is.

![image](https://user-images.githubusercontent.com/15125341/112873081-7458da00-90c1-11eb-9a3f-9693521fdab4.png)
![image](https://user-images.githubusercontent.com/15125341/112873094-77ec6100-90c1-11eb-8883-cb05f29962de.png)
![image](https://user-images.githubusercontent.com/15125341/112873102-7a4ebb00-90c1-11eb-9559-aa99a1003c29.png)


link color doesn't look very readable on dark themes 🤔 
