### PR TITLE
Update PCL minimum version to 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: bionic
+dist: focal
 cache: ccache
 language: cpp
 compiler:

--- a/plugins/core/Standard/qPCL/PclUtils/CMakeLists.txt
+++ b/plugins/core/Standard/qPCL/PclUtils/CMakeLists.txt
@@ -2,7 +2,7 @@ project( QPCL_PLUGIN_UTILS_LIB )
 
 find_package( Qt5 COMPONENTS Widgets REQUIRED )
 
-find_package( PCL 1.7 REQUIRED )
+find_package( PCL 1.9 REQUIRED )
 
 add_library( ${PROJECT_NAME} STATIC )
 


### PR DESCRIPTION
From PCL 1.9.0 sources: 

>   /** \brief MovingLeastSquaresOMP implementation has been merged into MovingLeastSquares for better maintainability.

and in PCL 1.10.0 `MovingLeastSquaresOMP` was marked as deprecated.

5bc453a08a4760cf63788461e5160b2644d4588c followed the instruction of the deprecation message, that means
that the qPCL plugins needs at least PCL 1.9 to build.

This PR updates the qPCL cmake to require PCL 1.9 and update the travis CI to use Ubuntu Focal (20.4) as it has PCL 1.10 in its reposiories (Ubuntu Bionic (18.04) has PCL 1.8)).

Related to #1459
