### PR TITLE
Segmentation Cancel Fix

### DIFF
--- a/qCC/ccGraphicalSegmentationTool.cpp
+++ b/qCC/ccGraphicalSegmentationTool.cpp
@@ -275,11 +275,13 @@ void ccGraphicalSegmentationTool::reset()
 			ccHObjectCaster::ToGenericPointCloud(*p)->resetVisibilityArray();
 		}
 
-		if (m_associatedWin)
-			m_associatedWin->redraw(false);
 		m_somethingHasChanged = false;
 	}
-
+	if (m_associatedWin)
+	{
+		m_associatedWin->redraw(false);
+		m_associatedWin->releaseMouse();
+	}
 	razButton->setEnabled(false);
 	validButton->setEnabled(false);
 	validAndDeleteButton->setEnabled(false);


### PR DESCRIPTION
Release mouse in-case the escape shortcut was pressed while mouse was captured.

Moved the check outside of the `if (m_somethingHasChanged)` check so the mouse is released regardless of whether or not something has changed