### PR TITLE
fix build on Linux if CMAKE_INSTALL_LIBDIR is an absolute path

### DIFF
--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -27,7 +27,11 @@ function( InstallSharedLibrary )
             if(UNIX AND NOT APPLE)
                 # this is a an hack to restore install ability on linux systems
                 # TODO this should not be the right way for managing install probably
-                set( destination "${destination}/${CMAKE_INSTALL_LIBDIR}/")
+                if (IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
+                    set( destination "${CMAKE_INSTALL_LIBDIR}")
+                else()
+                    set( destination "${destination}/${CMAKE_INSTALL_LIBDIR}/")
+                endif()
             endif()
 
 		_InstallSharedTarget(


### PR DESCRIPTION
Does what it says on the tin. If CMAKE_INSTALL_LIBDIR is an absolute path, put the libraries there instead of prefixing it with the destination and incorrectly putting the libraries as a subdirectory of the install directory.

Probably worth re-evaluating the concept of multiple install destinations on Linux, as it does not make too much sense with absolute install paths, but this fixes the build for my use case of CloudCompare on NixOS.