### PR TITLE
Fix qCC_db typos

### DIFF
--- a/libs/CCPluginAPI/include/ccOverlayDialog.h
+++ b/libs/CCPluginAPI/include/ccOverlayDialog.h
@@ -60,7 +60,7 @@ public:
 	//! Adds a keyboard shortcut (single key) that will be overridden from the associated window
 	/** When an overridden key is pressed, the shortcutTriggered(int) signal is emitted.
 	**/
-	void addOverridenShortcut(Qt::Key key);
+	void addOverriddenShortcut(Qt::Key key);
 
 	//! Returns whether the tool is currently started or not
 	bool started() const { return m_processing; }
@@ -73,7 +73,7 @@ signals:
 	void processFinished(bool accepted);
 
 	//! Signal emitted when an overridden key shortcut is pressed
-	/** See ccOverlayDialog::addOverridenShortcut
+	/** See ccOverlayDialog::addOverriddenShortcut
 	**/
 	void shortcutTriggered(int key);
 

--- a/libs/CCPluginAPI/src/ccColorScaleEditorWidget.cpp
+++ b/libs/CCPluginAPI/src/ccColorScaleEditorWidget.cpp
@@ -609,7 +609,7 @@ void ccColorScaleEditorWidget::onPointClicked(double relativePos)
 		}
 	}
 
-	//determine the new slider defaut color
+	//determine the new slider default color
 	QColor color = Qt::white;
 	if (m_sliders->size() > 1)
 	{

--- a/libs/CCPluginAPI/src/ccOverlayDialog.cpp
+++ b/libs/CCPluginAPI/src/ccOverlayDialog.cpp
@@ -125,7 +125,7 @@ void ccOverlayDialog::reject()
 	stop(false);
 }
 
-void ccOverlayDialog::addOverridenShortcut(Qt::Key key)
+void ccOverlayDialog::addOverriddenShortcut(Qt::Key key)
 {
 	m_overriddenKeys.push_back(key);
 }

--- a/libs/qCC_db/include/ccCameraSensor.h
+++ b/libs/qCC_db/include/ccCameraSensor.h
@@ -288,7 +288,7 @@ public: //coordinate systems conversion methods
 
 	//! Apply the Brown's lens correction to the real projection (through a lens) of a 3D point in the image
 	/**	\warning Only works with Brown's distortion model for now (see BrownDistortionParameters).
-		\param real real 2D coordinates of a pixel (asumming that this pixel coordinate is obtained after projection through a lens) (input) !! Note that the first index is (0,0) and the last (width-1,height-1) !!
+		\param real real 2D coordinates of a pixel (assuming that this pixel coordinate is obtained after projection through a lens) (input) !! Note that the first index is (0,0) and the last (width-1,height-1) !!
 		\param ideal after applying lens correction (output) --> !! Note that the first index is (0,0) and the last (width-1,height-1) !!
 	**/
 	bool fromRealImCoordToIdealImCoord(const CCVector2& real, CCVector2& ideal) const;
@@ -460,7 +460,7 @@ public: //misc
 
 	//! Compute the coefficients of the 6 planes frustum in the global coordinates system (normal vector are headed the frustum inside), the edges direction vectors and the frustum center
 	/** \param planeCoefficients coefficients of the six planes
-		\param edges direction vectors of the frustum edges (there are 12 edges but some of them are colinear)
+		\param edges direction vectors of the frustum edges (there are 12 edges but some of them are collinear)
 		\param ptsFrustum the 8 frustum corners in the global coordinates system
 		\param center center of the the frustum circumscribed sphere
 		\return success
@@ -554,7 +554,7 @@ public:
 		return CELL_OUTSIDE_FRUSTUM;
 	}
 
-	//! Compute intersection between the octree and a frustum and send back the indices of 3D points inside the frustum or in cells interescting it.
+	//! Compute intersection between the octree and a frustum and send back the indices of 3D points inside the frustum or in cells intersecting it.
 	/** Every cells of each level of the octree will be classified as INSIDE, OUTSIDE or INTERSECTING the frustum.
 		Their truncated code are then stored in m_cellsInFrustum (for cells INSIDE) or m_cellsIntersectFrustum (for
 		cells INTERSECTING).

--- a/libs/qCC_db/include/ccClipBox.h
+++ b/libs/qCC_db/include/ccClipBox.h
@@ -35,8 +35,8 @@ class QCC_DB_LIB_API ccClipBox : public QObject, public ccHObject, public ccInte
 public:
 
 	//! Default constructor
-	/** \parma name entity name (optional)
-		\param uniqueID unique ID (handle with care)
+	/** \param name entity name (optional)
+	    \param uniqueID unique ID (handle with care)
 	**/
 	ccClipBox(QString name = QString("Clipping box"), unsigned uniqueID = ccUniqueIDGenerator::InvalidUniqueID);
 

--- a/libs/qCC_db/include/ccColorScalesManager.h
+++ b/libs/qCC_db/include/ccColorScalesManager.h
@@ -53,7 +53,7 @@ public:
 							BROWN_YELLOW	=	11,		/**< Brown-Yellow */
 							YELLOW_BROWN	=	12,		/**< Yellow-Brown */
 							TOPO_LANDSERF	=	13,		/**< Topo Landserf (quartile) */
-							HIGH_CONTRAST	=	14		/**< High constrast */
+							HIGH_CONTRAST	=	14		/**< High contrast */
 	};
 
 	//! Returns a pre-defined color scale UUID

--- a/libs/qCC_db/include/ccCustomObject.h
+++ b/libs/qCC_db/include/ccCustomObject.h
@@ -45,11 +45,11 @@ public:
 	//! Returns the default key for the "class name" metadata
 	/** See ccHObject::New.
 	**/
-	static QString DefautMetaDataClassName() { return QString("class_name"); }
+	static QString DefaultMetaDataClassName() { return QString("class_name"); }
 	//! Returns the default key for the "plugin name" metadata
 	/** See ccHObject::New.
 	**/
-	static QString DefautMetaDataPluginName() { return QString("plugin_name"); }
+	static QString DefaultMetaDataPluginName() { return QString("plugin_name"); }
 };
 
 //! Custom leaf object

--- a/libs/qCC_db/include/ccDrawableObject.h
+++ b/libs/qCC_db/include/ccDrawableObject.h
@@ -58,9 +58,9 @@ public:  //drawing and drawing options
 	//! Toggles visibility
 	inline virtual void toggleVisibility() { setVisible(!isVisible()); }
 
-	//! Returns whether visibilty is locked or not
+	//! Returns whether visibility is locked or not
 	inline virtual bool isVisiblityLocked() const { return m_lockedVisibility; }
-	//! Locks/unlocks visibilty
+	//! Locks/unlocks visibility
 	/** If visibility is locked, the user won't be able to modify it
 		(via the properties tree for instance).
 	**/
@@ -72,7 +72,7 @@ public:  //drawing and drawing options
 	inline virtual void setSelected(bool state) { m_selected = state; }
 
 	//! Returns main OpenGL parameters for this entity
-	/** These parameters are deduced from the visiblity states
+	/** These parameters are deduced from the visibility states
 		of its different features (points, normals, etc.).
 		\param params a glDrawParams structure
 	**/
@@ -217,7 +217,7 @@ public: //Transformation matrix management (for display only)
 	**/
 	virtual void resetGLTransformation();
 
-	//! Mutliplies (left) current GL transformation by a rotation matrix
+	//! Multiplies (left) current GL transformation by a rotation matrix
 	/** 'GLtrans = M * GLtrans'
 		Note: GL transformation is automatically enabled.
 		See ccDrawableObject::setGLTransformation.

--- a/libs/qCC_db/include/ccDrawableObject.h
+++ b/libs/qCC_db/include/ccDrawableObject.h
@@ -59,7 +59,7 @@ public:  //drawing and drawing options
 	inline virtual void toggleVisibility() { setVisible(!isVisible()); }
 
 	//! Returns whether visibility is locked or not
-	inline virtual bool isVisiblityLocked() const { return m_lockedVisibility; }
+	inline virtual bool isVisibilityLocked() const { return m_lockedVisibility; }
 	//! Locks/unlocks visibility
 	/** If visibility is locked, the user won't be able to modify it
 		(via the properties tree for instance).
@@ -137,7 +137,7 @@ public: //Temporary color
 	//! Returns whether colors are currently overridden by a temporary (unique) color
 	/** See ccDrawableObject::setTempColor.
 	**/
-	inline virtual bool isColorOverriden() const { return m_colorIsOverriden; }
+	inline virtual bool isColorOverridden() const { return m_colorIsOverridden; }
 
 	//! Returns current temporary (unique) color
 	inline virtual const ccColor::Rgba& getTempColor() const { return m_tempColor; }
@@ -155,7 +155,7 @@ public: //Temporary color
 	virtual void setTempColor(const ccColor::Rgb& col, bool autoActivate = true);
 
 	//! Set temporary color activation state
-	inline virtual void enableTempColor(bool state) { m_colorIsOverriden = state; }
+	inline virtual void enableTempColor(bool state) { m_colorIsOverridden = state; }
 
 public: //associated display management
 
@@ -269,7 +269,7 @@ protected: //members
 	//! Temporary (unique) color
 	ccColor::Rgba m_tempColor;
 	//! Temporary (unique) color activation state
-	bool m_colorIsOverriden;
+	bool m_colorIsOverridden;
 
 	//! Current GL transformation
 	/** See ccDrawableObject::setGLTransformation.

--- a/libs/qCC_db/include/ccDrawableObject.h
+++ b/libs/qCC_db/include/ccDrawableObject.h
@@ -102,7 +102,7 @@ public: //scalar fields
 	inline virtual bool hasDisplayedScalarField() const { return false; }
 
 	//! Returns whether one or more scalar fields are instantiated
-	/** WARNING: doesn't mean a scalar field is currently displayed
+	/** \warning doesn't mean a scalar field is currently displayed
 		(see ccDrawableObject::hasDisplayedScalarField).
 	**/
 	inline virtual bool hasScalarFields() const  { return false; }

--- a/libs/qCC_db/include/ccExternalFactory.h
+++ b/libs/qCC_db/include/ccExternalFactory.h
@@ -25,7 +25,7 @@
 #include <QMap>
 
 /**  Provides new objects with an external factory
-  *  This is intendend to be used into plugins.
+  *  This is intended to be used into plugins.
   *  Each plugin may define a new factory by subclassing this class.
   *  Factories are then stored in a unique container and used to load custom types.
  **/
@@ -54,10 +54,10 @@ public:
 		//! Shared pointer type
 		typedef QSharedPointer<Container> Shared;
 
-		//! Returns the unqiue static instance of the external factories container
+		//! Returns the unique static instance of the external factories container
 		static Container::Shared GetUniqueInstance();
 
-		//! Sets the unqiue static instance of the external factories container
+		//! Sets the unique static instance of the external factories container
 		/** A default static instance is provided for convenience but another user defined instance
 			can be declared here instead.
 		**/

--- a/libs/qCC_db/include/ccGBLSensor.h
+++ b/libs/qCC_db/include/ccGBLSensor.h
@@ -112,7 +112,7 @@ public: //setters and getters
 	inline PointCoordinateType getPitchStep() const { return m_deltaPhi; }
 
 	//! Returns whether the pitch angles are shifted (i.e. between [0 ; 2pi] instead of [-pi ; pi])
-	bool picthIsShifted() const { return m_pitchAnglesAreShifted; }
+	bool pitchIsShifted() const { return m_pitchAnglesAreShifted; }
 
 	//! Sets the yaw scanning limits
 	/** \param minTheta min yaw angle (in radians)

--- a/libs/qCC_db/include/ccGBLSensor.h
+++ b/libs/qCC_db/include/ccGBLSensor.h
@@ -38,7 +38,7 @@ public:
 
 	//! The order of inner-rotations of the sensor (body/mirrors)
 	/** Either the first rotation is made around the Z axis (yaw) then around the lateral
-		axis (pitch) as most scanners do today (Leica, Riegl, Faro, etc.). Othewise the
+		axis (pitch) as most scanners do today (Leica, Riegl, Faro, etc.). Otherwise the
 		opposite order is used (as the very old Mensi Soisic).
 	**/
 	enum ROTATION_ORDER {	YAW_THEN_PITCH = 0,
@@ -69,7 +69,7 @@ public:
 
 	//! Determines a 3D point "visibility" relatively to the sensor field of view
 	/** Relies on the sensor associated depth map (see ccGBLSensor::computeDepthBuffer).
-		The depth map is used to determine the "visiblity" of a 3D point relatively to
+		The depth map is used to determine the "visibility" of a 3D point relatively to
 		the laser scanner field of view. This can be useful for filtering out points
 		that shouldn't be compared while computing the distances between two point
 		clouds for instance (for more information on this	particular topic, refer to

--- a/libs/qCC_db/include/ccGBLSensor.h
+++ b/libs/qCC_db/include/ccGBLSensor.h
@@ -80,7 +80,7 @@ public:
 	unsigned char checkVisibility(const CCVector3& P) const override;
 
 	//! Computes angular parameters automatically (all but the angular steps!)
-	/** WARNING: this method uses the cloud global iterator.
+	/** \warning this method uses the cloud global iterator.
 	**/
 	bool computeAutoParameters(CCCoreLib::GenericCloud* theCloud);
 
@@ -179,7 +179,7 @@ public: //projection tools
 	using NormalGrid = std::vector<CCVector3>;
 
 	//! Projects a set of point cloud normals in the sensor world
-	/** WARNING: this method uses the cloud global iterator
+	/** \warning this method uses the cloud global iterator
 		\param cloud a point cloud
 		\param norms the normals vectors (should have the same size and order as the point cloud)
 		\param posIndex (optional) sensor position index (see ccIndexedTransformationBuffer)
@@ -193,7 +193,7 @@ public: //projection tools
 	using ColorGrid = std::vector<ccColor::Rgb>;
 
 	//! Projects a set of point cloud colors in the sensor frame defined by this instance
-	/** WARNING: this method uses the cloud global iterator
+	/** \warning this method uses the cloud global iterator
 		\param cloud a point cloud
 		\param rgbColors the RGB colors (should have the same size and order as the point cloud)
 		\return a set of RGB colors organized as a bidimensional grid (same size as the depth buffer)
@@ -204,7 +204,7 @@ public: //projection tools
 public: //depth buffer management
 
 	//! Projects a point cloud along the sensor point of view defined by this instance
-	/** WARNING: this method uses the cloud global iterator
+	/** \warning this method uses the cloud global iterator
 		\param cloud a point cloud
 		\param errorCode error code in case the returned cloud is 0
 		\param projectedCloud optional (empty) cloud to store the projected points

--- a/libs/qCC_db/include/ccGLDrawContext.h
+++ b/libs/qCC_db/include/ccGLDrawContext.h
@@ -114,9 +114,9 @@ struct ccGLDrawContext
 	unsigned minLODPointCount;
 	//! Current level for LOD display
 	unsigned char currentLODLevel;
-	//! Wheter more points are available or not at the current level
+	//! Whether more points are available or not at the current level
 	bool moreLODPointsAvailable;
-	//! Wheter higher levels are available or not
+	//! Whether higher levels are available or not
 	bool higherLODLevelsAvailable;
 
 	//! Whether to decimate big meshes when rotating the camera
@@ -153,7 +153,7 @@ struct ccGLDrawContext
 	//! Stereo pass index
 	unsigned stereoPassIndex;
 
-	//! Whether to draw rounded points (instead of sqaures)
+	//! Whether to draw rounded points (instead of squares)
 	bool drawRoundedPoints;
 
 	//Default constructor

--- a/libs/qCC_db/include/ccGLMatrixTpl.h
+++ b/libs/qCC_db/include/ccGLMatrixTpl.h
@@ -648,13 +648,13 @@ public:
 	//! Returns a const pointer to internal data
 	inline const T* data() const { return m_mat; }
 
-	//! Retruns a pointer to internal translation
+	//! Returns a pointer to internal translation
 	/** Translation corresponds to the beginning of the
 		third column of the matrix.
 	**/
 	inline T* getTranslation() { return m_mat+12; }
 
-	//! Retruns a const pointer to internal translation
+	//! Returns a const pointer to internal translation
 	/** Translation corresponds to the beginning of the
 		third column of the matrix.
 	**/

--- a/libs/qCC_db/include/ccGenericGLDisplay.h
+++ b/libs/qCC_db/include/ccGenericGLDisplay.h
@@ -125,7 +125,7 @@ public:
 		\param y vertical position of string origin
 		\param align alignment position flags
 		\param bkgAlpha background transparency (0 by default)
-		\param rgbColor text color (optional)
+		\param color text color (optional)
 		\param font optional font (otherwise default one will be used)
 	**/
 	virtual void displayText(	QString text,
@@ -140,7 +140,7 @@ public:
 	/** This method should be called solely during 3D pass rendering (see paintGL).
 		\param str string
 		\param pos3D 3D position of string origin
-		\param rgbColor color (optional: if let to 0, default text rendering color is used)
+		\param color RGBA color (optional: if let to 0, default text rendering color is used)
 		\param font font (optional)
 	**/
 	virtual void display3DLabel(const QString& str,

--- a/libs/qCC_db/include/ccGenericGLDisplay.h
+++ b/libs/qCC_db/include/ccGenericGLDisplay.h
@@ -98,12 +98,12 @@ public:
 	**/
 	virtual void deprecate3DLayer() = 0;
 
-	//! Returns defaul text display font
+	//! Returns default text display font
 	/** Warning: already takes rendering zoom into account!
 	**/
 	virtual QFont getTextDisplayFont() const = 0;
 
-	//! Returns defaul label display font
+	//! Returns default label display font
 	/** Warning: already takes rendering zoom into account!
 	**/
 	virtual QFont getLabelDisplayFont() const = 0;

--- a/libs/qCC_db/include/ccGenericPointCloud.h
+++ b/libs/qCC_db/include/ccGenericPointCloud.h
@@ -102,7 +102,7 @@ public:
 	//! Computes the cloud octree
 	/** The octree bounding-box is automatically defined as the smallest
 		3D cube that totally encloses the cloud.
-		WARNING: any previously attached octree will be deleted,
+		\warning any previously attached octree will be deleted,
 				 even if the new octree computation failed.
 		\param progressCb the caller can get some notification of the process progress through this callback mechanism (see CCCoreLib documentation)
 		\param autoAddChild whether to automatically add the computed octree as child of this cloud or not
@@ -128,35 +128,35 @@ public:
 	//! Returns color corresponding to a given scalar value
 	/** The returned value depends on the current scalar field display parameters.
 		It may even be 0 if the value shouldn't be displayed.
-		WARNING: scalar field must be enabled! (see ccDrawableObject::hasDisplayedScalarField)
+		\warning scalar field must be enabled! (see ccDrawableObject::hasDisplayedScalarField)
 	**/
 	virtual const ccColor::Rgb* geScalarValueColor(ScalarType d) const = 0;
 
 	//! Returns color corresponding to a given point associated scalar value
 	/** The returned value depends on the current scalar field display parameters.
 		It may even be 0 if the value shouldn't be displayed.
-		WARNING: scalar field must be enabled! (see ccDrawableObject::hasDisplayedScalarField)
+		\warning scalar field must be enabled! (see ccDrawableObject::hasDisplayedScalarField)
 	**/
 	virtual const ccColor::Rgb* getPointScalarValueColor(unsigned pointIndex) const = 0;
 
 	//! Returns scalar value associated to a given point
 	/** The returned value is taken from the current displayed scalar field
-		WARNING: scalar field must be enabled! (see ccDrawableObject::hasDisplayedScalarField)
+		\warning scalar field must be enabled! (see ccDrawableObject::hasDisplayedScalarField)
 	**/
 	virtual ScalarType getPointDisplayedDistance(unsigned pointIndex) const = 0;
 
 	//! Returns color corresponding to a given point
-	/** WARNING: color array must be enabled! (see ccDrawableObject::hasColors)
+	/** \warning color array must be enabled! (see ccDrawableObject::hasColors)
 	**/
 	virtual const ccColor::Rgba& getPointColor(unsigned pointIndex) const = 0;
 
 	//! Returns compressed normal corresponding to a given point
-	/** WARNING: normals array must be enabled! (see ccDrawableObject::hasNormals)
+	/** \warning normals array must be enabled! (see ccDrawableObject::hasNormals)
 	**/
 	virtual const CompressedNormType& getPointNormalIndex(unsigned pointIndex) const = 0;
 
 	//! Returns normal corresponding to a given point
-	/** WARNING: normals array must be enabled! (see ccDrawableObject::hasNormals)
+	/** \warning normals array must be enabled! (see ccDrawableObject::hasNormals)
 	**/
 	virtual const CCVector3& getPointNormal(unsigned pointIndex) const = 0;
 
@@ -228,7 +228,7 @@ public:
 	virtual CCCoreLib::ReferenceCloud* crop(const ccBBox& box, bool inside = true) = 0;
 
 	//! Multiplies all coordinates by constant factors (one per dimension)
-	/** WARNING: attached octree may be deleted.
+	/** \warning attached octree may be deleted.
 		\param fx multiplication factor along the X dimension
 		\param fy multiplication factor along the Y dimension
 		\param fz multiplication factor along the Z dimension

--- a/libs/qCC_db/include/ccGenericPointCloud.h
+++ b/libs/qCC_db/include/ccGenericPointCloud.h
@@ -49,7 +49,7 @@ class ccOctreeProxy;
 /** A generic point cloud can have multiples features:
 	- colors (RGB)
 	- normals (compressed)
-	- an octree strucutre
+	- an octree structure
 	- visibility information per point (to hide/display subsets of points)
 **/
 class QCC_DB_LIB_API ccGenericPointCloud : public ccShiftedObject,  public CCCoreLib::GenericIndexedCloudPersist
@@ -90,7 +90,7 @@ public:
 	***************************************************/
 
 	//! Clears the entity from all its points and features
-	/** Display parameters are also reseted to their default values.
+	/** Display parameters are also reset to their default values.
 	**/
 	virtual void clear();
 
@@ -170,28 +170,28 @@ public:
 	**/
 	using VisibilityTableType = std::vector<unsigned char>;
 	
-	//! Returns associated visiblity array
+	//! Returns associated visibility array
 	virtual inline VisibilityTableType& getTheVisibilityArray() { return m_pointsVisibility; }
 
-	//! Returns associated visiblity array (const version)
+	//! Returns associated visibility array (const version)
 	virtual inline const VisibilityTableType& getTheVisibilityArray() const { return m_pointsVisibility; }
 
-	//! Returns a ReferenceCloud equivalent to the visiblity array
+	//! Returns a ReferenceCloud equivalent to the visibility array
 	/** \param visTable visibility table (optional, otherwise the cloud's default one will be used)
 		\param silent don't issue warnings if no visible point is present
 		\return the visible points as a ReferenceCloud
 	**/
 	virtual CCCoreLib::ReferenceCloud* getTheVisiblePoints(const VisibilityTableType* visTable = nullptr, bool silent = false) const;
 	
-	//! Returns whether the visiblity array is allocated or not
+	//! Returns whether the visibility array is allocated or not
 	virtual bool isVisibilityTableInstantiated() const;
 
-	//! Resets the associated visiblity array
+	//! Resets the associated visibility array
 	/** Warning: allocates the array if it was not done yet!
 	**/
 	virtual bool resetVisibilityArray();
 
-	//! Inverts the visiblity array
+	//! Inverts the visibility array
 	virtual void invertVisibilityArray();
 
 	//! Erases the points visibility information
@@ -219,9 +219,9 @@ public:
 	//! Applies a rigid transformation (rotation + translation)
 	virtual void applyRigidTransformation(const ccGLMatrix& trans) = 0;
 
-	//! Crops the cloud inside (or outside) a boundig box
+	//! Crops the cloud inside (or outside) a bounding box
 	/** \warning Always returns a selection (potentially empty) if successful.
-		\param box croping box
+		\param box cropping box
 		\param inside whether selected points are inside or outside the box
 		\return points falling inside (or outside) as a selection
 	**/

--- a/libs/qCC_db/include/ccHObject.h
+++ b/libs/qCC_db/include/ccHObject.h
@@ -181,7 +181,7 @@ public: //children management
 		want to avoid deletion).
 	**/
 	//! Detaches all children
-	void detatchAllChildren();
+	void detachAllChildren();
 
 	void removeChild(ccHObject* child);
 	//! Removes a specific child given its index

--- a/libs/qCC_db/include/ccHObject.h
+++ b/libs/qCC_db/include/ccHObject.h
@@ -282,7 +282,7 @@ public: //display
 	//Inherited from ccDrawableObject
 	void draw(CC_DRAW_CONTEXT& context) override;
 
-	//! Returns the absolute transformation (i.e. the actual displayed GL transforamtion) of an entity
+	//! Returns the absolute transformation (i.e. the actual displayed GL transformation) of an entity
 	/** \param[out] trans absolute transformation
 		\return whether a GL transformation is actually enabled or not
 	**/
@@ -395,7 +395,7 @@ public: //display
 	//! Returns selection behavior
 	virtual inline SelectionBehavior getSelectionBehavior() const { return m_selectionBehavior; }
 
-	//! Returns object unqiue ID used for display
+	//! Returns object unique ID used for display
 	virtual inline unsigned getUniqueIDForDisplay() const { return getUniqueID(); }
 
 	//! Returns the transformation 'history' matrix

--- a/libs/qCC_db/include/ccHObject.h
+++ b/libs/qCC_db/include/ccHObject.h
@@ -31,7 +31,7 @@ public: //construction
 
 	//! Default constructor
 	/** \param name object name (optional)
-		\param uniqueID unique ID (handle with care)
+	    \param uniqueID unique ID (handle with care)
 	**/
 	ccHObject(const QString& name = QString(), unsigned uniqueID = ccUniqueIDGenerator::InvalidUniqueID);
 	//! Copy constructor
@@ -41,7 +41,7 @@ public: //construction
 	~ccHObject() override;
 
 	//! Static factory
-	/** Warning: objects depending on other structures (such as meshes 
+	/** \warning Objects depending on other structures (such as meshes
 		or polylines that should be linked with point clouds playing the
 		role of vertices) are returned 'naked'.
 		\param objectType object type
@@ -386,7 +386,7 @@ public: //display
 							 SELECTION_IGNORED };
 
 	//! Sets selection behavior (when displayed)
-	/** WARNING: SELECTION_FIT_BBOX relies on the
+	/** \warning SELECTION_FIT_BBOX relies on the
 		'ccDrawableObject::getFitBB' method (which
 		is not supported by all entities).
 	**/

--- a/libs/qCC_db/include/ccIndexedTransformationBuffer.h
+++ b/libs/qCC_db/include/ccIndexedTransformationBuffer.h
@@ -75,14 +75,14 @@ public:
 										double maxIndexDistForInterpolation = DBL_MAX) const;
 	
 	//! [Display option] Returns whether trihedrons should be displayed or not (otherwise only points or a polyline)
-	bool triherdonsShown() const { return m_showTrihedrons; }
+	bool trihedronsShown() const { return m_showTrihedrons; }
 	//! [Display option] Sets whether trihedrons should be displayed or not (otherwise only points or a polyline)
-	void showTriherdons(bool state) { m_showTrihedrons = state; }
+	void showTrihedrons(bool state) { m_showTrihedrons = state; }
 
 	//! [Display option] Returns trihedron display size
-	float triherdonsDisplayScale() const { return m_trihedronsScale; }
+	float trihedronsDisplayScale() const { return m_trihedronsScale; }
 	//! [Display option] Sets trihedron display size
-	void setTriherdonsDisplayScale(float scale) { m_trihedronsScale = scale; }
+	void setTrihedronsDisplayScale(float scale) { m_trihedronsScale = scale; }
 
 	//! [Display option] Returns whether the path should be displayed as a polyline or not (otherwise only points)
 	bool isPathShownAsPolyline() const { return m_showAsPolyline; }

--- a/libs/qCC_db/include/ccMaterial.h
+++ b/libs/qCC_db/include/ccMaterial.h
@@ -119,7 +119,7 @@ public:
 	GLuint getTextureID() const;
 
 	//! Helper: makes all active GL light sources neutral (i.e. 'gray')
-	/** WARNING: an OpenGL context must be active!
+	/** \warning an OpenGL context must be active!
 	**/
 	static void MakeLightsNeutral(const QOpenGLContext* context);
 

--- a/libs/qCC_db/include/ccMesh.h
+++ b/libs/qCC_db/include/ccMesh.h
@@ -398,10 +398,10 @@ public:
 	void transformTriNormals(const ccGLMatrix& trans);
 
 	//! Default octree level for the 'mergeDuplicatedVertices' algorithm
-	static const unsigned char DefaultMergeDulicateVerticesLevel = 10;
+	static const unsigned char DefaultMergeDuplicateVerticesLevel = 10;
 
 	//! Merges duplicated vertices
-	bool mergeDuplicatedVertices(unsigned char octreeLevel = DefaultMergeDulicateVerticesLevel, QWidget* parentWidget = nullptr);
+	bool mergeDuplicatedVertices(unsigned char octreeLevel = DefaultMergeDuplicateVerticesLevel, QWidget* parentWidget = nullptr);
 
 protected: //methods
 

--- a/libs/qCC_db/include/ccMesh.h
+++ b/libs/qCC_db/include/ccMesh.h
@@ -203,7 +203,7 @@ public:
 		sure to reserve the  necessary amount of memory with
 		this method. This method reserves memory for as many
 		normals indexes triplets as the number of triangles
-		in the mesh (effictively stored or reserved - a call to
+		in the mesh (effectively stored or reserved - a call to
 		ccMesh::reserve prior to this one is mandatory).
 		\return true if ok, false if there's not enough memory
 	**/
@@ -255,7 +255,7 @@ public:
 		to reserve the  necessary amount of memory with this
 		method. This method reserves memory for as many
 		material descriptors as the number of triangles in
-		the mesh (effictively stored or reserved - a call to
+		the mesh (effectively stored or reserved - a call to
 		ccMesh::reserve prior to this one is mandatory).
 		\return true if ok, false if there's not enough memory
 	**/
@@ -309,7 +309,7 @@ public:
 		sure to reserve the  necessary amount of memory with
 		this method. This method reserves memory for as many
 		tex coords indexes triplets as the number of triangles
-		in the mesh (effictively stored or reserved - a call to
+		in the mesh (effectively stored or reserved - a call to
 		ccMesh::reserve prior to this one is mandatory).
 		\return true if ok, false if there's not enough memory
 	**/

--- a/libs/qCC_db/include/ccObject.h
+++ b/libs/qCC_db/include/ccObject.h
@@ -178,7 +178,7 @@ public:
 
 	//! Default constructor
 	/** \param name object name (optional)
-		\param uniqueID unique ID (handle with care! Will be auto generated if equal to ccUniqueIDGenerator::InvalidUniqueID)
+	    \param uniqueID unique ID (handle with care! Will be auto generated if equal to ccUniqueIDGenerator::InvalidUniqueID)
 	**/
 	ccObject(const QString& name = QString(), unsigned uniqueID = ccUniqueIDGenerator::InvalidUniqueID);
 
@@ -205,7 +205,7 @@ public:
 	virtual inline unsigned getUniqueID() const { return m_uniqueID; }
 
 	//! Changes unique ID
-	/** WARNING: HANDLE WITH CARE!
+	/** \warning HANDLE WITH CARE!
 		Updates persistent settings (last unique ID) if necessary.
 	**/
 	virtual void setUniqueID(unsigned ID);

--- a/libs/qCC_db/include/ccOctree.h
+++ b/libs/qCC_db/include/ccOctree.h
@@ -85,9 +85,9 @@ public: //RENDERING
 
 	//! Octree displaying methods
 	enum DisplayMode {
-		WIRE = 0,					/**< The octree is displayed as wired boxes (one box per cell) */
-		MEAN_POINTS = 1,			/**< The octree is displayed as points (one point per cell = the center of gravity of the points lying in it) */
-		MEAN_CUBES = 2				/**< The octree is displayed as plain 3D cubes (one cube per cell) */
+		WIRE = 0,			/**< The octree is displayed as wired boxes (one box per cell) */
+		MEAN_POINTS = 1,		/**< The octree is displayed as points (one point per cell = the center of gravity of the points lying in it) */
+		MEAN_CUBES = 2			/**< The octree is displayed as plain 3D cubes (one cube per cell) */
 	};
 	//! Returns the currently display mode
 	DisplayMode getDisplayMode() const { return m_displayMode; }

--- a/libs/qCC_db/include/ccPointCloud.h
+++ b/libs/qCC_db/include/ccPointCloud.h
@@ -57,7 +57,7 @@ const unsigned CC_MAX_NUMBER_OF_POINTS_PER_CLOUD = 2000000000; //we must keep it
 	- colors (RGB)
 	- normals (compressed)
 	- scalar fields
-	- an octree strucutre
+	- an octree structure
 	- per-point visibility information (to hide/display subsets of points)
 	- other children objects (meshes, calibrated pictures, etc.)
 **/
@@ -68,7 +68,7 @@ public:
 	using BaseClass = CCCoreLib::PointCloudTpl<ccGenericPointCloud, QString>;
 
 	//! Default constructor
-	/** Creates an empty cloud without any feature. Each of them shoud be
+	/** Creates an empty cloud without any feature. Each of them should be
 		specifically instantiated/created (once the points have been
 		added to this cloud, at least partially).
 		\param name cloud name (optional)
@@ -144,7 +144,7 @@ public: //clone, copy, etc.
 public: //features deletion/clearing
 
 	//! Clears the entity from all its points and features
-	/** Display parameters are also reseted to their default values.
+	/** Display parameters are also reset to their default values.
 	**/
 	void clear() override;
 
@@ -184,14 +184,14 @@ public: //features allocation/resize
 		be sure to reserve the necessary amount of memory
 		with this method. This method reserves memory for as
 		many colors as the number of points in the cloud
-		(effictively stored or reserved).
+		(effectively stored or reserved).
 		\return true if ok, false if there's not enough memory
 	**/
 	bool reserveTheRGBTable();
 
 	//! Resizes the RGB colors array
 	/** If possible, the colors array is resized to fit exactly the number
-		of points in the cloud (effictively stored or reserved). If the
+		of points in the cloud (effectively stored or reserved). If the
 		new size is inferior to the actual one, the last elements will be
 		deleted. Otherwise, the array is filled with zeros (default behavior)
 		or "white" colors (is fillWithWhite).
@@ -206,14 +206,14 @@ public: //features allocation/resize
 		be sure to reserve the necessary amount of memory
 		with this method. This method reserves memory for as
 		many normals as the number of points in the cloud
-		(effictively stored or reserved).
+		(effectively stored or reserved).
 		\return true if ok, false if there's not enough memory
 	**/
 	bool reserveTheNormsTable();
 
 	//! Resizes the compressed normals array
 	/** If possible, the normals array is resized to fit exactly the number
-		of points in the cloud (effictively stored or reserved). If the
+		of points in the cloud (effectively stored or reserved). If the
 		new size is inferior to the actual one, the last elements will be
 		deleted. Otherwise, the array is filled with blank elements.
 		WARNING: don't try to "add" any element on a resized array...
@@ -230,7 +230,7 @@ public: //features allocation/resize
 
 	//! Resizes all the active features arrays
 	/** This method is meant to be called after having increased the cloud
-		population (if the final number of insterted point is lower than the
+		population (if the final number of inserted point is lower than the
 		reserved size). Otherwise, it fills all new elements with blank values.
 		\return true if ok, false if there's not enough memory
 	**/
@@ -340,7 +340,7 @@ public: //associated (scan) grid structure
 	size_t gridCount() const { return m_grids.size(); }
 	//! Returns an associated grid
 	inline Grid::Shared& grid(size_t gridIndex) { return m_grids[gridIndex]; }
-	//! Returns an associated grid (const verson)
+	//! Returns an associated grid (const version)
 	inline const Grid::Shared& grid(size_t gridIndex) const { return m_grids[gridIndex]; }
 	//! Adds an associated grid
 	inline bool addGrid(Grid::Shared grid) { try{ m_grids.push_back(grid); } catch (const std::bad_alloc&) { return false; } return true; }
@@ -587,7 +587,7 @@ public: //other methods
 	**/
 	bool colorize(float r, float g, float b, float a = 1.0f);
 
-	//! Assigns color to points proportionnaly to their 'height'
+	//! Assigns color to points proportionally to their 'height'
 	/** Height is defined wrt to the specified dimension (heightDim).
 		Color array is automatically allocated if necessary.
 		\param heightDim ramp dimension (0:X, 1:Y, 2:Z)
@@ -711,7 +711,7 @@ public: //other methods
 
 	//! Crops the cloud inside (or outside) a 2D polyline
 	/** \warning Always returns a selection (potentially empty) if successful.
-		\param poly croping polyline
+		\param poly cropping polyline
 		\param orthoDim dimension orthogonal to the plane in which the segmentation should occur (X=0, Y=1, Z=2)
 		\param inside whether selected points are inside or outside the polyline
 		\return points falling inside (or outside) as a selection
@@ -848,7 +848,7 @@ protected: // VBO
 
 public: //Level of Detail (LOD)
 
-	//! Intializes the LOD structure
+	//! Initializes the LOD structure
 	/** \return success
 	**/
 	bool initLOD();

--- a/libs/qCC_db/include/ccPointCloud.h
+++ b/libs/qCC_db/include/ccPointCloud.h
@@ -195,7 +195,7 @@ public: //features allocation/resize
 		new size is inferior to the actual one, the last elements will be
 		deleted. Otherwise, the array is filled with zeros (default behavior)
 		or "white" colors (is fillWithWhite).
-		WARNING: don't try to "add" any element on a resized array...
+		\warning don't try to "add" any element on a resized array...
 		\param fillWithWhite whether to fill new array elements with zeros (false) or white color (true)
 		\return true if ok, false if there's not enough memory
 	**/
@@ -216,7 +216,7 @@ public: //features allocation/resize
 		of points in the cloud (effectively stored or reserved). If the
 		new size is inferior to the actual one, the last elements will be
 		deleted. Otherwise, the array is filled with blank elements.
-		WARNING: don't try to "add" any element on a resized array...
+		\warning don't try to "add" any element on a resized array...
 		\return true if ok, false if there's not enough memory
 	**/
 	bool resizeTheNormsTable();
@@ -493,22 +493,22 @@ public: //other methods
 								unsigned char octreeLevel = 0);
 
 	//! Sets a particular point color
-	/** WARNING: colors must be enabled.
+	/** \warning colors must be enabled.
 	**/
 	void setPointColor(unsigned pointIndex, const ccColor::Rgba& col);
 
 	//! Sets a particular point color
-	/** WARNING: colors must be enabled.
+	/** \warning colors must be enabled.
 	**/
 	inline void setPointColor(unsigned pointIndex, const ccColor::Rgb& col) { setPointColor(pointIndex, ccColor::Rgba(col, ccColor::MAX)); }
 
 	//! Sets a particular point compressed normal
-	/** WARNING: normals must be enabled.
+	/** \warning normals must be enabled.
 	**/
 	void setPointNormalIndex(unsigned pointIndex, CompressedNormType norm);
 
 	//! Sets a particular point normal (shortcut)
-	/** WARNING: normals must be enabled.
+	/** \warning normals must be enabled.
 		Normal is automatically compressed before storage.
 	**/
 	void setPointNormal(unsigned pointIndex, const CCVector3& N);
@@ -560,8 +560,9 @@ public: //other methods
 
 	//! Pushes an RGB color on stack (shortcut)
 	/** \param r red component
-		\param g green component
-		\param b blue component
+	    \param g green component
+	    \param b blue component
+	    \param a alpha component
 	**/
 	inline void addColor(ColorCompType r, ColorCompType g, ColorCompType b, ColorCompType a = ccColor::MAX) { addColor(ccColor::Rgba(r, g, b, a)); }
 

--- a/libs/qCC_db/include/ccPointCloudInterpolator.h
+++ b/libs/qCC_db/include/ccPointCloudInterpolator.h
@@ -50,7 +50,7 @@ public:
 
 	//! Interpolate scalar fields from another cloud
 	static bool InterpolateScalarFieldsFrom(ccPointCloud* destCloud,
-											ccPointCloud* srccloud,
+											ccPointCloud* srcCloud,
 											const std::vector<int>& sfIndexes,
 											const Parameters& params,
 											CCCoreLib::GenericProgressCallback* progressCb = 0,

--- a/libs/qCC_db/include/ccPolyline.h
+++ b/libs/qCC_db/include/ccPolyline.h
@@ -172,12 +172,12 @@ public: //meta-data keys
 	static QString MetaKeyAbscissa()		{ return "profile.abscissa"; }
 	//! Meta data key (prefix): intersection point between profile and its generatrix
 	/** Expected value: 3D vector
-		\warning: must be followed by '.x', '.y' or '.z'
+		\warning must be followed by '.x', '.y' or '.z'
 	**/
 	static QString MetaKeyPrefixCenter()	{ return "profile.center"; }
 	//! Meta data key (prefix): generatrix orientation at the point of intersection with the profile
 	/** Expected value: 3D vector
-		\warning: must be followed by '.x', '.y' or '.z'
+		\warning must be followed by '.x', '.y' or '.z'
 	**/
 	static QString MetaKeyPrefixDirection()	{ return "profile.direction"; }
 

--- a/libs/qCC_db/include/ccPolyline.h
+++ b/libs/qCC_db/include/ccPolyline.h
@@ -196,10 +196,10 @@ protected:
 	//! Width of the line
 	PointCoordinateType m_width;
 
-	//! Whether poyline should be considered as 2D (true) or 3D (false)
+	//! Whether polyline should be considered as 2D (true) or 3D (false)
 	bool m_mode2D;
 
-	//! Whether poyline should draws itself in background (false) or foreground (true)
+	//! Whether polyline should draws itself in background (false) or foreground (true)
 	bool m_foreground;
 	
 	//! Whether vertices should be displayed or not

--- a/libs/qCC_db/include/ccScalarField.h
+++ b/libs/qCC_db/include/ccScalarField.h
@@ -101,20 +101,20 @@ public:
 	};
 
 	//! Access to the range of displayed values
-	/** Values outside of the [start;stop] intervale will either be grey
+	/** Values outside of the [start;stop] interval will either be grey
 		or invisible (see showNaNValuesInGrey).
 	**/
 	inline const Range& displayRange() const { return m_displayRange; }
 
 	//! Access to the range of saturation values
 	/** Relative color scales will only be applied to values inside the
-		[start;stop] intervale.
+		[start;stop] interval.
 	**/
 	inline const Range& saturationRange() const { return m_logScale ? m_logSaturationRange : m_saturationRange; }
 
 	//! Access to the range of log scale saturation values
 	/** Relative color scales will only be applied to values inside the
-		[start;stop] intervale.
+		[start;stop] interval.
 	**/
 	inline const Range& logSaturationRange() const { return m_logSaturationRange; }
 
@@ -193,7 +193,7 @@ public:
 	inline const Histogram& getHistogram() const { return m_histogram; }
 
 	//! Returns whether the scalar field in its current configuration MAY have 'hidden' values or not
-	/** 'Hidden' values are typically NaN values or values outside of the 'displayed' intervale
+	/** 'Hidden' values are typically NaN values or values outside of the 'displayed' interval
 		while those values are not displayed in grey (see ccScalarField::showNaNValuesInGrey).
 	**/
 	bool mayHaveHiddenValues() const;

--- a/libs/qCC_db/include/ccSensor.h
+++ b/libs/qCC_db/include/ccSensor.h
@@ -73,7 +73,7 @@ public:
 	void setPositions(ccIndexedTransformationBuffer* positions)  { m_posBuffer = positions; }
 
 	//! Adds a new position (shortcut)
-	/** \warning: may be slow as this method may sort the positions
+	/** \warning may be slow as this method may sort the positions
 		after each call (if the new index is lower than the last one pushed)
 	**/
 	bool addPosition(ccGLMatrix& trans, double index);

--- a/libs/qCC_db/include/ccSerializableObject.h
+++ b/libs/qCC_db/include/ccSerializableObject.h
@@ -39,13 +39,13 @@ class ccSerializableObject
 {
 public:
 
-	//! Desctructor
+	//! Destructor
 	virtual ~ccSerializableObject() = default;
 
 	//! Returns whether object is serializable of not
 	virtual bool isSerializable() const { return false; }
 
-	//! Saves data to binay stream
+	//! Saves data to binary stream
 	/** \param out output file (already opened)
 		\return success
 	**/
@@ -59,10 +59,10 @@ public:
 		DF_SCALAR_VAL_32_BITS	= 2, /**< Scalar values are stored as 32 bits floats (otherwise 64 bits double) **/
 	};
 
-	//! Map of loaded uniqie IDs (old ID --> new ID)
+	//! Map of loaded unique IDs (old ID --> new ID)
 	typedef QMultiMap<unsigned, unsigned> LoadedIDMap;
 
-	//! Loads data from binay stream
+	//! Loads data from binary stream
 	/** \param in input file (already opened)
 		\param dataVersion file version
 		\param flags deserialization flags (see ccSerializableObject::DeserializationFlags)
@@ -276,7 +276,7 @@ public:
 			}
 
 			//array data (dataVersion>=20)
-			//--> saldy we can't read it as a block...
+			//--> sadly we can't read it as a block...
 			//we must convert each element, value by value!
 			FileComponentType dummyArray[N] = { 0 };
 

--- a/libs/qCC_db/include/ccTorus.h
+++ b/libs/qCC_db/include/ccTorus.h
@@ -79,7 +79,7 @@ protected:
 	//! Inside radius
 	PointCoordinateType m_insideRadius;
 
-	//! Outisde radius
+	//! Outside radius
 	PointCoordinateType m_outsideRadius;
 
 	//! Whether torus has a rectangular (true) or circular (false) section

--- a/libs/qCC_db/include/ccViewportParameters.h
+++ b/libs/qCC_db/include/ccViewportParameters.h
@@ -56,7 +56,7 @@ public: //functions
 	const CCVector3d& getCameraCenter() const { return cameraCenter; }
 
 	//! Sets the 'focal' distance
-	/** \warning changes the camera cener position in object-centered view mode
+	/** \warning changes the camera center position in object-centered view mode
 	**/
 	void setFocalDistance(double distance);
 

--- a/libs/qCC_db/src/ccCameraSensor.cpp
+++ b/libs/qCC_db/src/ccCameraSensor.cpp
@@ -1479,7 +1479,7 @@ void ccCameraSensor::drawMeOnly(CC_DRAW_CONTEXT& context)
 			//frustum area (planes)
 			if (m_frustumInfos.drawSidePlanes && m_frustumInfos.initFrustumHull())
 			{
-				//set the rigth display (just to be sure)
+				//set the right display (just to be sure)
 				m_frustumInfos.frustumHull->setDisplay(getDisplay());
 				m_frustumInfos.frustumHull->setTempColor(m_color);
 
@@ -2636,7 +2636,7 @@ void ccOctreeFrustumIntersector::computeFrustumIntersectionByLevel(unsigned char
 			// look if there is a separating plane
 			OctreeCellVisibility result = (parentResult == CELL_INSIDE_FRUSTUM ? CELL_INSIDE_FRUSTUM : separatingAxisTest(bbMin, bbMax, planesCoefficients, ptsFrustum, edges, center));
 
-			// if the cell is not outside the frustum, there is a kind of intersection (inside or intesecting)
+			// if the cell is not outside the frustum, there is a kind of intersection (inside or intersecting)
 			if (result != CELL_OUTSIDE_FRUSTUM)
 			{
 				if (result == CELL_INSIDE_FRUSTUM)

--- a/libs/qCC_db/src/ccClipBox.cpp
+++ b/libs/qCC_db/src/ccClipBox.cpp
@@ -731,7 +731,7 @@ void ccClipBox::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 		//custom arrow 'context'
 		CC_DRAW_CONTEXT componentContext = context;
-		componentContext.drawingFlags &= (~CC_DRAW_ENTITY_NAMES); //we must remove the 'push name flag' so that the arows don't push their own!
+		componentContext.drawingFlags &= (~CC_DRAW_ENTITY_NAMES); //we must remove the 'push name flag' so that the arrows don't push their own!
 		componentContext.display = nullptr;
 
 		if (pushName) //2nd level = sub-item

--- a/libs/qCC_db/src/ccColorScale.cpp
+++ b/libs/qCC_db/src/ccColorScale.cpp
@@ -138,7 +138,7 @@ void ccColorScale::update()
 			{
 				const double relativePos = static_cast<double>(i) / (MAX_STEPS - 1);
 
-				//forward to the right intervale
+				//forward to the right interval
 				while (j+2 < stepCount && m_steps[j+1].getRelativePos() < relativePos)
 					++j;
 

--- a/libs/qCC_db/src/ccDrawableObject.cpp
+++ b/libs/qCC_db/src/ccDrawableObject.cpp
@@ -43,7 +43,7 @@ ccDrawableObject::ccDrawableObject(const ccDrawableObject& object)
 	, m_normalsDisplayed(object.m_normalsDisplayed)
 	, m_sfDisplayed(object.m_sfDisplayed)
 	, m_tempColor(object.m_tempColor)
-	, m_colorIsOverriden(object.m_colorIsOverriden)
+	, m_colorIsOverridden(object.m_colorIsOverridden)
 	, m_glTrans(object.m_glTrans)
 	, m_glTransEnabled(object.m_glTransEnabled)
 	, m_showNameIn3D(object.m_showNameIn3D)
@@ -148,7 +148,7 @@ void ccDrawableObject::setTempColor(const ccColor::Rgb& col, bool autoActivate/*
 void ccDrawableObject::getDrawingParameters(glDrawParams& params) const
 {
 	//color override
-	if (isColorOverriden())
+	if (isColorOverridden())
 	{
 		params.showColors = true;
 		params.showNorms = hasNormals() && normalsShown()/*false*/;

--- a/libs/qCC_db/src/ccFacet.cpp
+++ b/libs/qCC_db/src/ccFacet.cpp
@@ -129,7 +129,7 @@ ccFacet* ccFacet::clone() const
 	facet->m_showNormalVector = m_showNormalVector;
 	memcpy(facet->m_planeEquation, m_planeEquation, sizeof(PointCoordinateType)*4);
 	facet->setVisible(isVisible());
-	facet->lockVisibility(isVisiblityLocked());
+	facet->lockVisibility(isVisibilityLocked());
 	facet->setDisplay_recursive(getDisplay());
 
 	return facet;

--- a/libs/qCC_db/src/ccGBLSensor.cpp
+++ b/libs/qCC_db/src/ccGBLSensor.cpp
@@ -249,7 +249,7 @@ ccGBLSensor::NormalGrid* ccGBLSensor::projectNormals(	CCCoreLib::GenericCloud* c
 		m_posBuffer->getInterpolatedTransformation(posIndex, sensorPos);
 	sensorPos *= m_rigidTransformation;
 
-	//poject each point + normal
+	//project each point + normal
 	{
 		CCVector3 sensorOrigin = sensorPos.getTranslationAsVec3D();
 
@@ -532,7 +532,7 @@ bool ccGBLSensor::computeAutoParameters(CCCoreLib::GenericCloud* theCloud)
 	PointCoordinateType maxYaw = 0;
 	PointCoordinateType maxDepth = 0;
 	{
-		//first project all points to compute the (yaw,ptich) ranges
+		//first project all points to compute the (yaw,pitch) ranges
 		theCloud->placeIteratorAtBeginning();
 		for (unsigned i = 0; i < pointCount; ++i)
 		{
@@ -632,7 +632,7 @@ bool ccGBLSensor::computeDepthBuffer(CCCoreLib::GenericCloud* theCloud, int& err
 	assert(theCloud);
 	if (!theCloud)
 	{
-		//invlalid input parameter
+		//invalid input parameter
 		errorCode = ERROR_BAD_INPUT;
 		return false;
 	}

--- a/libs/qCC_db/src/ccGenericMesh.cpp
+++ b/libs/qCC_db/src/ccGenericMesh.cpp
@@ -298,7 +298,7 @@ void ccGenericMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 		RGBAColorsTableType* rgbaColorsTable = nullptr;
 		if (glParams.showColors)
 		{
-			if (isColorOverriden())
+			if (isColorOverridden())
 			{
 				ccGL::Color4v(glFunc, m_tempColor.rgba);
 				glParams.showColors = false;

--- a/libs/qCC_db/src/ccGenericMesh.cpp
+++ b/libs/qCC_db/src/ccGenericMesh.cpp
@@ -362,7 +362,7 @@ void ccGenericMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 			}
 
 			//we can scan and process each chunk separately in an optimized way
-			//we mimic the way ccMesh beahves by using virtual chunks!
+			//we mimic the way ccMesh behaves by using virtual chunks!
 			size_t chunkCount = ccChunk::Count(displayedTriNum);
 			size_t chunkStart = 0;
 			for (size_t k = 0; k < chunkCount; ++k, chunkStart += ccChunk::SIZE)
@@ -894,7 +894,7 @@ void ccGenericMesh::computeInterpolationWeights(unsigned triIndex, const CCVecto
 	const CCVector3 *B = tri->_getB();
 	const CCVector3 *C = tri->_getC();
 
-	//barcyentric intepolation weights
+	//barycentric interpolation weights
 	weights.x = ((P-*B).cross(*C-*B)).normd()/*/2*/;
 	weights.y = ((P-*C).cross(*A-*C)).normd()/*/2*/;
 	weights.z = ((P-*A).cross(*B-*A)).normd()/*/2*/;

--- a/libs/qCC_db/src/ccHObject.cpp
+++ b/libs/qCC_db/src/ccHObject.cpp
@@ -473,7 +473,7 @@ void ccHObject::transferChildren(ccHObject& newParent, bool forceFatherDependent
 		int childDependencyFlags = child->getDependencyFlagsWith(this);
 		int fatherDependencyFlags = getDependencyFlagsWith(child);
 	
-		//we must explicitely remove any dependency with the child as we don't call 'detachChild'
+		//we must explicitly remove any dependency with the child as we don't call 'detachChild'
 		removeDependencyWith(child);
 		child->removeDependencyWith(this);
 
@@ -777,7 +777,7 @@ void ccHObject::draw(CC_DRAW_CONTEXT& context)
 	{
 		if (MACRO_Draw3D(context))
 		{
-			//we have to comute the 2D position during the 3D pass!
+			//we have to compute the 2D position during the 3D pass!
 			ccBBox bBox = getBB_recursive(true); //DGM: take the OpenGL features into account (as some entities are purely 'GL'!)
 			if (bBox.isValid())
 			{
@@ -1059,12 +1059,12 @@ bool ccHObject::fromFile(QFile& in, short dataVersion, int flags, LoadedIDMap& o
 		//create corresponding child object
 		ccHObject* child = New(classID);
 
-		//specifc case of custom objects (defined by plugins)
+		//specific case of custom objects (defined by plugins)
 		if ((classID & CC_TYPES::CUSTOM_H_OBJECT) == CC_TYPES::CUSTOM_H_OBJECT)
 		{
 			//store current position
 			size_t originalFilePos = in.pos();
-			//we need to load the custom object as plain ccCustomHobject
+			//we need to load the custom object as plain ccCustomHObject
 			child->fromFileNoChildren(in, dataVersion, flags, oldToNewIDMap);
 			//go back to original position
 			in.seek(originalFilePos);
@@ -1168,7 +1168,7 @@ bool ccHObject::toFile_MeOnly(QFile& out) const
 	//'sfDisplayed' state (dataVersion>=20)
 	if (out.write(reinterpret_cast<const char*>(&m_sfDisplayed), sizeof(bool)) < 0)
 		return WriteError();
-	//'colorIsOverriden' state (dataVersion>=20)
+	//'colorIsOverridden' state (dataVersion>=20)
 	if (out.write(reinterpret_cast<const char*>(&m_colorIsOverriden), sizeof(bool)) < 0)
 		return WriteError();
 	if (m_colorIsOverriden)
@@ -1218,7 +1218,7 @@ bool ccHObject::fromFile_MeOnly(QFile& in, short dataVersion, int flags, LoadedI
 	//'sfDisplayed' state (dataVersion>=20)
 	if (in.read(reinterpret_cast<char*>(&m_sfDisplayed), sizeof(bool)) < 0)
 		return ReadError();
-	//'colorIsOverriden' state (dataVersion>=20)
+	//'colorIsOverridden' state (dataVersion>=20)
 	if (in.read(reinterpret_cast<char*>(&m_colorIsOverriden), sizeof(bool)) < 0)
 		return ReadError();
 	if (m_colorIsOverriden)

--- a/libs/qCC_db/src/ccHObject.cpp
+++ b/libs/qCC_db/src/ccHObject.cpp
@@ -892,7 +892,7 @@ void ccHObject::detachChild(ccHObject* child)
 	}
 }
 
-void ccHObject::detatchAllChildren()
+void ccHObject::detachAllChildren()
 {
 	for (auto child : m_children)
 	{
@@ -1070,8 +1070,8 @@ bool ccHObject::fromFile(QFile& in, short dataVersion, int flags, LoadedIDMap& o
 			in.seek(originalFilePos);
 			//get custom object name and plugin name
 			QString childName = child->getName();
-			QString classId = child->getMetaData(ccCustomHObject::DefautMetaDataClassName()).toString();
-			QString pluginId = child->getMetaData(ccCustomHObject::DefautMetaDataPluginName()).toString();
+			QString classId = child->getMetaData(ccCustomHObject::DefaultMetaDataClassName()).toString();
+			QString pluginId = child->getMetaData(ccCustomHObject::DefaultMetaDataPluginName()).toString();
 			//dont' need this instance anymore
 			delete child;
 			child = nullptr;
@@ -1169,9 +1169,9 @@ bool ccHObject::toFile_MeOnly(QFile& out) const
 	if (out.write(reinterpret_cast<const char*>(&m_sfDisplayed), sizeof(bool)) < 0)
 		return WriteError();
 	//'colorIsOverridden' state (dataVersion>=20)
-	if (out.write(reinterpret_cast<const char*>(&m_colorIsOverriden), sizeof(bool)) < 0)
+	if (out.write(reinterpret_cast<const char*>(&m_colorIsOverridden), sizeof(bool)) < 0)
 		return WriteError();
-	if (m_colorIsOverriden)
+	if (m_colorIsOverridden)
 	{
 		//'tempColor' (dataVersion>=20)
 		if (out.write(reinterpret_cast<const char*>(m_tempColor.rgba), sizeof(ColorCompType)*3) < 0) //TODO: save the alpha channel?
@@ -1219,9 +1219,9 @@ bool ccHObject::fromFile_MeOnly(QFile& in, short dataVersion, int flags, LoadedI
 	if (in.read(reinterpret_cast<char*>(&m_sfDisplayed), sizeof(bool)) < 0)
 		return ReadError();
 	//'colorIsOverridden' state (dataVersion>=20)
-	if (in.read(reinterpret_cast<char*>(&m_colorIsOverriden), sizeof(bool)) < 0)
+	if (in.read(reinterpret_cast<char*>(&m_colorIsOverridden), sizeof(bool)) < 0)
 		return ReadError();
-	if (m_colorIsOverriden)
+	if (m_colorIsOverridden)
 	{
 		//'tempColor' (dataVersion>=20)
 		if (in.read(reinterpret_cast<char*>(m_tempColor.rgba), sizeof(ColorCompType)*3) < 0)

--- a/libs/qCC_db/src/ccLog.cpp
+++ b/libs/qCC_db/src/ccLog.cpp
@@ -50,7 +50,7 @@ struct Message
 
 //message backup system
 static bool s_backupEnabled;
-//backuped messages
+//backed up messages
 static std::vector<Message> s_backupMessages;
 
 //unique console instance
@@ -98,7 +98,7 @@ void ccLog::RegisterInstance(ccLog* logInstance)
 	s_instance = logInstance;
 	if (s_instance)
 	{
-		//if we have a valid instance, we can now flush the backuped messages
+		//if we have a valid instance, we can now flush the backed up messages
 		for (const Message& message : s_backupMessages)
 		{
 			s_instance->logMessage(message.text, message.flags);

--- a/libs/qCC_db/src/ccMaterial.cpp
+++ b/libs/qCC_db/src/ccMaterial.cpp
@@ -124,7 +124,7 @@ bool ccMaterial::loadAndSetTexture(const QString& absoluteFilename)
 
 	if (s_materialDB.hasTexture(absoluteFilename))
 	{
-		//if the image is already in memory, we simply update the texture filename for this amterial
+		//if the image is already in memory, we simply update the texture filename for this material
 		m_textureFilename = absoluteFilename;
 		s_materialDB.increaseTextureCounter(absoluteFilename);
 	}

--- a/libs/qCC_db/src/ccMaterialSet.cpp
+++ b/libs/qCC_db/src/ccMaterialSet.cpp
@@ -402,7 +402,7 @@ bool ccMaterialSet::saveAsMTL(const QString& path, const QString& baseFilename, 
 				QString destFilename = path + QString('/') + texName;
 				if (mtl->getTexture().mirrored().save(destFilename)) //mirrored: see ccMaterial
 				{
-					//new absolute filemane
+					//new absolute filename
 					absFilenamesSaved[absFilename] = texName;
 				}
 				else

--- a/libs/qCC_db/src/ccMesh.cpp
+++ b/libs/qCC_db/src/ccMesh.cpp
@@ -1777,7 +1777,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 		RGBAColorsTableType* rgbaColorsTable = nullptr;
 		if (glParams.showColors)
 		{
-			if (isColorOverriden())
+			if (isColorOverridden())
 			{
 				ccGL::Color4v(glFunc, m_tempColor.rgba);
 				glParams.showColors = false;

--- a/libs/qCC_db/src/ccMesh.cpp
+++ b/libs/qCC_db/src/ccMesh.cpp
@@ -997,7 +997,7 @@ ccMesh* ccMesh::TriangulateTwoPolylines(ccPolyline* p1, ccPolyline* p2, CCVector
 
 	delaunayMesh->linkMeshWith(vertices, false);
 
-	//remove the points oustide of the 'concave' hull
+	//remove the points outside of the 'concave' hull
 	{
 		//first compute the Convex hull
 		std::vector<CCCoreLib::PointProjectionTools::IndexedCCVector2> indexedPoints2D;
@@ -3112,7 +3112,7 @@ void ccMesh::computeInterpolationWeights(const CCCoreLib::VerticesIndexes& vertI
 	const CCVector3 *B = m_associatedCloud->getPoint(vertIndexes.i2);
 	const CCVector3 *C = m_associatedCloud->getPoint(vertIndexes.i3);
 
-	//barcyentric intepolation weights
+	//barycentric interpolation weights
 	weights.x = sqrt(((P - *B).cross(*C - *B)).norm2d())/*/2*/;
 	weights.y = sqrt(((P - *C).cross(*A - *C)).norm2d())/*/2*/;
 	weights.z = sqrt(((P - *A).cross(*B - *A)).norm2d())/*/2*/;
@@ -3131,7 +3131,7 @@ bool ccMesh::interpolateNormals(unsigned triIndex, const CCVector3& P, CCVector3
 
 	const CCCoreLib::VerticesIndexes& tri = m_triVertIndexes->getValue(triIndex);
 
-	//intepolation weights
+	//interpolation weights
 	CCVector3d w;
 	computeInterpolationWeights(tri, P, w);
 
@@ -3188,7 +3188,7 @@ bool ccMesh::interpolateColors(unsigned triIndex, const CCVector3& P, ccColor::R
 
 	const CCCoreLib::VerticesIndexes& tri = m_triVertIndexes->getValue(triIndex);
 
-	//intepolation weights
+	//interpolation weights
 	CCVector3d w;
 	computeInterpolationWeights(tri, P, w);
 
@@ -3204,7 +3204,7 @@ bool ccMesh::interpolateColors(unsigned triIndex, const CCVector3& P, ccColor::R
 
 	const CCCoreLib::VerticesIndexes& tri = m_triVertIndexes->getValue(triIndex);
 
-	//intepolation weights
+	//interpolation weights
 	CCVector3d w;
 	computeInterpolationWeights(tri, P, w);
 
@@ -3370,7 +3370,7 @@ bool ccMesh::getColorFromMaterial(unsigned triIndex, const CCVector3& P, ccColor
 	const TexCoords2D* T2 = (txInd.u[1] >= 0 ? &m_texCoords->getValue(txInd.u[1]) : nullptr);
 	const TexCoords2D* T3 = (txInd.u[2] >= 0 ? &m_texCoords->getValue(txInd.u[2]) : nullptr);
 
-	//intepolation weights
+	//interpolation weights
 	CCVector3d w;
 	computeInterpolationWeights(triIndex, P, w);
 
@@ -3470,7 +3470,7 @@ bool ccMesh::pushSubdivide(/*PointCoordinateType maxArea, */unsigned indexA, uns
 	const CCVector3* B = vertices->getPoint(indexB);
 	const CCVector3* C = vertices->getPoint(indexC);
 
-	//do we need to sudivide this triangle?
+	//do we need to subdivide this triangle?
 	PointCoordinateType area = ((*B - *A)*(*C - *A)).norm() / 2;
 	if (area > s_maxSubdivideArea/*maxArea*/)
 	{
@@ -3741,7 +3741,7 @@ ccMesh* ccMesh::subdivide(PointCoordinateType maxArea) const
 				tri.i1 = indexes[i1];
 				tri.i2 = indexG;
 				tri.i3 = indexes[(i1 + 2) % 3];
-				//and add the other half (we can use pushSubdivide as the area should alredy be ok!)
+				//and add the other half (we can use pushSubdivide as the area should already be ok!)
 				if (!resultMesh->pushSubdivide(/*maxArea,*/indexes[i1], indexes[(i1 + 1) % 3], indexG))
 				{
 					ccLog::Error("[ccMesh::subdivide] Not enough memory!");
@@ -3803,7 +3803,7 @@ ccMesh* ccMesh::subdivide(PointCoordinateType maxArea) const
 				tri.i1 = indexA;
 				tri.i2 = indexG1;
 				tri.i3 = indexG3;
-				//and add the other 3 quarters (we can use pushSubdivide as the area should alredy be ok!)
+				//and add the other 3 quarters (we can use pushSubdivide as the area should already be ok!)
 				if (!resultMesh->pushSubdivide(/*maxArea, */indexB, indexG2, indexG1) ||
 					!resultMesh->pushSubdivide(/*maxArea, */indexC, indexG3, indexG2) ||
 					!resultMesh->pushSubdivide(/*maxArea, */indexG1, indexG2, indexG3))

--- a/libs/qCC_db/src/ccNormalVectors.cpp
+++ b/libs/qCC_db/src/ccNormalVectors.cpp
@@ -258,9 +258,9 @@ PointCoordinateType ccNormalVectors::GuessNaiveRadius(ccGenericPointCloud* cloud
 		return 0;
 	}
 
-	PointCoordinateType largetDim = cloud->getOwnBB().getMaxBoxDim();
+	PointCoordinateType largestDim = cloud->getOwnBB().getMaxBoxDim();
 
-	return largetDim / std::min<unsigned>(100, std::max<unsigned>(1, cloud->size()/100 ) );
+	return largestDim / std::min<unsigned>(100, std::max<unsigned>(1, cloud->size()/100 ) );
 }
 
 PointCoordinateType ccNormalVectors::GuessBestRadius(	ccGenericPointCloud* cloud,
@@ -361,7 +361,7 @@ PointCoordinateType ccNormalVectors::GuessBestRadius(	ccGenericPointCloud* cloud
 			double stdDevPop = sqrt(std::abs(static_cast<double>(totalSquareCount) / sampleCount - meanPop*meanPop));
 			double aboveMinPopRatio = static_cast<double>(aboveMinPopCount) / sampleCount;
 
-			ccLog::Print(QString("[GuessBestRadius] Radius = %1 -> samples population in [%2 ; %3] (mean %4 / std. dev. %5 / %6% above mininmum)")
+			ccLog::Print(QString("[GuessBestRadius] Radius = %1 -> samples population in [%2 ; %3] (mean %4 / std. dev. %5 / %6% above minimum)")
 										.arg(radius)
 										.arg(minPop)
 										.arg(maxPop)

--- a/libs/qCC_db/src/ccObject.cpp
+++ b/libs/qCC_db/src/ccObject.cpp
@@ -38,7 +38,7 @@
 	v2.5 - 03/16/2013 - ccViewportParameters structure modified
 	v2.6 - 04/03/2013 - strictly positive scalar field removed and 'hidden' values marker is now NaN
 	v2.7 - 04/12/2013 - Customizable color scales
-	v2.8 - 07/12/2013 - Poylines are now supported
+	v2.8 - 07/12/2013 - Polylines are now supported
 	v2.9 - 08/14/2013 - ccMeshGroup removed, ccSubMesh added
 	v3.0 - 08/30/2013 - QObject's meta data structure added
 	v3.1 - 09/25/2013 - ccPolyline width added

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -2159,7 +2159,7 @@ void ccPointCloud::swapPoints(unsigned firstIndex, unsigned secondIndex)
 void ccPointCloud::getDrawingParameters(glDrawParams& params) const
 {
 	//color override
-	if (isColorOverriden())
+	if (isColorOverridden())
 	{
 		params.showColors	= true;
 		params.showNorms	= false;
@@ -2691,7 +2691,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 			glFunc->glEnable(GL_BLEND);
 		}
 
-		if (glParams.showColors && isColorOverriden())
+		if (glParams.showColors && isColorOverridden())
 		{
 			ccGL::Color4v(glFunc, m_tempColor.rgba);
 			glParams.showColors = false;
@@ -4797,7 +4797,7 @@ static bool CatchGLErrors(GLenum err, const char* context)
 
 bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams& glParams)
 {
-	if (isColorOverriden())
+	if (isColorOverridden())
 	{
 		//nothing to do (we don't display true colors, SF or normals!)
 		return false;

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -709,7 +709,7 @@ const ccPointCloud& ccPointCloud::append(ccPointCloud* addedCloud, unsigned poin
 				//assert(hasFWF()); //DGM: new waveforms are not pushed yet, so there might not be any in the cloud at the moment!
 				size_t lostWaveformCount = 0;
 
-				//map from old descritpor IDs to new ones
+				//map from old descriptor IDs to new ones
 				QMap<uint8_t, uint8_t> descriptorIDMap;
 
 				//first: copy the wave descriptors
@@ -961,7 +961,7 @@ const ccPointCloud& ccPointCloud::append(ccPointCloud* addedCloud, unsigned poin
 		m_grids.resize(0);
 	}
 
-	//has the cloud been recentered/rescaled?
+	//has the cloud been re-centered/rescaled?
 	{
 		if (addedCloud->isShifted())
 		{
@@ -1818,8 +1818,8 @@ bool ccPointCloud::setRGBColorByHeight(unsigned char heightDim, ccColorScale::Sh
 	for (unsigned i = 0; i < count; i++)
 	{
 		const CCVector3* Q = getPoint(i);
-		double realtivePos = (Q->u[heightDim] - minHeight) / height;
-		const ccColor::Rgb* col = colorScale->getColorByRelativePos(realtivePos);
+		double relativePos = (Q->u[heightDim] - minHeight) / height;
+		const ccColor::Rgb* col = colorScale->getColorByRelativePos(relativePos);
 		if (!col) //DGM: yes it happens if we encounter a point with NaN coordinates!!!
 		{
 			col = &ccColor::blackRGB;
@@ -2623,7 +2623,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 								//get the current viewport and OpenGL matrices
 								ccGLCameraParameters camera;
 								context.display->getGLCameraParameters(camera);
-								//relpace the viewport and matrices by the real ones
+								//replace the viewport and matrices by the real ones
 								glFunc->glGetIntegerv(GL_VIEWPORT, camera.viewport);
 								glFunc->glGetDoublev(GL_PROJECTION_MATRIX, camera.projectionMat.data());
 								glFunc->glGetDoublev(GL_MODELVIEW_MATRIX, camera.modelViewMat.data());
@@ -2815,7 +2815,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 				if (colorRampShader)
 				{
-					//max available space for frament's shader uniforms
+					//max available space for fragment's shader uniforms
 					GLint maxBytes = 0;
 					glFunc->glGetIntegerv(GL_MAX_FRAGMENT_UNIFORM_COMPONENTS, &maxBytes);
 					GLint maxComponents = (maxBytes >> 2) - 4; //leave space for the other uniforms!
@@ -3472,7 +3472,7 @@ QSharedPointer<CCCoreLib::ReferenceCloud> ccPointCloud::computeCPSet(	ccGenericP
 		params.octreeLevel = octreeLevel;
 	}
 
-	//create temporary SF for the nearest neighors determination (computeCloud2CloudDistances)
+	//create temporary SF for the nearest neighbors determination (computeCloud2CloudDistances)
 	//so that we can properly remove it afterwards!
 	static const char s_defaultTempSFName[] = "CPSetComputationTempSF";
 	int sfIdx = getScalarFieldIndexByName(s_defaultTempSFName);

--- a/libs/qCC_db/src/ccPolyline.cpp
+++ b/libs/qCC_db/src/ccPolyline.cpp
@@ -106,7 +106,7 @@ void ccPolyline::importParametersFrom(const ccPolyline& poly)
 	set2DMode(poly.m_mode2D);
 	setForeground(poly.m_foreground);
 	setVisible(poly.isVisible());
-	lockVisibility(poly.isVisiblityLocked());
+	lockVisibility(poly.isVisibilityLocked());
 	setColor(poly.m_rgbColor);
 	setWidth(poly.m_width);
 	showColors(poly.colorsShown());
@@ -194,7 +194,7 @@ void ccPolyline::drawMeOnly(CC_DRAW_CONTEXT& context)
 	if (pushName)
 		glFunc->glPushName(getUniqueIDForDisplay());
 
-	if (isColorOverriden())
+	if (isColorOverridden())
 		ccGL::Color4v(glFunc, getTempColor().rgba);
 	else if (colorsShown())
 		ccGL::Color3v(glFunc, m_rgbColor.rgb);
@@ -696,7 +696,7 @@ ccPointCloud* ccPolyline::samplePoints(	bool densityBased,
 
 	if (withRGB)
 	{
-		if (isColorOverriden())
+		if (isColorOverridden())
 		{
 			//we use the default 'temporary' color
 			cloud->setColor(getTempColor());

--- a/libs/qCC_db/src/ccRasterGrid.cpp
+++ b/libs/qCC_db/src/ccRasterGrid.cpp
@@ -769,7 +769,7 @@ ccPointCloud* ccRasterGrid::convertToCloud(	const std::vector<ExportableFields>&
 	ccPointCloud* cloudGrid = nullptr;
 	
 	//if we 'resample' the input cloud, we actually resample it (one point in each cell)
-	//and we may have to change some things aftewards (height, scalar fields, etc.)
+	//and we may have to change some things afterwards (height, scalar fields, etc.)
 	if (resampleInputCloudXY)
 	{
 		if (!inputCloud)

--- a/libs/qCC_db/src/ccSubMesh.cpp
+++ b/libs/qCC_db/src/ccSubMesh.cpp
@@ -414,7 +414,7 @@ bool ccSubMesh::addTriangleIndex(unsigned globalIndex)
 	}
 	catch (const std::bad_alloc&)
 	{
-		//not engough memory
+		//not enough memory
 		return false;
 	}
 
@@ -439,7 +439,7 @@ bool ccSubMesh::addTriangleIndex(unsigned firstIndex, unsigned lastIndex)
 	}
 	catch (const std::bad_alloc&)
 	{
-		//not engough memory
+		//not enough memory
 		return false;
 	}
 	
@@ -468,7 +468,7 @@ bool ccSubMesh::reserve(size_t n)
 	}
 	catch (const std::bad_alloc&)
 	{
-		//not engough memory
+		//not enough memory
 		return false;
 	}
 	return true;
@@ -482,7 +482,7 @@ bool ccSubMesh::resize(size_t n)
 	}
 	catch (const std::bad_alloc&)
 	{
-		//not engough memory
+		//not enough memory
 		return false;
 	}
 	return true;

--- a/libs/qCC_db/src/ccViewportParameters.cpp
+++ b/libs/qCC_db/src/ccViewportParameters.cpp
@@ -167,7 +167,7 @@ bool ccViewportParameters::fromFile(QFile& in, short dataVersion, int flags, Loa
 		inStream >> orthoAspectRatio;
 	}
 
-	//for older version, deduce the focal distance from the old paramters (pixelSize and zoom)
+	//for older version, deduce the focal distance from the old parameters (pixelSize and zoom)
 	if (dataVersion < 51 && zoom != 1.0f)
 	{
 		if (perspectiveView)

--- a/libs/qCC_glWindow/include/ccGLWindow.h
+++ b/libs/qCC_glWindow/include/ccGLWindow.h
@@ -471,7 +471,7 @@ public:
 	void setDisplayParameters(const ccGui::ParamStruct& params, bool thisWindowOnly = false);
 
 	//! Whether display parameters are overidden for this window
-	bool hasOverridenDisplayParameters() const { return m_overridenDisplayParametersEnabled; }
+	bool hasOverriddenDisplayParameters() const { return m_overriddenDisplayParametersEnabled; }
 
 	//! Default picking radius value
 	static const int DefaultPickRadius = 5;
@@ -1218,10 +1218,10 @@ protected: //members
 	ccPolyline* m_rectPickingPoly;
 
 	//! Overridden display parameter 
-	ccGui::ParamStruct m_overridenDisplayParameters;
+	ccGui::ParamStruct m_overriddenDisplayParameters;
 
 	//! Whether display parameters are overidden for this window
-	bool m_overridenDisplayParametersEnabled;
+	bool m_overriddenDisplayParametersEnabled;
 
 	//! Whether to display overlay entities or not (scale, tetrahedron, etc.)
 	bool m_displayOverlayEntities;

--- a/libs/qCC_glWindow/src/ccGLWindow.cpp
+++ b/libs/qCC_glWindow/src/ccGLWindow.cpp
@@ -372,7 +372,7 @@ ccGLWindow::ccGLWindow(	QSurfaceFormat* format/*=0*/,
 	, m_pivotSymbolShown(false)
 	, m_allowRectangularEntityPicking(true)
 	, m_rectPickingPoly(nullptr)
-	, m_overridenDisplayParametersEnabled(false)
+	, m_overriddenDisplayParametersEnabled(false)
 	, m_displayOverlayEntities(true)
 	, m_silentInitialization(silentInitialization)
 	, m_bubbleViewModeEnabled(false)
@@ -659,19 +659,19 @@ void ccGLWindow::setInteractionMode(INTERACTION_FLAGS flags)
 
 const ccGui::ParamStruct& ccGLWindow::getDisplayParameters() const
 {
-	return m_overridenDisplayParametersEnabled ? m_overridenDisplayParameters : ccGui::Parameters();
+	return m_overriddenDisplayParametersEnabled ? m_overriddenDisplayParameters : ccGui::Parameters();
 }
 
 void ccGLWindow::setDisplayParameters(const ccGui::ParamStruct &params, bool thisWindowOnly)
 {
 	if (thisWindowOnly)
 	{
-		m_overridenDisplayParametersEnabled = true;
-		m_overridenDisplayParameters = params;
+		m_overriddenDisplayParametersEnabled = true;
+		m_overriddenDisplayParameters = params;
 	}
 	else
 	{
-		m_overridenDisplayParametersEnabled = false;
+		m_overriddenDisplayParametersEnabled = false;
 		ccGui::Set(params);
 	}
 }
@@ -977,7 +977,7 @@ bool ccGLWindow::initialize()
 #endif
 
 		//apply (potentially) updated parameters;
-		setDisplayParameters(params, hasOverridenDisplayParameters());
+		setDisplayParameters(params, hasOverriddenDisplayParameters());
 
 #if 0
 		//OpenGL 3.3+ rendering shader
@@ -1002,7 +1002,7 @@ bool ccGLWindow::initialize()
 				{
 					m_customRenderingShader = renderingShader;
 				}
-				setDisplayParameters(params,hasOverridenDisplayParameters());
+				setDisplayParameters(params,hasOverriddenDisplayParameters());
 			}
 		}
 #endif

--- a/plugins/core/IO/qAdditionalIO/src/PovFilter.cpp
+++ b/plugins/core/IO/qAdditionalIO/src/PovFilter.cpp
@@ -333,7 +333,7 @@ CC_FILE_ERROR PovFilter::loadFile(const QString& filename, ccHObject& container,
 				else
 				{
 					entities->filterChildren(clouds, true, CC_TYPES::POINT_CLOUD);
-					entities->detatchAllChildren();
+					entities->detachAllChildren();
 					delete entities;
 				}
 				entities = nullptr;

--- a/plugins/core/IO/qCoreIO/src/STLFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/STLFilter.cpp
@@ -362,7 +362,7 @@ CC_FILE_ERROR STLFilter::loadFile(const QString& filename, ccHObject& container,
 	}
 
 	//remove duplicated vertices
-	mesh->mergeDuplicatedVertices(ccMesh::DefaultMergeDulicateVerticesLevel, parameters.parentWidget);
+	mesh->mergeDuplicatedVertices(ccMesh::DefaultMergeDuplicateVerticesLevel, parameters.parentWidget);
 	vertices = nullptr; //warning, after this point, 'vertices' is not valid anymore
 
 	ccGenericPointCloud* meshVertices = mesh->getAssociatedCloud();

--- a/plugins/core/IO/qPhotoscanIO/extern/quazip/quazip/quazip/quazip.h
+++ b/plugins/core/IO/qPhotoscanIO/extern/quazip/quazip/quazip/quazip.h
@@ -534,7 +534,7 @@ class QUAZIP_EXPORT QuaZip {
      * The default codec is used by the constructors, so calling this function
      * won't affect the QuaZip instances already created at that moment.
      *
-     * The codec specified here can be overriden by calling setFileNameCodec().
+     * The codec specified here can be overridden by calling setFileNameCodec().
      * If neither function is called, QTextCodec::codecForLocale() will be used
      * to decode or encode file names. Use this function with caution if
      * the application uses other libraries that depend on QuaZIP. Those

--- a/plugins/core/IO/qPhotoscanIO/src/PhotoScanFilter.cpp
+++ b/plugins/core/IO/qPhotoscanIO/src/PhotoScanFilter.cpp
@@ -896,7 +896,7 @@ CC_FILE_ERROR PhotoScanFilter::loadFile(const QString& filename,
 					{
 						container.addChild(tempContainer.getChild(i));
 					}
-					tempContainer.detatchAllChildren();
+					tempContainer.detachAllChildren();
 				}
 
 				if (!tempTextureFilename.isNull())
@@ -916,7 +916,7 @@ CC_FILE_ERROR PhotoScanFilter::loadFile(const QString& filename,
 					{
 						container.addChild(newGroup->getChild(i));
 					}
-					newGroup->detatchAllChildren();
+					newGroup->detachAllChildren();
 					delete newGroup;
 					newGroup = nullptr;
 				}

--- a/plugins/core/Standard/qCompass/src/ccCompass.cpp
+++ b/plugins/core/Standard/qCompass/src/ccCompass.cpp
@@ -350,7 +350,7 @@ void ccCompass::tryLoading()
 		}
 
 		//remove them from the orignal parent
-		original->detatchAllChildren();
+		original->detachAllChildren();
 
 		//add new parent to scene graph
 		original->getParent()->addChild(replacement);

--- a/plugins/core/Standard/qCompass/src/ccCompassDlg.cpp
+++ b/plugins/core/Standard/qCompass/src/ccCompassDlg.cpp
@@ -192,9 +192,9 @@ ccCompassDlg::ccCompassDlg(QWidget* parent/*=0*/)
 	setAutoFillBackground(true);
 
 	//add shortcuts
-	addOverridenShortcut(Qt::Key_Escape); //escape key for the "cancel" button
-	addOverridenShortcut(Qt::Key_Return); //return key for the "apply" button
-	addOverridenShortcut(Qt::Key_Space); //space key also hits the "apply" button (easier for some)
+	addOverriddenShortcut(Qt::Key_Escape); //escape key for the "cancel" button
+	addOverriddenShortcut(Qt::Key_Return); //return key for the "apply" button
+	addOverriddenShortcut(Qt::Key_Space); //space key also hits the "apply" button (easier for some)
 	
 	connect(this, &ccOverlayDialog::shortcutTriggered, this, &ccCompassDlg::onShortcutTriggered);
 }

--- a/plugins/core/Standard/qSRA/src/ccSymbolCloud.cpp
+++ b/plugins/core/Standard/qSRA/src/ccSymbolCloud.cpp
@@ -175,7 +175,7 @@ void ccSymbolCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 		//default color
 		const ccColor::Rgba* color = &context.pointsDefaultCol;
-		if (isColorOverriden())
+		if (isColorOverridden())
 		{
 			color = &m_tempColor;
 			glParams.showColors = false;

--- a/qCC/ccGraphicalSegmentationTool.cpp
+++ b/qCC/ccGraphicalSegmentationTool.cpp
@@ -77,13 +77,13 @@ ccGraphicalSegmentationTool::ccGraphicalSegmentationTool(QWidget* parent)
 	connect(actionExportSegmentationPolyline,	&QAction::triggered,	this,	&ccGraphicalSegmentationTool::doExportSegmentationPolyline);
 
 	//add shortcuts
-	addOverridenShortcut(Qt::Key_Space);  //space bar for the "pause" button
-	addOverridenShortcut(Qt::Key_Escape); //escape key for the "cancel" button
-	addOverridenShortcut(Qt::Key_Return); //return key for the "apply" button
-	addOverridenShortcut(Qt::Key_Delete); //delete key for the "apply and delete" button
-	addOverridenShortcut(Qt::Key_Tab);    //tab key to switch between rectangular and polygonal selection modes
-	addOverridenShortcut(Qt::Key_I);      //'I' key for the "segment in" button
-	addOverridenShortcut(Qt::Key_O);      //'O' key for the "segment out" button
+	addOverriddenShortcut(Qt::Key_Space);  //space bar for the "pause" button
+	addOverriddenShortcut(Qt::Key_Escape); //escape key for the "cancel" button
+	addOverriddenShortcut(Qt::Key_Return); //return key for the "apply" button
+	addOverriddenShortcut(Qt::Key_Delete); //delete key for the "apply and delete" button
+	addOverriddenShortcut(Qt::Key_Tab);    //tab key to switch between rectangular and polygonal selection modes
+	addOverriddenShortcut(Qt::Key_I);      //'I' key for the "segment in" button
+	addOverriddenShortcut(Qt::Key_O);      //'O' key for the "segment out" button
 	connect(this, &ccOverlayDialog::shortcutTriggered, this, &ccGraphicalSegmentationTool::onShortcutTriggered);
 
 	QMenu* selectionModeMenu = new QMenu(this);

--- a/qCC/ccGraphicalTransformationTool.cpp
+++ b/qCC/ccGraphicalTransformationTool.cpp
@@ -49,9 +49,9 @@ ccGraphicalTransformationTool::ccGraphicalTransformationTool(QWidget* parent)
 	connect(objCenterRadio, &QRadioButton::toggled, this, &ccGraphicalTransformationTool::advObjectAxisRadioToggled);
 	
 	//add shortcuts
-	addOverridenShortcut(Qt::Key_Space); //space bar for the "pause" button
-	addOverridenShortcut(Qt::Key_Escape); //escape key for the "cancel" button
-	addOverridenShortcut(Qt::Key_Return); //return key for the "ok" button
+	addOverriddenShortcut(Qt::Key_Space); //space bar for the "pause" button
+	addOverriddenShortcut(Qt::Key_Escape); //escape key for the "cancel" button
+	addOverriddenShortcut(Qt::Key_Return); //return key for the "ok" button
 	connect(this, &ccOverlayDialog::shortcutTriggered, this, &ccGraphicalTransformationTool::onShortcutTriggered);
 
 	objCenterRadio->setChecked(true);
@@ -615,7 +615,7 @@ void ccGraphicalTransformationTool::advObjectAxisRadioToggled(bool state)
 
 void ccGraphicalTransformationTool::clear()
 {
-	m_toTransform.detatchAllChildren();
+	m_toTransform.detachAllChildren();
 
 	m_rotation.toIdentity();
 	m_translation = CCVector3d(0,0,0);

--- a/qCC/ccPointListPickingDlg.cpp
+++ b/qCC/ccPointListPickingDlg.cpp
@@ -396,7 +396,7 @@ void ccPointListPickingDlg::markerSizeChanged(int size)
 	if (guiParams.labelMarkerSize != static_cast<unsigned>(size))
 	{
 		guiParams.labelMarkerSize = static_cast<unsigned>(size);
-		m_associatedWin->setDisplayParameters(guiParams,m_associatedWin->hasOverridenDisplayParameters());
+		m_associatedWin->setDisplayParameters(guiParams,m_associatedWin->hasOverriddenDisplayParameters());
 		m_associatedWin->redraw();
 	}
 }

--- a/qCC/ccSectionExtractionTool.cpp
+++ b/qCC/ccSectionExtractionTool.cpp
@@ -91,9 +91,9 @@ ccSectionExtractionTool::ccSectionExtractionTool(QWidget* parent)
 	connect(m_UI->exportSectionsToolButton, &QAbstractButton::clicked, this, &ccSectionExtractionTool::exportSections);
 
 	//add shortcuts
-	addOverridenShortcut(Qt::Key_Space);  //space bar for the "pause" button
-	addOverridenShortcut(Qt::Key_Escape); //cancel current polyline edition
-	addOverridenShortcut(Qt::Key_Delete); //delete key to delete the selected polyline
+	addOverriddenShortcut(Qt::Key_Space);  //space bar for the "pause" button
+	addOverriddenShortcut(Qt::Key_Escape); //cancel current polyline edition
+	addOverriddenShortcut(Qt::Key_Delete); //delete key to delete the selected polyline
 
 	connect(this, &ccOverlayDialog::shortcutTriggered, this, &ccSectionExtractionTool::onShortcutTriggered);
 }

--- a/qCC/ccTracePolylineTool.cpp
+++ b/qCC/ccTracePolylineTool.cpp
@@ -69,8 +69,8 @@ ccTracePolylineTool::ccTracePolylineTool(ccPickingHub* pickingHub, QWidget* pare
 	connect(m_ui->widthSpinBox,			static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &ccTracePolylineTool::onWidthSizeChanged);
 
 	//add shortcuts
-	addOverridenShortcut(Qt::Key_Escape); //escape key for the "cancel" button
-	addOverridenShortcut(Qt::Key_Return); //return key for the "apply" button
+	addOverriddenShortcut(Qt::Key_Escape); //escape key for the "cancel" button
+	addOverriddenShortcut(Qt::Key_Return); //return key for the "apply" button
 	connect(this, &ccTracePolylineTool::shortcutTriggered, this, &ccTracePolylineTool::onShortcutTriggered);
 
 	m_polyTipVertices = new ccPointCloud("Tip vertices", static_cast<unsigned>(ReservedIDs::TRACE_POLYLINE_TOOL_POLYLINE_TIP_VERTICES));

--- a/qCC/db_tree/ccPropertiesTreeDelegate.cpp
+++ b/qCC/db_tree/ccPropertiesTreeDelegate.cpp
@@ -428,7 +428,7 @@ void ccPropertiesTreeDelegate::fillWithHObject(ccHObject* _obj)
 	appendRow(ITEM( tr( "Name" ) ), ITEM(_obj->getName(), Qt::ItemIsEditable, OBJECT_NAME));
 
 	//visibility
-	if (!_obj->isVisiblityLocked())
+	if (!_obj->isVisibilityLocked())
 	{
 		appendRow(ITEM(tr("Visible")), CHECKABLE_ITEM(_obj->isVisible(), OBJECT_VISIBILITY));
 	}
@@ -967,7 +967,7 @@ void ccPropertiesTreeDelegate::fillWithTransBuffer(const ccIndexedTransformation
 	appendRow(ITEM( tr( "Show path" ) ), CHECKABLE_ITEM(_obj->isPathShownAsPolyline(), OBJECT_SHOW_TRANS_BUFFER_PATH));
 
 	//Show trihedrons
-	appendRow(ITEM( tr( "Show trihedrons" ) ), CHECKABLE_ITEM(_obj->triherdonsShown(), OBJECT_SHOW_TRANS_BUFFER_TRIHDERONS));
+	appendRow(ITEM( tr( "Show trihedrons" ) ), CHECKABLE_ITEM(_obj->trihedronsShown(), OBJECT_SHOW_TRANS_BUFFER_TRIHDERONS));
 
 	//Trihedrons scale
 	appendRow(ITEM( tr( "Scale" ) ), PERSISTENT_EDITOR(OBJECT_TRANS_BUFFER_TRIHDERONS_SCALE), true);
@@ -1923,7 +1923,7 @@ void ccPropertiesTreeDelegate::setEditorData(QWidget *editor, const QModelIndex 
 	{
 		ccIndexedTransformationBuffer* buffer = ccHObjectCaster::ToTransBuffer(m_currentObject);
 		assert(buffer);
-		SetDoubleSpinBoxValue(editor, buffer ? buffer->triherdonsDisplayScale() : 0.0);
+		SetDoubleSpinBoxValue(editor, buffer ? buffer->trihedronsDisplayScale() : 0.0);
 		break;
 	}
 	case OBJECT_CLOUD_POINT_SIZE:
@@ -2118,7 +2118,7 @@ void ccPropertiesTreeDelegate::updateItem(QStandardItem * item)
 	{
 		ccIndexedTransformationBuffer* buffer = ccHObjectCaster::ToTransBuffer(m_currentObject);
 		assert(buffer);
-		buffer->showTriherdons(item->checkState() == Qt::Checked);
+		buffer->showTrihedrons(item->checkState() == Qt::Checked);
 	}
 	redraw = true;
 	break;
@@ -2636,10 +2636,10 @@ void ccPropertiesTreeDelegate::trihedronsScaleChanged(double val)
 	ccIndexedTransformationBuffer* buffer = ccHObjectCaster::ToTransBuffer(m_currentObject);
 	assert(buffer);
 
-	if (buffer && buffer->triherdonsDisplayScale() != static_cast<float>(val))
+	if (buffer && buffer->trihedronsDisplayScale() != static_cast<float>(val))
 	{
-		buffer->setTriherdonsDisplayScale(static_cast<float>(val));
-		if (buffer->triherdonsShown())
+		buffer->setTrihedronsDisplayScale(static_cast<float>(val));
+		if (buffer->trihedronsShown())
 		{
 			updateDisplay();
 		}

--- a/qCC/extern/QCustomPlot/qcustomplot.cpp
+++ b/qCC/extern/QCustomPlot/qcustomplot.cpp
@@ -287,7 +287,7 @@ QCPPainter::QCPPainter() :
   mModes(pmDefault),
   mIsAntialiasing(false)
 {
-  // don't setRenderHint(QPainter::NonCosmeticDefautPen) here, because painter isn't active yet and
+  // don't setRenderHint(QPainter::NonCosmeticDefaultPen) here, because painter isn't active yet and
   // a call to begin() will follow
 }
 
@@ -29618,7 +29618,7 @@ QPen QCPItemPixmap::mainPen() const
   the coordinate axes of the graph and update its \a position to be on the graph's data. This means
   the key stays controllable via \ref setGraphKey, but the value will follow the graph data. If a
   QCPGraph is connected, note that setting the coordinates of the tracer item directly via \a
-  position will have no effect because they will be overriden in the next redraw (this is when the
+  position will have no effect because they will be overridden in the next redraw (this is when the
   coordinate update happens).
   
   If the specified key in \ref setGraphKey is outside the key bounds of the graph, the tracer will


### PR DESCRIPTION
Fix a bunch of typos in comments/documentation.

And use \warning for better doxygen output.


There are some typos in methods names, should we also correct them ?