### PR TITLE
LasFilter: use Qstring::toStdString in tilling mode

### DIFF
--- a/plugins/core/IO/qPDALIO/src/LASFilter.cpp
+++ b/plugins/core/IO/qPDALIO/src/LASFilter.cpp
@@ -804,7 +804,7 @@ public:
 			PointTable table;
 			BufferReader bufferReader;
 
-			writerOptions.add("filename", fileNames[i].toLocal8Bit().toStdString());
+			writerOptions.add("filename", fileNames[i].toStdString());
 			if (tilePointViews[i]->empty())
 				continue;
 			try


### PR DESCRIPTION
This applies the fix proposed in #1489 