### PR TITLE
PLY: TEXTUREFILE -> TextureFile

### DIFF
--- a/libs/qCC_io/src/PlyFilter.cpp
+++ b/libs/qCC_io/src/PlyFilter.cpp
@@ -371,8 +371,8 @@ CC_FILE_ERROR PlyFilter::saveToFile(ccHObject* entity, QString filename, e_ply_s
 				}
 				else
 				{
-					//save texture filename as a comment!
-					result = ply_add_comment(ply,qPrintable(QString("TEXTUREFILE %1").arg(defaultTextureName)));
+					//save texture filename as a comment! Note MeshLab only supports CamelCase as of writing.
+					result = ply_add_comment(ply,qPrintable(QString("TextureFile %1").arg(defaultTextureName)));
 					//DGM FIXME: is this the right name?
 					result = ply_add_list_property(ply, "texcoord", PLY_UCHAR, PLY_FLOAT); //'texcoord' to mimick Photoscan
 					


### PR DESCRIPTION
MeshLab, which is the most popular user of the TextureFile comment,
only supports CamelCase, not all-caps.

This change makes textures PLY meshes exported by CloudCompare
open immediately in MeshLab.