### PR TITLE
QSharedPointer explicit construction with nullptr

### DIFF
--- a/libs/qCC_db/src/ccColorScale.cpp
+++ b/libs/qCC_db/src/ccColorScale.cpp
@@ -80,7 +80,7 @@ ccColorScale::Shared ccColorScale::copy(const QString& uuid/*=QString()*/) const
 	catch (const std::bad_alloc&)
 	{
 		ccLog::Warning("Not enough memory to copy the color scale");
-		return nullptr;
+		return ccColorScale::Shared(nullptr);
 	}
 
 	return newCS;


### PR DESCRIPTION
The implicit constructor with nullptr fails on ubuntu 16.04 versions with qt 5.11