### PR TITLE
Fix macOs DeployQt.cmake for XCode generator

### DIFF
--- a/cmake/DeployQt.cmake
+++ b/cmake/DeployQt.cmake
@@ -47,8 +47,13 @@ function( DeployQt )
 		
 	if ( APPLE )
 		set( app_name "${name}.app" )
-		set( app_path "${CMAKE_CURRENT_BINARY_DIR}/${app_name}" )
-		set( temp_dir "${CMAKE_CURRENT_BINARY_DIR}/deployqt" )
+		if (CMAKE_CONFIGURATION_TYPES)
+			set(app_path "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${app_name}")
+			set(temp_dir "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/deployqt")
+		else ()
+			set(app_path "${CMAKE_CURRENT_BINARY_DIR}/${app_name}")
+			set(temp_dir "${CMAKE_CURRENT_BINARY_DIR}/deployqt")
+		endif ()
 		set( temp_app_path "${temp_dir}/$<CONFIG>/${app_name}" )
 
 		add_custom_command(


### PR DESCRIPTION
XCode is a multi config generator so we have to take that
into account to point to the correct path where binaries are.