### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/libs/CCAppCommon/src/ccPluginManager.cpp
+++ b/libs/CCAppCommon/src/ccPluginManager.cpp
@@ -273,7 +273,7 @@ void ccPluginManager::loadFromPathsAndAddToList()
 		"*.dylib"
 #elif defined(Q_OS_WIN)
 		"*.dll"
-#elif defined(Q_OS_LINUX)
+#elif defined(Q_OS_UNIX)
 		"*.so"
 #else
 #error Need to specify the dynamic library extension for this OS.


### PR DESCRIPTION
.so is the standard for unix-like (except macos), not only linux.

Replace Q_OS_LINUX by Q_OS_UNIX