### PR TITLE
CMake/macOs: Fix install

### DIFF
--- a/ccViewer/CMakeLists.txt
+++ b/ccViewer/CMakeLists.txt
@@ -82,8 +82,10 @@ if( WIN32 )
 	endif()
 endif()
 
-# install program
-install_ext( TARGETS ccViewer ${CCVIEWER_DEST_FOLDER} "" )
+if (NOT APPLE)
+	# install program
+	install_ext( TARGETS ccViewer ${CCVIEWER_DEST_FOLDER} "" )
+endif()
 
 # Auxiliary files
 set( auxFiles bin_other/license.txt )

--- a/cmake/DeployQt.cmake
+++ b/cmake/DeployQt.cmake
@@ -71,6 +71,7 @@ function( DeployQt )
 		install(
 			DIRECTORY ${temp_app_path}
 			DESTINATION "${deploy_path}"
+			USE_SOURCE_PERMISSIONS
 		)
 	elseif( WIN32 )	
 		set( app_name "${name}.exe" )

--- a/qCC/CMakeLists.txt
+++ b/qCC/CMakeLists.txt
@@ -92,8 +92,12 @@ if( WIN32 )
 	endif()
 endif()
 
-# install program
-install_ext( TARGETS ${PROJECT_NAME} ${CLOUDCOMPARE_DEST_FOLDER} "" )
+if (NOT APPLE)
+	# Install program.
+	# On macOs, the DeployQt step will install the bundle that contains the executable with
+	# library paths properly set, reinstalling the executable here would break the bundle.
+	install_ext( TARGETS ${PROJECT_NAME} ${CLOUDCOMPARE_DEST_FOLDER} "" )
+endif()
 
 # Auxiliary files
 set( auxFiles  ${CloudCompareProjects_SOURCE_DIR}/CHANGELOG.md bin_other/license.txt bin_other/global_shift_list_template.txt )


### PR DESCRIPTION
Installing the CloudCompare / CCViewer executable after DeployQt broke the installation
because it overwrote in the bundle (.app) the executable that had the proper path to load liraries
(set by the macdeployqt program) by the 'base' executable that does not have the proper paths to
load libraries resulting in a broken .app

In the DeployQt for macOs use USE_SOURCE_PERMISSIONS so that the files keep the correct
permissions (like permission to be executable).