### PR TITLE
define SUPPORT_TOPO_STREAM_OPERATORS for Cork plugin

### DIFF
--- a/plugins/core/Standard/qCork/src/qCork.cpp
+++ b/plugins/core/Standard/qCork/src/qCork.cpp
@@ -31,6 +31,7 @@
 #include <QtConcurrentRun>
 
 //Cork
+#define SUPPORT_TOPO_STREAM_OPERATORS
 #include <mesh/corkMesh.h>
 
 //system


### PR DESCRIPTION
This defines `SUPPORT_TOPO_STREAM_OPERATORS` to compile Cork with the streaming operators (see https://github.com/CloudCompare/CloudCompare/issues/1368).

This fixes the build error:
```
error: no type named ‘type’ in ‘struct std::enable_if<false, std::basic_ostream<char>&>’
```
when building the Cork plugin.