### PR TITLE
Allow paths to be defined in environment variables

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -247,3 +247,5 @@ See [this post](http://www.danielgm.net/cc/forum/viewtopic.php?t=992) on the for
 ## Debugging plugins
 
 If you want to use or debug plugins in DEBUG mode while using a single configuration compiler/IDE (gcc, etc.) the you'll have to comment the automatic definition of the `QT_NO_DEBUG` macro in '/plugins/CMakePluginTpl.cmake' (see http://www.cloudcompare.org/forum/viewtopic.php?t=2070).
+
+If you wish to specify a custom directory to search for plugins, shaders, or translations, you may set the `CC_PLUGIN_PATH`, `CC_SHADER_PATH`, and `CC_TRANSLATION_PATH` environment variables. The paths may be relative to the current working directory or absolute.

--- a/libs/CCAppCommon/src/ccApplicationBase.cpp
+++ b/libs/CCAppCommon/src/ccApplicationBase.cpp
@@ -24,6 +24,7 @@
 #include <QSurfaceFormat>
 #include <QTranslator>
 #include <QtGlobal>
+#include <QProcessEnvironment>
 
 // CCCoreLib
 #include "CCPlatform.h"
@@ -226,6 +227,19 @@ void ccApplicationBase::setupPaths()
 #warning Need to specify the shader path for this OS.
 #endif
 
+	// If the environment variables are specified, overwrite the shader and translation paths.
+	QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+
+	if ( env.contains("CC_SHADER_PATH") )
+	{
+		m_ShaderPath = env.value("CC_SHADER_PATH");
+	}
+
+	if ( env.contains("CC_TRANSLATION_PATH") )
+	{
+		m_TranslationPath = env.value("CC_TRANSLATION_PATH");
+	}
+
 	// Add any app data paths to plugin paths
 	// Plugins in these directories take precendence over the included ones
 	// This allows users to put plugins outside of the install directories.
@@ -239,5 +253,12 @@ void ccApplicationBase::setupPaths()
 		{
 			m_PluginPaths << path;
 		}
+	}
+
+	// If the environment variable is specified, the path takes precedence over
+	// included and appdata ones.
+	if ( env.contains("CC_PLUGIN_PATH") )
+	{
+		m_PluginPaths << env.value("CC_PLUGIN_PATH");
 	}
 }


### PR DESCRIPTION
Useful during development, as you sometimes need to specify a custom path for plugins, shaders, and translations.