### PR TITLE
Linux: Fix shared lib install folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,12 +37,6 @@ endif()
 # Default debug suffix for libraries.
 set( CMAKE_DEBUG_POSTFIX "d" )
 
-# RPATH Linux/Unix: (dynamic) libs are put in a subdir of prefix/lib,
-# since they are only used by qCC/ccViewer
-if( UNIX AND NOT APPLE )
-	include( GNUInstallDirs )
-	set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}/cloudcompare")
-endif()
 
 # Define target folders
 # (now that ccViewer can have its own plugins, qCC and ccViewer must fall in separate folders!
@@ -65,7 +59,12 @@ if( WIN32 )
         list( APPEND INSTALL_DESTINATIONS ${CCVIEWER_DEST_FOLDER} )
 	endif()
 elseif( UNIX AND NOT APPLE )
-        set( INSTALL_DESTINATIONS ${CMAKE_INSTALL_PREFIX})
+	# RPATH Linux/Unix: (dynamic) libs are put in $prefix/$lib/cloudcompare,
+	# since they are only used by qCC/ccViewer
+	include( GNUInstallDirs )
+	set( LINUX_INSTALL_SHARED_DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/cloudcompare" )
+	set( CMAKE_INSTALL_RPATH ${LINUX_INSTALL_SHARED_DESTINATION} )
+	set( INSTALL_DESTINATIONS ${CMAKE_INSTALL_PREFIX})
 endif()
 
 # Load advanced scripts

--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -6,11 +6,11 @@
 #
 # Arguments:
 #	TARGET The name of the library target
-function( InstallSharedLibrary )
-	if( NOT INSTALL_DESTINATIONS )
+function(InstallSharedLibrary)
+	if(NOT INSTALL_DESTINATIONS)
 		return()
 	endif()
-	
+
 	cmake_parse_arguments(
 			INSTALL_SHARED_LIB
 			""
@@ -19,26 +19,20 @@ function( InstallSharedLibrary )
 			${ARGN}
 	)
 
-        # For readability
-        set( shared_lib_target "${INSTALL_SHARED_LIB_TARGET}" )
-	message( STATUS "Install shared library: ${shared_lib_target}")
+	# For readability
+	set(shared_lib_target "${INSTALL_SHARED_LIB_TARGET}")
+	message(STATUS "Install shared library: ${shared_lib_target}")
 
-        foreach( destination ${INSTALL_DESTINATIONS} )
-            if(UNIX AND NOT APPLE)
-                # this is a an hack to restore install ability on linux systems
-                # TODO this should not be the right way for managing install probably
-                if (IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
-                    set( destination "${CMAKE_INSTALL_LIBDIR}")
-                else()
-                    set( destination "${destination}/${CMAKE_INSTALL_LIBDIR}/")
-                endif()
-            endif()
+	foreach (destination ${INSTALL_DESTINATIONS})
+		if(UNIX AND NOT APPLE)
+			set(destination ${LINUX_INSTALL_SHARED_DESTINATION})
+		endif()
 
 		_InstallSharedTarget(
-			TARGET ${shared_lib_target}
-			DEST_PATH ${destination}
-		)		
-	endforeach()
+				TARGET ${shared_lib_target}
+				DEST_PATH ${destination}
+		)
+	endforeach ()
 endfunction()
 
 # InstallFiles should be called to install files that are not targets.


### PR DESCRIPTION
On Linux the `INSTALL_RPATH` was set to
`"${CMAKE_INSTALL_FULL_LIBDIR}/cloudcompare`.

However the path where the shared libs were installed
was set to `"${destination}/${CMAKE_INSTALL_LIBDIR}/` or
`"${CMAKE_INSTALL_LIBDIR}"` which is not the same path as
the `INSTALL_RPATH`.

To illustrate, with a `CMAKE_INSTALL_PREFIX` set to
`~/CloudCompare/install` the shared libs were installed
in `~/CloudCompare/install/lib64` but the RPATH set in
each lib was pointing to `~/CloudCompare/install/lib64/cloudcompare`

Resulting in an error like this when running the installed CloudCompare:
```
error while loading shared libraries: libCCAppCommond.so: cannot open shared object file: No such file or directory
```

This fixes the problem by making the two things point to the same
path `"${CMAKE_INSTALL_FULL_LIBDIR}/cloudcompare"`.
So in the example libs properly end up in
`~/CloudCompare/install/lib64/cloudcompare`.

Although the cmake for installing shared target is still a bit ?strange?.