### PR TITLE
Another Global Shift bug fix 

### DIFF
--- a/libs/CCPluginAPI/include/ccCommandLineInterface.h
+++ b/libs/CCPluginAPI/include/ccCommandLineInterface.h
@@ -228,8 +228,8 @@ public: //file I/O
 	{
 		CLLoadParameters();
 
-		bool m_coordinatesShiftEnabled;
-		CCVector3d m_coordinatesShift;
+		bool coordinatesShiftEnabled;
+		CCVector3d coordinatesShift;
 	};
 
 	//! File loading parameters

--- a/libs/CCPluginAPI/src/ccCommandLineInterface.cpp
+++ b/libs/CCPluginAPI/src/ccCommandLineInterface.cpp
@@ -308,12 +308,12 @@ ccCommandLineInterface::Command::Command(const QString &name, const QString &key
 
 ccCommandLineInterface::CLLoadParameters::CLLoadParameters()
 	: FileIOFilter::LoadParameters()
-	, m_coordinatesShiftEnabled(false)
-	, m_coordinatesShift(0, 0, 0)
+	, coordinatesShiftEnabled(false)
+	, coordinatesShift(0, 0, 0)
 {
 	shiftHandlingMode = ccGlobalShiftManager::NO_DIALOG;
 	alwaysDisplayLoadDialog = false;
 	autoComputeNormals = false;
-	coordinatesShiftEnabled = &m_coordinatesShiftEnabled;
-	coordinatesShift = &m_coordinatesShift;
+	_coordinatesShiftEnabled = &coordinatesShiftEnabled;
+	_coordinatesShift = &coordinatesShift;
 }

--- a/libs/qCC_io/include/FileIOFilter.h
+++ b/libs/qCC_io/include/FileIOFilter.h
@@ -63,8 +63,8 @@ public:
 		LoadParameters()
 			: shiftHandlingMode(ccGlobalShiftManager::DIALOG_IF_NECESSARY)
 			, alwaysDisplayLoadDialog(true)
-			, coordinatesShiftEnabled(nullptr)
-			, coordinatesShift(nullptr)
+			, _coordinatesShiftEnabled(nullptr)
+			, _coordinatesShift(nullptr)
 			, preserveShiftOnSave(true)
 			, autoComputeNormals(false)
 			, parentWidget(nullptr)
@@ -76,9 +76,9 @@ public:
 		//! Wether to always display a dialog (if any), even if automatic guess is possible
 		bool alwaysDisplayLoadDialog;
 		//! Whether shift on load has been applied after loading (optional)
-		bool* coordinatesShiftEnabled;
+		bool* _coordinatesShiftEnabled;
 		//! If applicable, applied shift on load (optional)
-		CCVector3d* coordinatesShift;
+		CCVector3d* _coordinatesShift;
 		//! If applicable, whether shift should be preserved or not (optional)
 		bool preserveShiftOnSave;
 		//! Whether normals should be computed at loading time (if possible - e.g. for gridded clouds) or not

--- a/libs/qCC_io/include/ccGlobalShiftManager.h
+++ b/libs/qCC_io/include/ccGlobalShiftManager.h
@@ -46,9 +46,9 @@ public:
 						Mode mode,
 						bool useInputCoordinatesShiftIfPossible,
 						CCVector3d& coordinatesShift,
-						bool* preserveCoordinateShift = nullptr,
-						double* coordinatesScale = nullptr,
-						bool* applyAll = nullptr);
+						bool* _preserveCoordinateShift = nullptr,
+						double* _coordinatesScale = nullptr,
+						bool* _applyAll = nullptr);
 
 	//! Returns whether a particular point (coordinates) is too big or not
 	static bool NeedShift(const CCVector3d& P);
@@ -91,8 +91,15 @@ public: //Shift and scale info
 		ShiftInfo(QString str, const CCVector3d& T, double s = 1.0) : shift(T), scale(s), name(str), preserve(true) {}
 	};
 
-	static bool GetLast(ShiftInfo& info);
-	static bool GetLast(std::vector<ShiftInfo>& infos);
+	//! Returns the default and last input shift/scale entries
+	const static std::vector<ShiftInfo>& GetLast();
+
+	//! Tries to load ShiftInfo data from a (text) file
+	/** \param[in]  filename filename
+		\param[out] infos read information
+		\return success
+	**/
+	static bool LoadInfoFromFile(QString filename, std::vector<ShiftInfo>& infos);
 
 protected:
 	

--- a/libs/qCC_io/include/ccShiftAndScaleCloudDlg.h
+++ b/libs/qCC_io/include/ccShiftAndScaleCloudDlg.h
@@ -108,9 +108,6 @@ public:
 	//! Sets the current combo-box entry (profile)
 	void setCurrentProfile(int index);
 
-	//! Adds information from default file (if any)
-	bool addFileInfo();
-
     //! Sets the last shift and scale information
     static void SetLastInfo(const CCVector3d& shift, double scale);
 
@@ -142,13 +139,6 @@ protected:
 	void updateLocalSystem();
 	//! Updates info on the global coordinate system
 	void updateGlobalSystem();
-
-	//! Tries to load ShiftInfo data from a (text) file
-	/** Data is stored in m_defaultInfos.
-		\param filename filename
-		\return success
-	**/
-	bool loadInfoFromFile(QString filename);
 
 	//! Associated UI
 	Ui_GlobalShiftAndScaleDlg* m_ui;

--- a/libs/qCC_io/src/FileIOFilter.cpp
+++ b/libs/qCC_io/src/FileIOFilter.cpp
@@ -562,10 +562,12 @@ bool FileIOFilter::HandleGlobalShift(	const CCVector3d& P,
 										LoadParameters& loadParameters,
 										bool useInputCoordinatesShiftIfPossible/*=false*/)
 {
-	bool shiftAlreadyEnabled = (loadParameters.coordinatesShiftEnabled && *loadParameters.coordinatesShiftEnabled && loadParameters.coordinatesShift);
+	bool shiftAlreadyEnabled = (	(nullptr != loadParameters._coordinatesShiftEnabled)
+								&&	(*loadParameters._coordinatesShiftEnabled)
+								&&	(nullptr != loadParameters._coordinatesShift) );
 	if (shiftAlreadyEnabled)
 	{
-		Pshift = *loadParameters.coordinatesShift;
+		Pshift = *loadParameters._coordinatesShift;
 		preserveCoordinateShift = loadParameters.preserveShiftOnSave;
 	}
 	
@@ -580,12 +582,17 @@ bool FileIOFilter::HandleGlobalShift(	const CCVector3d& P,
 											nullptr,
 											&applyAll) )
 	{
-		//we save coordinates shift information
-		if ((applyAll || loadParameters.shiftHandlingMode == ccGlobalShiftManager::NO_DIALOG_AUTO_SHIFT) //in command line mode, with the 'AUTO GLOBAL SHIFT' option, we want to retrieve the applied coordinate shift
-			&& loadParameters.coordinatesShiftEnabled && loadParameters.coordinatesShift)
+		// we save coordinates shift information
+		if (applyAll || loadParameters.shiftHandlingMode == ccGlobalShiftManager::NO_DIALOG_AUTO_SHIFT) //in command line mode, with the 'AUTO GLOBAL SHIFT' option, we want to retrieve the applied coordinate shift
 		{
-			*loadParameters.coordinatesShiftEnabled = true;
-			*loadParameters.coordinatesShift = Pshift;
+			if (nullptr != loadParameters._coordinatesShiftEnabled)
+			{
+				*loadParameters._coordinatesShiftEnabled = true;
+			}
+			if (nullptr != loadParameters._coordinatesShift)
+			{
+				*loadParameters._coordinatesShift = Pshift;
+			}
 			loadParameters.preserveShiftOnSave = preserveCoordinateShift;
 		}
 

--- a/libs/qCC_io/test/TestShpFilter.cpp
+++ b/libs/qCC_io/test/TestShpFilter.cpp
@@ -10,6 +10,14 @@
 #include "ccHObject.h"
 #include "ccPointCloud.h"
 
+static void SetDefaultLoadParameters(FileIOFilter::LoadParameters& params, CCVector3d& shift, bool& shiftEnabled)
+{
+	params.alwaysDisplayLoadDialog = false;
+	params.shiftHandlingMode = ccGlobalShiftManager::Mode::NO_DIALOG;
+	params._coordinatesShiftEnabled = &shiftEnabled;
+	params._coordinatesShift = &shift;
+	params.preserveShiftOnSave = true;
+}
 
 void TestShpFilter::readPolylineFile(const QString &filePath) const
 {
@@ -21,10 +29,10 @@ void TestShpFilter::readPolylineFile(const QString &filePath) const
 
 	QVERIFY(container.getChildrenNumber() == 2);
 
-	for (unsigned i(0); i < container.getChildrenNumber(); ++i)
+	for (unsigned i = 0; i < container.getChildrenNumber(); ++i)
 	{
 		ccHObject *child = container.getChild(i);
-		QVERIFY(child->getClassID() == CC_TYPES::POLY_LINE);
+		QVERIFY(child->isA(CC_TYPES::POLY_LINE));
 	}
 
 	auto *firstPolyline = static_cast<ccPolyline *>(container.getChild(0));
@@ -72,10 +80,10 @@ void TestShpFilter::readPolylineMFile(const QString &filePath) const
 
 	QVERIFY(container.getChildrenNumber() == 2);
 
-	for (unsigned i(0); i < container.getChildrenNumber(); ++i)
+	for (unsigned i = 0; i < container.getChildrenNumber(); ++i)
 	{
 		ccHObject *child = container.getChild(i);
-		QVERIFY(child->getClassID() == CC_TYPES::POLY_LINE);
+		QVERIFY(child->isA(CC_TYPES::POLY_LINE));
 	}
 
 	auto *firstPolyline = static_cast<ccPolyline *>(container.getChild(0));
@@ -131,10 +139,10 @@ void TestShpFilter::readPolylineZFile(const QString &filePath) const
 	QVERIFY(error == CC_FERR_NO_ERROR);
 
 	QVERIFY(container.getChildrenNumber() == 3);
-	for (unsigned i(0); i < container.getChildrenNumber(); ++i)
+	for (unsigned i = 0; i < container.getChildrenNumber(); ++i)
 	{
 		ccHObject *child = container.getChild(i);
-		QVERIFY(child->getClassID() == CC_TYPES::POLY_LINE);
+		QVERIFY(child->isA(CC_TYPES::POLY_LINE));
 	}
 
 	// 1st part of the polyline
@@ -181,7 +189,7 @@ void TestShpFilter::readMultiPointFile(const QString &filePath) const
 	QVERIFY(error == CC_FERR_NO_ERROR);
 
 	QVERIFY(container.getChildrenNumber() == 1);
-	QVERIFY(container.getChild(0)->getClassID() == CC_TYPES::POINT_CLOUD);
+	QVERIFY(container.getChild(0)->isA(CC_TYPES::POINT_CLOUD));
 
 	auto *cloud = static_cast<ccPointCloud *>(container.getChild(0));
 	QVERIFY(cloud->size() == 2);
@@ -206,19 +214,15 @@ void TestShpFilter::readMultiPointZFile(const QString &filePath) const
 
 	ccHObject container;
 	FileIOFilter::LoadParameters params;
-	params.alwaysDisplayLoadDialog = false;
-	params.shiftHandlingMode = ccGlobalShiftManager::Mode::NO_DIALOG;
-	params.coordinatesShiftEnabled = &shiftEnabled;
-	params.coordinatesShift = &shift;
-	params.preserveShiftOnSave = true;
+	SetDefaultLoadParameters(params, shift, shiftEnabled);
 	ShpFilter filter;
 
 	CC_FILE_ERROR error = filter.loadFile(filePath, container, params);
 	QVERIFY(error == CC_FERR_NO_ERROR);
 
 	QVERIFY(container.getChildrenNumber() == 1);
-	ccHObject *item = container.getFirstChild();
-	QVERIFY(item->getClassID() == CC_TYPES::POINT_CLOUD);
+	ccHObject* item = container.getFirstChild();
+	QVERIFY(item->isA(CC_TYPES::POINT_CLOUD));
 
 	auto *pointCloud = static_cast<ccPointCloud *>(item);
 	QVERIFY(pointCloud->size() == 4);
@@ -264,9 +268,9 @@ void TestShpFilter::readMultipatchFile(const QString &filePath) const
 
 	QVERIFY(container.getChildrenNumber() == 2);
 
-	for (unsigned i(0); i < container.getChildrenNumber(); ++i)
+	for (unsigned i = 0; i < container.getChildrenNumber(); ++i)
 	{
-		QVERIFY(container.getChild(i)->getClassID() == CC_TYPES::MESH);
+		QVERIFY(container.getChild(i)->isA(CC_TYPES::MESH));
 	}
 
 	constexpr unsigned expectedNumPoints = 10;
@@ -309,21 +313,17 @@ void TestShpFilter::readPolygonFile(const QString &filePath) const
 
 	ccHObject container;
 	FileIOFilter::LoadParameters params;
-	params.alwaysDisplayLoadDialog = false;
-	params.shiftHandlingMode = ccGlobalShiftManager::Mode::NO_DIALOG;
-	params.coordinatesShiftEnabled = &shiftEnabled;
-	params.coordinatesShift = &shift;
-	params.preserveShiftOnSave = true;
+	SetDefaultLoadParameters(params, shift, shiftEnabled);
 	ShpFilter filter;
 
 	CC_FILE_ERROR error = filter.loadFile(filePath, container, params);
 	QVERIFY(error == CC_FERR_NO_ERROR);
 
 	QVERIFY(container.getChildrenNumber() == 1);
-	ccHObject *item = container.getFirstChild();
-	QVERIFY(item->getClassID() == CC_TYPES::POLY_LINE);
+	ccHObject* item = container.getFirstChild();
+	QVERIFY(item->isA(CC_TYPES::POLY_LINE));
 
-	auto *poly = static_cast<ccPolyline *>(item);
+	auto poly = static_cast<ccPolyline *>(item);
 	QVERIFY(poly->size() == expectedNumPoints);
 	QVERIFY(!poly->isScalarFieldEnabled());
 	QVERIFY(!poly->is2DMode());
@@ -341,7 +341,7 @@ void TestShpFilter::readPolygonFile(const QString &filePath) const
 	                                  5391094.921049644, 5271679.246403368, 5352573.735679878, 5219675.646154184,
 	                                  5348721.617142901, 5789789.189626727};
 
-	for (unsigned i(0); i < expectedNumPoints; ++i)
+	for (unsigned i = 0; i < expectedNumPoints; ++i)
 	{
 		const CCVector3 *p = vertices->getPoint(i);
 		QCOMPARE(p->x, static_cast<ScalarType >(expectedXs[i] + shift.x));
@@ -358,18 +358,14 @@ void TestShpFilter::readPolygonZFile(const QString &filePath) const
 
 	ccHObject container;
 	FileIOFilter::LoadParameters params;
-	params.alwaysDisplayLoadDialog = false;
-	params.shiftHandlingMode = ccGlobalShiftManager::Mode::NO_DIALOG;
-	params.coordinatesShiftEnabled = &shiftEnabled;
-	params.coordinatesShift = &shift;
-	params.preserveShiftOnSave = true;
+	SetDefaultLoadParameters(params, shift, shiftEnabled);
 	ShpFilter filter;
 
 	CC_FILE_ERROR error = filter.loadFile(filePath, container, params);
 	QVERIFY(error == CC_FERR_NO_ERROR);
 
 	QVERIFY(container.getChildrenNumber() == 1);
-	QVERIFY(container.getFirstChild()->getClassID() == CC_TYPES::POLY_LINE);
+	QVERIFY(container.getFirstChild()->isA(CC_TYPES::POLY_LINE));
 
 	auto *polygon = static_cast<ccPolyline *>(container.getFirstChild());
 	QVERIFY(polygon->size() == 72); //File has 73 points, but cc reads 72 as its a polygon
@@ -483,11 +479,7 @@ void TestShpFilter::testWriteMultiPointZFile() const
 
 	ccHObject container;
 	FileIOFilter::LoadParameters params;
-	params.alwaysDisplayLoadDialog = false;
-	params.shiftHandlingMode = ccGlobalShiftManager::Mode::NO_DIALOG;
-	params.coordinatesShiftEnabled = &shiftEnabled;
-	params.coordinatesShift = &shift;
-	params.preserveShiftOnSave = true;
+	SetDefaultLoadParameters(params, shift, shiftEnabled);
 	ShpFilter filter;
 
 	CC_FILE_ERROR error = filter.loadFile(MULTIPOINT_Z, container, params);
@@ -512,11 +504,7 @@ void TestShpFilter::testWritePolygonFile() const
 
 	ccHObject container;
 	FileIOFilter::LoadParameters params;
-	params.alwaysDisplayLoadDialog = false;
-	params.shiftHandlingMode = ccGlobalShiftManager::Mode::NO_DIALOG;
-	params.coordinatesShiftEnabled = &shiftEnabled;
-	params.coordinatesShift = &shift;
-	params.preserveShiftOnSave = true;
+	SetDefaultLoadParameters(params, shift, shiftEnabled);
 	ShpFilter filter;
 
 	CC_FILE_ERROR error = filter.loadFile(POLYGON_FILE, container, params);
@@ -543,11 +531,7 @@ void TestShpFilter::testWritePolygonZFile() const
 
 	ccHObject container;
 	FileIOFilter::LoadParameters params;
-	params.alwaysDisplayLoadDialog = false;
-	params.shiftHandlingMode = ccGlobalShiftManager::Mode::NO_DIALOG;
-	params.coordinatesShiftEnabled = &shiftEnabled;
-	params.coordinatesShift = &shift;
-	params.preserveShiftOnSave = true;
+	SetDefaultLoadParameters(params, shift, shiftEnabled);
 	ShpFilter filter;
 
 	CC_FILE_ERROR error = filter.loadFile(POLYGONZ_FILE, container, params);
@@ -573,18 +557,14 @@ void TestShpFilter::readSinglePointZFile(const QString &filePath) const
 
 	ccHObject container;
 	FileIOFilter::LoadParameters params;
-	params.alwaysDisplayLoadDialog = false;
-	params.shiftHandlingMode = ccGlobalShiftManager::Mode::NO_DIALOG;
-	params.coordinatesShiftEnabled = &shiftEnabled;
-	params.coordinatesShift = &shift;
-	params.preserveShiftOnSave = true;
+	SetDefaultLoadParameters(params, shift, shiftEnabled);
 	ShpFilter filter;
 
 	CC_FILE_ERROR error = filter.loadFile(filePath, container, params);
 	QVERIFY(error == CC_FERR_NO_ERROR);
 
 	QVERIFY(container.getChildrenNumber() == 1);
-	QVERIFY(container.getFirstChild()->getClassID() == CC_TYPES::POINT_CLOUD);
+	QVERIFY(container.getFirstChild()->isA(CC_TYPES::POINT_CLOUD));
 
 	unsigned expectedNumPoints = 2;
 	auto *cloud = static_cast<ccPointCloud *>(container.getFirstChild());
@@ -594,7 +574,7 @@ void TestShpFilter::readSinglePointZFile(const QString &filePath) const
 	std::array<double, 2> expectedXs{1422464.3681007193, 1422459.0908050265};
 	std::array<double, 2> expectedYs{4188962.3364355816, 4188942.211755641};
 	std::array<double, 2> expectedZs{72.40956470558095, 72.58286959604922};
-	for (unsigned i(0); i < expectedNumPoints; ++i)
+	for (unsigned i = 0; i < expectedNumPoints; ++i)
 	{
 		const CCVector3 *p = cloud->getPoint(i);
 		QCOMPARE(p->x, static_cast<ScalarType>(expectedXs[i] + shift.x));

--- a/plugins/core/IO/qCoreIO/src/SimpleBinFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/SimpleBinFilter.cpp
@@ -568,7 +568,7 @@ CC_FILE_ERROR SimpleBinFilter::loadFile(const QString& filename, ccHObject& cont
 			ccGlobalShiftManager::Mode csModeBackup = parameters.shiftHandlingMode;
 			bool useGlobalShift = false;
 			CCVector3d Pshift(0, 0, 0);
-			if ((descriptor.globalShift.norm2() != 0 || descriptor.globalScale != 1.0) && (!parameters.coordinatesShiftEnabled || !*parameters.coordinatesShiftEnabled))
+			if ((descriptor.globalShift.norm2() != 0 || descriptor.globalScale != 1.0) && ((nullptr == parameters._coordinatesShiftEnabled) || (false == *parameters._coordinatesShiftEnabled)))
 			{
 				if (csModeBackup != ccGlobalShiftManager::NO_DIALOG) //No dialog, practically means that we don't want any shift!
 				{

--- a/plugins/core/IO/qLASFWFIO/src/LASFWFFilter.cpp
+++ b/plugins/core/IO/qLASFWFIO/src/LASFWFFilter.cpp
@@ -1144,7 +1144,7 @@ CC_FILE_ERROR LASFWFFilter::loadFile(const QString& filename, ccHObject& contain
 				ccGlobalShiftManager::Mode csModeBackup = parameters.shiftHandlingMode;
 				bool useLasShift = false;
 				//set the LAS shift as default shift (if none was provided)
-				if (lasShift.norm2() != 0 && (!parameters.coordinatesShiftEnabled || !*parameters.coordinatesShiftEnabled))
+				if (lasShift.norm2() != 0 && ((nullptr == parameters._coordinatesShiftEnabled) || (false == *parameters._coordinatesShiftEnabled)))
 				{
 					useLasShift = true;
 					Pshift = lasShift;

--- a/plugins/core/IO/qPDALIO/src/LASFilter.cpp
+++ b/plugins/core/IO/qPDALIO/src/LASFilter.cpp
@@ -1406,17 +1406,17 @@ CC_FILE_ERROR LASFilter::loadFile(const QString& filename, ccHObject& container,
 				ccGlobalShiftManager::Mode csModeBackup = parameters.shiftHandlingMode;
 				bool useLasOffset = false;
 				//set the lasOffset as default if none was provided
-				if (lasOffset.norm2() != 0 && (!parameters.coordinatesShiftEnabled || !*parameters.coordinatesShiftEnabled))
+				if (lasOffset.norm2() != 0 && ((nullptr == parameters._coordinatesShiftEnabled) || (false == *parameters._coordinatesShiftEnabled)))
 				{
-					    if (csModeBackup != ccGlobalShiftManager::NO_DIALOG) //No dialog, practically means that we don't want any shift!
+				    if (csModeBackup != ccGlobalShiftManager::NO_DIALOG) //No dialog, practically means that we don't want any shift!
+					{
+						useLasOffset = true;
+						Pshift = -lasOffset;
+						if (csModeBackup != ccGlobalShiftManager::NO_DIALOG_AUTO_SHIFT)
 						{
-							useLasOffset = true;
-							Pshift = -lasOffset;
-							if (csModeBackup != ccGlobalShiftManager::NO_DIALOG_AUTO_SHIFT)
-							{
-								parameters.shiftHandlingMode = ccGlobalShiftManager::ALWAYS_DISPLAY_DIALOG;
-							}
+							parameters.shiftHandlingMode = ccGlobalShiftManager::ALWAYS_DISPLAY_DIALOG;
 						}
+					}
 				}
 
 				if (HandleGlobalShift(P, Pshift, preserveCoordinateShift, parameters, useLasOffset))

--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -380,8 +380,8 @@ bool ccCommandLineParser::importFile(QString filename, const GlobalShiftOptions&
 
 	//default Global Shift handling parameters
 	m_loadingParameters.shiftHandlingMode = ccGlobalShiftManager::NO_DIALOG;
-	m_loadingParameters.m_coordinatesShiftEnabled = false;
-	m_loadingParameters.m_coordinatesShift = CCVector3d(0, 0, 0);
+	m_loadingParameters.coordinatesShiftEnabled = false;
+	m_loadingParameters.coordinatesShift = CCVector3d(0, 0, 0);
 
 	switch (globalShiftOptions.mode)
 	{
@@ -393,14 +393,14 @@ bool ccCommandLineParser::importFile(QString filename, const GlobalShiftOptions&
 	case GlobalShiftOptions::FIRST_GLOBAL_SHIFT:
 		//use the first encountered global shift value (if any)
 		m_loadingParameters.shiftHandlingMode = ccGlobalShiftManager::NO_DIALOG_AUTO_SHIFT;
-		m_loadingParameters.m_coordinatesShiftEnabled = s_firstCoordinatesShiftEnabled;
-		m_loadingParameters.m_coordinatesShift = s_firstGlobalShift;
+		m_loadingParameters.coordinatesShiftEnabled = s_firstCoordinatesShiftEnabled;
+		m_loadingParameters.coordinatesShift = s_firstGlobalShift;
 		break;
 
 	case GlobalShiftOptions::CUSTOM_GLOBAL_SHIFT:
 		//set the user defined shift vector as default shift information
-		m_loadingParameters.m_coordinatesShiftEnabled = true;
-		m_loadingParameters.m_coordinatesShift = globalShiftOptions.customGlobalShift;
+		m_loadingParameters.coordinatesShiftEnabled = true;
+		m_loadingParameters.coordinatesShift = globalShiftOptions.customGlobalShift;
 		break;
 
 	default:
@@ -430,8 +430,8 @@ bool ccCommandLineParser::importFile(QString filename, const GlobalShiftOptions&
 		if (s_firstTime)
 		{
 			// remember the first Global Shift parameters used
-			s_firstCoordinatesShiftEnabled = m_loadingParameters.m_coordinatesShiftEnabled;
-			s_firstGlobalShift = m_loadingParameters.m_coordinatesShift;
+			s_firstCoordinatesShiftEnabled = m_loadingParameters.coordinatesShiftEnabled;
+			s_firstGlobalShift = m_loadingParameters.coordinatesShift;
 			s_firstTime = false;
 		}
 	}

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -1150,14 +1150,8 @@ void MainWindow::applyTransformation(const ccGLMatrixd& mat)
 							double suggestedScale = ccGlobalShiftManager::BestScale(Dg);
 							index = sasDlg.addShiftInfo(ccGlobalShiftManager::ShiftInfo(tr("Suggested"), suggestedShift, suggestedScale));
 							sasDlg.setCurrentProfile(index);
-							//add "last" entry (if available)
-							std::vector<ccGlobalShiftManager::ShiftInfo> lastInfos;
-							if (ccGlobalShiftManager::GetLast(lastInfos))
-							{
-								sasDlg.addShiftInfo(lastInfos);
-							}
-							//add entries from file (if any)
-							sasDlg.addFileInfo();
+							//add "last" entries (if any)
+							sasDlg.addShiftInfo(ccGlobalShiftManager::GetLast());
 
 							if (sasDlg.exec())
 							{
@@ -1491,14 +1485,8 @@ void MainWindow::doActionEditGlobalShiftAndScale()
 	//add "original" entry
 	int index = sasDlg.addShiftInfo(ccGlobalShiftManager::ShiftInfo(tr("Original"), shift, scale));
 	sasDlg.setCurrentProfile(index);
-	//add "last" entry (if available)
-	std::vector<ccGlobalShiftManager::ShiftInfo> lastInfos;
-	if (ccGlobalShiftManager::GetLast(lastInfos))
-	{
-		sasDlg.addShiftInfo(lastInfos);
-	}
-	//add entries from file (if any)
-	sasDlg.addFileInfo();
+	//add "last" entries (if any)
+	sasDlg.addShiftInfo(ccGlobalShiftManager::GetLast());
 
 	if (!sasDlg.exec())
 		return;
@@ -9780,8 +9768,8 @@ void MainWindow::addToDB(	const QStringList& filenames,
 	{
 		parameters.alwaysDisplayLoadDialog = true;
 		parameters.shiftHandlingMode = ccGlobalShiftManager::DIALOG_IF_NECESSARY;
-		parameters.coordinatesShift = &loadCoordinatesShift;
-		parameters.coordinatesShiftEnabled = &loadCoordinatesTransEnabled;
+		parameters._coordinatesShift = &loadCoordinatesShift;
+		parameters._coordinatesShiftEnabled = &loadCoordinatesTransEnabled;
 		parameters.parentWidget = this;
 	}
 


### PR DESCRIPTION
The Global Shift was not properly applied to the aligned entities when using manually input points with large coordinates in the 'point-pair alignment' tool.

+ Global shift management code improved (hopefully).