### PR TITLE
Allow the possibility to define multiple plugin paths from CC_PLUGIN_PATH environment variable

### DIFF
--- a/libs/CCAppCommon/src/ccApplicationBase.cpp
+++ b/libs/CCAppCommon/src/ccApplicationBase.cpp
@@ -259,6 +259,6 @@ void ccApplicationBase::setupPaths()
 	// included and appdata ones.
 	if ( env.contains("CC_PLUGIN_PATH") )
 	{
-		m_PluginPaths << env.value("CC_PLUGIN_PATH");
+		m_PluginPaths << env.value("CC_PLUGIN_PATH").split(QDir::listSeparator());
 	}
 }


### PR DESCRIPTION
A very tiny modification to allow definition of multiple plugin paths from environment variable. It can be useful when debugging or compiling a plugin (for example CC_PLUGIN_PATH=<build dir>/plugins/core/IO/qCoreIO:<build dir>/plugins/core/IO/qE57IO)