### PR TITLE
PCL: removing the 16 bytes alignment for cloud fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ v2.12 (???) - (in development)
 	- PCD:
 		- CC can now load PCL files with integer xyz coordinates (16 and 32 bits) as well as double coordinates
 		- CC can now load 'scan grids' corresponding to structured clouds (so as to compute robust normals for instance)
+		- the (standard ?) 16bytes alignment for the various fields has been removed, so as to drastically reduce the memory consumption and the output file size!
 	- STL:
 		- loading speed should be greatly improved (compared to v2.10 and v2.11)
 	- LAS (1.3/1.4):

--- a/plugins/core/Standard/qPCL/PclUtils/utils/cc2sm.cpp
+++ b/plugins/core/Standard/qPCL/PclUtils/utils/cc2sm.cpp
@@ -156,7 +156,6 @@ PCLCloud::Ptr cc2smReader::getColors() const
 	try
 	{
 		PointCloud<OnlyRGB> rgbCloud;
-
 		unsigned pointCount = m_ccCloud->size();
 		rgbCloud.resize(pointCount);
 

--- a/plugins/core/Standard/qPCL/PclUtils/utils/my_point_types.h
+++ b/plugins/core/Standard/qPCL/PclUtils/utils/my_point_types.h
@@ -25,7 +25,7 @@
 #include <pcl/io/boost.h> // for boost::uint8_t
 
 //! PCL custom point type used for reading RGB data
-struct EIGEN_ALIGN16 OnlyRGB
+struct OnlyRGB
 {
 	union
 	{
@@ -47,49 +47,49 @@ struct EIGEN_ALIGN16 OnlyRGB
 };
 
 //! PCL custom point type used for reading intensity data
-struct EIGEN_ALIGN16 PointI
+struct PointI
 {
 	float intensity;
 	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
 };
 
-struct EIGEN_ALIGN16 FloatScalar
+struct FloatScalar
 {
 	float S5c4laR;
 	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
 };
 
-struct EIGEN_ALIGN16 DoubleScalar
+struct DoubleScalar
 {
 	double S5c4laR;
 	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
 };
 
-struct EIGEN_ALIGN16 IntScalar
+struct IntScalar
 {
 	int S5c4laR;
 	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
 };
 
-struct EIGEN_ALIGN16 UIntScalar
+struct UIntScalar
 {
 	unsigned S5c4laR;
 	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
 };
 
-struct EIGEN_ALIGN16 ShortScalar
+struct ShortScalar
 {
 	short S5c4laR;
 	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
 };
 
-struct EIGEN_ALIGN16 UShortScalar
+struct UShortScalar
 {
 	unsigned short S5c4laR;
 	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -97,7 +97,7 @@ struct EIGEN_ALIGN16 UShortScalar
 };
 
 //! PCL custom point type used for reading intensity data
-struct EIGEN_ALIGN16 OnlyNormals
+struct OnlyNormals
 {
 	float normal_x;
 	float normal_y;
@@ -120,7 +120,7 @@ struct OnlyNormalsCurvature
 	};
 };
 
-struct EIGEN_ALIGN16 PointXYZScalar
+struct PointXYZScalar
 {
 	PCL_ADD_POINT4D;
 	float scalar;
@@ -128,7 +128,7 @@ struct EIGEN_ALIGN16 PointXYZScalar
 
 };						// enforce SSE padding for correct memory alignment
 
-struct EIGEN_ALIGN16 PointXYZScalarRGB
+struct PointXYZScalarRGB
 {
 	PCL_ADD_POINT4D;
 	float scalar;
@@ -151,7 +151,7 @@ struct EIGEN_ALIGN16 PointXYZScalarRGB
 
 };
 
-struct EIGEN_ALIGN16 PointXYZScalarRGBNormals
+struct PointXYZScalarRGBNormals
 {
 	PCL_ADD_NORMAL4D;
 	//PCL_ADD_RGB;


### PR DESCRIPTION
The (standard ?) 16 bytes alignment for the various fields has been removed, so as to drastically reduce the memory consumption and the output file size!