### PR TITLE
SF tools: Split cloud using SF / Set classification field

### DIFF
--- a/libs/qCC_io/cmake/GDALSupport.cmake
+++ b/libs/qCC_io/cmake/GDALSupport.cmake
@@ -30,7 +30,64 @@ function( target_link_GDAL ) # ARGV0 = project name
 		message( STATUS "Looking for GDAL DLLs in: " ${GDAL_BIN_DIR} )
 		file( GLOB GDAL_DLL_FILES ${GDAL_BIN_DIR}/gdal*.dll )
 
-		if (GDAL_VERSION_3)
+                message( STATUS "GDAL VERSION: " ${GDAL_VERSION} )
+                if (GDAL_VERSION EQUAL 3.2)
+                    set ( GDAL_DEP_DLL_FILES ${GDAL_BIN_DIR}/xerces-c_3_2.dll
+                        ${GDAL_BIN_DIR}/libexpat.dll
+                        ${GDAL_BIN_DIR}/LIBPQ.dll
+                        ${GDAL_BIN_DIR}/hdf.dll
+                        ${GDAL_BIN_DIR}/mfhdf.dll
+                        ${GDAL_BIN_DIR}/cfitsio.dll
+                        ${GDAL_BIN_DIR}/libjpeg.dll
+                        ${GDAL_BIN_DIR}/netcdf.dll
+                        ${GDAL_BIN_DIR}/geotiff.dll
+                        ${GDAL_BIN_DIR}/tiff.dll
+                        ${GDAL_BIN_DIR}/proj_8_0.dll
+                        ${GDAL_BIN_DIR}/sqlite3.dll
+                        ${GDAL_BIN_DIR}/spatialite.dll
+                        ${GDAL_BIN_DIR}/geos_c.dll
+                        ${GDAL_BIN_DIR}/hdf5.dll
+                        ${GDAL_BIN_DIR}/hdf5_cpp.dll
+                        ${GDAL_BIN_DIR}/libkea.dll
+                        ${GDAL_BIN_DIR}/libcurl.dll
+                        ${GDAL_BIN_DIR}/libpng16.dll
+                        ${GDAL_BIN_DIR}/openjp2.dll
+                        ${GDAL_BIN_DIR}/poppler.dll
+                        ${GDAL_BIN_DIR}/iconv.dll
+                        ${GDAL_BIN_DIR}/libwebp.dll
+                        ${GDAL_BIN_DIR}/tiledb.dll
+                        ${GDAL_BIN_DIR}/freexl.dll
+                        ${GDAL_BIN_DIR}/libssl-1_1-x64.dll
+                        ${GDAL_BIN_DIR}/libcrypto-1_1-x64.dll
+                        ${GDAL_BIN_DIR}/gssapi64.dll
+                        ${GDAL_BIN_DIR}/xdr.dll
+                        ${GDAL_BIN_DIR}/hdf5_hl.dll
+                        ${GDAL_BIN_DIR}/zip.dll
+                        ${GDAL_BIN_DIR}/zlib.dll
+                        ${GDAL_BIN_DIR}/liblzma.dll
+                        ${GDAL_BIN_DIR}/zstd.dll
+                        ${GDAL_BIN_DIR}/libxml2.dll
+                        ${GDAL_BIN_DIR}/charset.dll
+                        ${GDAL_BIN_DIR}/geos.dll
+                        ${GDAL_BIN_DIR}/libssh2.dll
+                        ${GDAL_BIN_DIR}/freetype.dll
+                        ${GDAL_BIN_DIR}/aws-cpp-sdk-s3.dll
+                        ${GDAL_BIN_DIR}/aws-cpp-sdk-core.dll
+                        ${GDAL_BIN_DIR}/aws-cpp-sdk-identity-management.dll
+                        ${GDAL_BIN_DIR}/libbz2.dll
+                        ${GDAL_BIN_DIR}/liblz4.dll
+                        ${GDAL_BIN_DIR}/krb5_64.dll
+                        ${GDAL_BIN_DIR}/comerr64.dll
+                        ${GDAL_BIN_DIR}/k5sprt64.dll
+                        ${GDAL_BIN_DIR}/aws-c-event-stream.dll
+                        ${GDAL_BIN_DIR}/aws-c-common.dll
+                        ${GDAL_BIN_DIR}/aws-cpp-sdk-cognito-identity.dll
+                        ${GDAL_BIN_DIR}/aws-cpp-sdk-sts.dll
+                        ${GDAL_BIN_DIR}/aws-checksums.dll
+                        # for pdal
+                        ${GDAL_BIN_DIR}/laszip3.dll
+                        )
+                elseif (GDAL_VERSION_3)
 			set (  GDAL_DEP_DLL_FILES	${GDAL_BIN_DIR}/ogdi.dll
 										${GDAL_BIN_DIR}/expat.dll
 										${GDAL_BIN_DIR}/libpq.dll

--- a/qCC/ccEntityAction.cpp
+++ b/qCC/ccEntityAction.cpp
@@ -1079,7 +1079,7 @@ namespace ccEntityAction
 		return true;
 	}
 	
-    bool    sfSplitCloud(const ccHObject::Container &selectedEntities, ccMainAppInterface *app)
+    bool sfSplitCloud(const ccHObject::Container &selectedEntities, ccMainAppInterface *app)
     {
         for (ccHObject* ent : selectedEntities)
         {
@@ -1139,6 +1139,20 @@ namespace ccEntityAction
                     group->addChild(pc); // add to group
                     app->addToDB(pc); // add to data base
                 }
+            }
+        }
+
+        return true;
+    }
+
+    bool sfSetClassificationField(const ccHObject::Container &selectedEntities)
+    {
+        for (ccHObject* ent : selectedEntities)
+        {
+            ccPointCloud* cloud = ccHObjectCaster::ToPointCloud(ent);
+            if (cloud != nullptr)
+            {
+
             }
         }
 

--- a/qCC/ccEntityAction.cpp
+++ b/qCC/ccEntityAction.cpp
@@ -1145,20 +1145,6 @@ namespace ccEntityAction
         return true;
     }
 
-    bool sfSetClassificationField(const ccHObject::Container &selectedEntities)
-    {
-        for (ccHObject* ent : selectedEntities)
-        {
-            ccPointCloud* cloud = ccHObjectCaster::ToPointCloud(ent);
-            if (cloud != nullptr)
-            {
-
-            }
-        }
-
-        return true;
-    }
-
 	bool	sfSetAsCoord(const ccHObject::Container &selectedEntities, QWidget *parent)
 	{
 		ccExportCoordToSFDlg ectsDlg(parent);

--- a/qCC/ccEntityAction.h
+++ b/qCC/ccEntityAction.h
@@ -41,6 +41,7 @@ namespace ccEntityAction
 	bool	sfConvertToRandomRGB(const ccHObject::Container &selectedEntities, QWidget *parent);
 	bool	sfRename(const ccHObject::Container &selectedEntities, QWidget *parent);
 	bool	sfAddIdField(const ccHObject::Container &selectedEntities);
+    bool	sfSplitCloud(const ccHObject::Container &selectedEntities, ccMainAppInterface *app);
 	bool	sfSetAsCoord(const ccHObject::Container &selectedEntities, QWidget *parent);
 	bool	exportCoordToSF(const ccHObject::Container &selectedEntities, QWidget *parent);
 	bool	exportNormalToSF(const ccHObject::Container &selectedEntities, QWidget *parent, bool* exportDimensions = nullptr);

--- a/qCC/ccEntityAction.h
+++ b/qCC/ccEntityAction.h
@@ -42,7 +42,6 @@ namespace ccEntityAction
 	bool	sfRename(const ccHObject::Container &selectedEntities, QWidget *parent);
 	bool	sfAddIdField(const ccHObject::Container &selectedEntities);
     bool	sfSplitCloud(const ccHObject::Container &selectedEntities, ccMainAppInterface *app);
-    bool    sfSetClassificationField(const ccHObject::Container &selectedEntities);
 	bool	sfSetAsCoord(const ccHObject::Container &selectedEntities, QWidget *parent);
 	bool	exportCoordToSF(const ccHObject::Container &selectedEntities, QWidget *parent);
 	bool	exportNormalToSF(const ccHObject::Container &selectedEntities, QWidget *parent, bool* exportDimensions = nullptr);

--- a/qCC/ccEntityAction.h
+++ b/qCC/ccEntityAction.h
@@ -42,6 +42,7 @@ namespace ccEntityAction
 	bool	sfRename(const ccHObject::Container &selectedEntities, QWidget *parent);
 	bool	sfAddIdField(const ccHObject::Container &selectedEntities);
     bool	sfSplitCloud(const ccHObject::Container &selectedEntities, ccMainAppInterface *app);
+    bool    sfSetClassificationField(const ccHObject::Container &selectedEntities);
 	bool	sfSetAsCoord(const ccHObject::Container &selectedEntities, QWidget *parent);
 	bool	exportCoordToSF(const ccHObject::Container &selectedEntities, QWidget *parent);
 	bool	exportNormalToSF(const ccHObject::Container &selectedEntities, QWidget *parent, bool* exportDimensions = nullptr);

--- a/qCC/ccGraphicalSegmentationTool.cpp
+++ b/qCC/ccGraphicalSegmentationTool.cpp
@@ -34,6 +34,7 @@
 #include <ccMesh.h>
 #include <ccHObjectCaster.h>
 #include <cc2DViewportObject.h>
+#include <ccSetClassificationField.h>
 
 //for the helper (apply)
 #include <cc2DLabel.h>
@@ -74,6 +75,7 @@ ccGraphicalSegmentationTool::ccGraphicalSegmentationTool(QWidget* parent)
 	connect(validAndDeleteButton,				&QToolButton::clicked,		this,	&ccGraphicalSegmentationTool::applyAndDelete);
 	connect(cancelButton,						&QToolButton::clicked,		this,	&ccGraphicalSegmentationTool::cancel);
 	connect(pauseButton,						&QToolButton::toggled,		this,	&ccGraphicalSegmentationTool::pauseSegmentationMode);
+    connect(toolButton_class,                   &QToolButton::clicked,      this,   &ccGraphicalSegmentationTool::setClassificationField);
 
 	//selection modes
 	connect(actionSetPolylineSelection,			&QAction::triggered,	this,	&ccGraphicalSegmentationTool::doSetPolylineSelection);
@@ -918,6 +920,125 @@ void ccGraphicalSegmentationTool::pauseSegmentationMode(bool state)
 	pauseButton->blockSignals(false);
 
 	m_associatedWin->redraw(!state);
+}
+
+void ccGraphicalSegmentationTool::setClassificationField()
+{
+    int class_ = 0;
+    // get the value of class_
+    ccSetClassificationField setClassificationField(this);
+    if (setClassificationField.exec())
+    {
+        class_ = setClassificationField.getClass();
+    }
+    else
+        return;
+
+    // the following lines are very similar to the segment tool
+
+    if (!m_associatedWin)
+        return;
+
+    if (!m_segmentationPoly)
+    {
+        ccLog::Error("No polyline defined!");
+        return;
+    }
+
+    if (!m_segmentationPoly->isClosed())
+    {
+        ccLog::Error("Define and/or close the segmentation polygon first! (right click to close)");
+        return;
+    }
+
+    // we must close the polyline if we are in RUNNING mode
+    if ((m_state & POLYLINE) != 0 && (m_state & RUNNING) != 0)
+    {
+        QPoint mousePos = m_associatedWin->mapFromGlobal(QCursor::pos());
+        ccLog::Warning(QString("Polyline was not closed - we'll close it with the current mouse cursor position: (%1 ; %2)").arg(mousePos.x()).arg(mousePos.y()));
+        addPointToPolylineExt(mousePos.x(), mousePos.y(), true);
+        closePolyLine(0, 0);
+    }
+
+    ccGLCameraParameters camera;
+    m_associatedWin->getGLCameraParameters(camera);
+    const double half_w = camera.viewport[2] / 2.0;
+    const double half_h = camera.viewport[3] / 2.0;
+
+    //check if the polyline is totally inside the frustum or not
+    bool polyInsideFrustum = true;
+    {
+        int vertexCount = static_cast<int>(m_segmentationPoly->size());
+        for (int i = 0; i < vertexCount; ++i)
+        {
+            const CCVector3* P = m_segmentationPoly->getPoint(i);
+
+            CCVector3d Q2D;
+            bool pointInFrustum = false;
+            camera.project(*P, Q2D, &pointInFrustum);
+
+            if (!pointInFrustum)
+            {
+                polyInsideFrustum = false;
+                break;
+            }
+        }
+    }
+    ccLog::PrintDebug("Polyline is fully inside frustrum: " + QString(polyInsideFrustum ? "Yes" : "No"));
+
+    //for each selected entity
+    for (QSet<ccHObject*>::const_iterator p = m_toSegment.constBegin(); p != m_toSegment.constEnd(); ++p)
+    {
+        ccPointCloud* cloud = ccHObjectCaster::ToPointCloud(*p);
+        assert(cloud);
+
+        // check that the scalar field Classification exists
+        int idx = cloud->getScalarFieldIndexByName("Classification");
+        CCCoreLib::ScalarField *sf = nullptr;
+
+        // create the scalar field Classification if needed
+        if (idx == -1)
+        {
+            idx = cloud->addScalarField("Classification");
+            sf = cloud->getScalarField(idx);
+        }
+        else
+            sf = cloud->getScalarField(idx);
+
+        ccGenericPointCloud::VisibilityTableType& visibilityArray = cloud->getTheVisibilityArray();
+        assert(!visibilityArray.empty());
+
+        int cloudSize = static_cast<int>(cloud->size());
+
+        //we project each point and we check if it falls inside the segmentation polyline
+#if defined(_OPENMP)
+#pragma omp parallel for
+#endif
+        for (int i = 0; i < cloudSize; ++i)
+        {
+            if (visibilityArray[i] == CCCoreLib::POINT_VISIBLE)
+            {
+                const CCVector3* P3D = cloud->getPoint(i);
+
+                CCVector3d Q2D;
+                bool pointInFrustum = false;
+                camera.project(*P3D, Q2D, &pointInFrustum);
+
+                bool pointInside = false;
+                if (pointInFrustum || !polyInsideFrustum) //we can only skip the test if the polyline is fully inside the frustum
+                {
+                    CCVector2 P2D(	static_cast<PointCoordinateType>(Q2D.x - half_w),
+                                    static_cast<PointCoordinateType>(Q2D.y - half_h));
+
+                    pointInside = CCCoreLib::ManualSegmentationTools::isPointInsidePoly(P2D, m_segmentationPoly);
+                }
+
+                if (pointInside)
+                    sf->setValue(i, class_);
+            }
+        }
+        sf->computeMinAndMax();
+    }
 }
 
 void ccGraphicalSegmentationTool::doSetPolylineSelection()

--- a/qCC/ccGraphicalSegmentationTool.cpp
+++ b/qCC/ccGraphicalSegmentationTool.cpp
@@ -924,15 +924,13 @@ void ccGraphicalSegmentationTool::pauseSegmentationMode(bool state)
 
 void ccGraphicalSegmentationTool::setClassificationField()
 {
-    int class_ = 0;
+    int pointClass = 0;
     // get the value of class_
-    ccSetClassificationField setClassificationField(this);
-    if (setClassificationField.exec())
-    {
-        class_ = setClassificationField.getClass();
-    }
-    else
+    ccSetClassificationFieldDlg setClassificationField(this);
+    if (!setClassificationField.exec())
         return;
+    else
+        pointClass = setClassificationField.getClass();
 
     // the following lines are very similar to the segment tool
 
@@ -1034,7 +1032,7 @@ void ccGraphicalSegmentationTool::setClassificationField()
                 }
 
                 if (pointInside)
-                    sf->setValue(i, class_);
+                    sf->setValue(i, pointClass);
             }
         }
         sf->computeMinAndMax();

--- a/qCC/ccGraphicalSegmentationTool.h
+++ b/qCC/ccGraphicalSegmentationTool.h
@@ -97,6 +97,7 @@ protected:
 	void closeRectangle();
 	void updatePolyLine(int x, int y, Qt::MouseButtons buttons);
 	void pauseSegmentationMode(bool);
+    void setClassificationField();
 	void doSetPolylineSelection();
 	void doSetRectangularSelection();
 	void doActionUseExistingPolyline();

--- a/qCC/ccSetClassificationField.cpp
+++ b/qCC/ccSetClassificationField.cpp
@@ -4,23 +4,42 @@
 //qCC_db
 #include <ccHObjectCaster.h>
 #include <ccPointCloud.h>
+#include <QSettings>
 
 ccSetClassificationField::ccSetClassificationField(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::ccSetClassificationField)
 {
     ui->setupUi(this);
+    readSettings();
 }
 
 ccSetClassificationField::~ccSetClassificationField()
 {
+    writeSettings();
     delete ui;
+}
+
+void ccSetClassificationField::readSettings()
+{
+    QSettings settings("osur", "ccSetClassificationField");
+
+    class_ = settings.value("class_", 0).toInt();
+    this->ui->spinBox_classification->setValue(class_);
+}
+
+void ccSetClassificationField::writeSettings()
+{
+    QSettings settings("osur", "ccSetClassificationField");
+
+    int class_ = settings.value("class_", 0).toInt();
+    this->ui->spinBox_classification->setValue(class_);
 }
 
 bool ccSetClassificationField::setClassificationField(const ccHObject::Container &selectedEntities)
 {
     QString errorMessage;
-    int class_ = getClass();
+    class_ = getClass(); // update the internal class_ value
     for (ccHObject* ent : selectedEntities)
     {
         ccPointCloud* cloud = ccHObjectCaster::ToPointCloud(ent);
@@ -57,7 +76,6 @@ bool ccSetClassificationField::setClassificationField(const ccHObject::Container
 
     return true;
 }
-
 
 int ccSetClassificationField::getClass()
 {

--- a/qCC/ccSetClassificationField.cpp
+++ b/qCC/ccSetClassificationField.cpp
@@ -38,10 +38,19 @@ bool ccSetClassificationField::setClassificationField(const ccHObject::Container
                 sf = cloud->getScalarField(idx);
             }
             else
+            {
                 sf = cloud->getScalarField(idx);
+            }
+
             for (unsigned index = 0; index < N; index++)
             {
                 sf->setValue(index, class_);
+            }
+
+            if (sf != nullptr)
+            {
+                sf->computeMinAndMax();
+                cloud->setCurrentDisplayedScalarField(idx);
             }
         }
     }

--- a/qCC/ccSetClassificationField.cpp
+++ b/qCC/ccSetClassificationField.cpp
@@ -6,78 +6,72 @@
 #include <ccPointCloud.h>
 #include <QSettings>
 
-ccSetClassificationField::ccSetClassificationField(QWidget *parent) :
-    QDialog(parent),
-    ui(new Ui::ccSetClassificationField)
+ccSetClassificationFieldDlg::ccSetClassificationFieldDlg(QWidget *parent) : QDialog(parent)
+  , m_ui(new Ui::ccSetClassificationField)
 {
-    ui->setupUi(this);
+    m_ui->setupUi(this);
     readSettings();
 }
 
-ccSetClassificationField::~ccSetClassificationField()
+ccSetClassificationFieldDlg::~ccSetClassificationFieldDlg()
 {
     writeSettings();
-    delete ui;
+    delete m_ui;
 }
 
-void ccSetClassificationField::readSettings()
+void ccSetClassificationFieldDlg::readSettings()
 {
     QSettings settings("osur", "ccSetClassificationField");
 
-    class_ = settings.value("class_", 0).toInt();
-    this->ui->spinBox_classification->setValue(class_);
+    m_class = settings.value("m_class", 0).toInt();
+    this->m_ui->spinBox_classification->setValue(m_class);
 }
 
-void ccSetClassificationField::writeSettings()
+void ccSetClassificationFieldDlg::writeSettings()
 {
     QSettings settings("osur", "ccSetClassificationField");
 
-    int class_ = settings.value("class_", 0).toInt();
-    this->ui->spinBox_classification->setValue(class_);
+    int m_class = settings.value("m_class", 0).toInt();
+    this->m_ui->spinBox_classification->setValue(m_class);
 }
 
-bool ccSetClassificationField::setClassificationField(const ccHObject::Container &selectedEntities)
+bool ccSetClassificationFieldDlg::setClassificationField(const ccHObject::Container &selectedEntities)
 {
     QString errorMessage;
-    class_ = getClass(); // update the internal class_ value
+    m_class = getClass(); // update the internal class_ value
     for (ccHObject* ent : selectedEntities)
     {
         ccPointCloud* cloud = ccHObjectCaster::ToPointCloud(ent);
-        unsigned int N = cloud->size();
         if (cloud != nullptr)
         {
+            unsigned int N = cloud->size();
+
             // check that the scalar field Classification exists
             int idx = cloud->getScalarFieldIndexByName("Classification");
-            CCCoreLib::ScalarField *sf = nullptr;
 
             // create the scalar field Classification if needed
             if (idx == -1)
-            {
                 idx = cloud->addScalarField("Classification");
-                sf = cloud->getScalarField(idx);
-            }
-            else
-            {
-                sf = cloud->getScalarField(idx);
-            }
 
-            for (unsigned index = 0; index < N; index++)
-            {
-                sf->setValue(index, class_);
-            }
+            CCCoreLib::ScalarField *sf = cloud->getScalarField(idx);
 
             if (sf != nullptr)
             {
+                for (unsigned index = 0; index < N; index++)
+                    sf->setValue(index, m_class);
+
                 sf->computeMinAndMax();
                 cloud->setCurrentDisplayedScalarField(idx);
             }
+            else
+                return false;
         }
     }
 
     return true;
 }
 
-int ccSetClassificationField::getClass()
+int ccSetClassificationFieldDlg::getClass() const
 {
-    return ui->spinBox_classification->value();
+    return m_ui->spinBox_classification->value();
 }

--- a/qCC/ccSetClassificationField.cpp
+++ b/qCC/ccSetClassificationField.cpp
@@ -1,0 +1,56 @@
+#include "ccSetClassificationField.h"
+#include "ui_setClassificationFieldDlg.h"
+
+//qCC_db
+#include <ccHObjectCaster.h>
+#include <ccPointCloud.h>
+
+ccSetClassificationField::ccSetClassificationField(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::ccSetClassificationField)
+{
+    ui->setupUi(this);
+}
+
+ccSetClassificationField::~ccSetClassificationField()
+{
+    delete ui;
+}
+
+bool ccSetClassificationField::setClassificationField(const ccHObject::Container &selectedEntities)
+{
+    QString errorMessage;
+    int class_ = getClass();
+    for (ccHObject* ent : selectedEntities)
+    {
+        ccPointCloud* cloud = ccHObjectCaster::ToPointCloud(ent);
+        unsigned int N = cloud->size();
+        if (cloud != nullptr)
+        {
+            // check that the scalar field Classification exists
+            int idx = cloud->getScalarFieldIndexByName("Classification");
+            CCCoreLib::ScalarField *sf = nullptr;
+
+            // create the scalar field Classification if needed
+            if (idx == -1)
+            {
+                idx = cloud->addScalarField("Classification");
+                sf = cloud->getScalarField(idx);
+            }
+            else
+                sf = cloud->getScalarField(idx);
+            for (unsigned index = 0; index < N; index++)
+            {
+                sf->setValue(index, class_);
+            }
+        }
+    }
+
+    return true;
+}
+
+
+int ccSetClassificationField::getClass()
+{
+    return ui->spinBox_classification->value();
+}

--- a/qCC/ccSetClassificationField.h
+++ b/qCC/ccSetClassificationField.h
@@ -8,28 +8,24 @@ namespace Ui {
 class ccSetClassificationField;
 }
 
-//namespace ccHObject{
-//class Container;
-//}
-
 #include <ccHObject.h>
 
-class ccSetClassificationField : public QDialog
+class ccSetClassificationFieldDlg : public QDialog
 {
     Q_OBJECT
 
 public:
-    explicit ccSetClassificationField(QWidget *parent = nullptr);
-    ~ccSetClassificationField();
+    explicit ccSetClassificationFieldDlg(QWidget *parent = nullptr);
+    ~ccSetClassificationFieldDlg() override;
     void readSettings(void);
     void writeSettings(void);
 
     bool setClassificationField(const ccHObject::Container &selectedEntities);
-    int getClass();
+    int getClass() const;
 
 private:
-    Ui::ccSetClassificationField *ui;
-    int class_;
+    Ui::ccSetClassificationField *m_ui;
+    int m_class;
 };
 
 #endif // CCSETCLASSIFICATIONFIELD_H

--- a/qCC/ccSetClassificationField.h
+++ b/qCC/ccSetClassificationField.h
@@ -1,0 +1,32 @@
+#ifndef CCSETCLASSIFICATIONFIELD_H
+#define CCSETCLASSIFICATIONFIELD_H
+
+#include <QDialog>
+
+
+namespace Ui {
+class ccSetClassificationField;
+}
+
+//namespace ccHObject{
+//class Container;
+//}
+
+#include <ccHObject.h>
+
+class ccSetClassificationField : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit ccSetClassificationField(QWidget *parent = nullptr);
+    ~ccSetClassificationField();
+
+    bool setClassificationField(const ccHObject::Container &selectedEntities);
+    int getClass();
+
+private:
+    Ui::ccSetClassificationField *ui;
+};
+
+#endif // CCSETCLASSIFICATIONFIELD_H

--- a/qCC/ccSetClassificationField.h
+++ b/qCC/ccSetClassificationField.h
@@ -21,12 +21,15 @@ class ccSetClassificationField : public QDialog
 public:
     explicit ccSetClassificationField(QWidget *parent = nullptr);
     ~ccSetClassificationField();
+    void readSettings(void);
+    void writeSettings(void);
 
     bool setClassificationField(const ccHObject::Container &selectedEntities);
     int getClass();
 
 private:
     Ui::ccSetClassificationField *ui;
+    int class_;
 };
 
 #endif // CCSETCLASSIFICATIONFIELD_H

--- a/qCC/db_tree/ccDBRoot.cpp
+++ b/qCC/db_tree/ccDBRoot.cpp
@@ -2183,14 +2183,12 @@ void ccDBRoot::setClassificationField()
             selectedClouds.push_back(cloud);
     }
 
-    ccSetClassificationField setClassificationField;
+    ccSetClassificationFieldDlg setClassificationField;
     if (setClassificationField.exec())
     {
         setClassificationField.setClassificationField(selectedClouds);
         updatePropertiesView();
     }
-    else
-        return;
 }
 
 void ccDBRoot::showContextMenu(const QPoint& menuPos)

--- a/qCC/db_tree/ccDBRoot.cpp
+++ b/qCC/db_tree/ccDBRoot.cpp
@@ -45,6 +45,7 @@
 #include <ccPointCloud.h>
 #include <ccPolyline.h>
 #include <ccScalarField.h>
+#include <ccSetClassificationField.h>
 
 //CClib
 #include <CCMiscTools.h>
@@ -271,6 +272,7 @@ ccDBRoot::ccDBRoot(ccCustomQTreeView* dbTreeWidget, QTreeView* propertiesTreeWid
 	m_alignCameraWithEntityReverse = new QAction("Align camera (reverse)", this);
 	m_enableBubbleViewMode = new QAction("Bubble-view", this);
 	m_editLabelScalarValue = new QAction("Edit scalar value", this);
+    m_setClassificationField = new QAction("Set classification field", this);
 
 	m_contextMenuPos = QPoint(-1,-1);
 
@@ -296,6 +298,8 @@ ccDBRoot::ccDBRoot(ccCustomQTreeView* dbTreeWidget, QTreeView* propertiesTreeWid
 	connect(m_alignCameraWithEntityReverse,		&QAction::triggered,					this, &ccDBRoot::alignCameraWithEntityIndirect);
 	connect(m_enableBubbleViewMode,				&QAction::triggered,					this, &ccDBRoot::enableBubbleViewMode);
 	connect(m_editLabelScalarValue,				&QAction::triggered,					this, &ccDBRoot::editLabelScalarValue);
+    connect(m_setClassificationField,           &QAction::triggered,                    this, &ccDBRoot::setClassificationField);
+
 
 	//other DB tree signals/slots connection
 	connect(m_dbTreeWidget->selectionModel(), &QItemSelectionModel::selectionChanged, this, &ccDBRoot::changeSelection);
@@ -2157,6 +2161,38 @@ void ccDBRoot::editLabelScalarValue()
 	}
 }
 
+void ccDBRoot::setClassificationField()
+{
+    QItemSelectionModel* qism = m_dbTreeWidget->selectionModel();
+    QModelIndexList selectedIndexes = qism->selectedIndexes();
+    if (selectedIndexes.empty())
+    {
+        return;
+    }
+    unsigned selCount = static_cast<unsigned>(selectedIndexes.size());
+
+    ccHObject::Container selectedClouds;
+    for (unsigned i = 0; i < selCount; ++i)
+    {
+        ccHObject* obj = static_cast<ccHObject*>(selectedIndexes[i].internalPointer());
+
+        ccPointCloud* cloud = ccHObjectCaster::ToPointCloud(obj);
+
+        // keep only clouds in the selection
+        if (cloud != nullptr)
+            selectedClouds.push_back(cloud);
+    }
+
+    ccSetClassificationField setClassificationField;
+    if (setClassificationField.exec())
+    {
+        setClassificationField.setClassificationField(selectedClouds);
+        updatePropertiesView();
+    }
+    else
+        return;
+}
+
 void ccDBRoot::showContextMenu(const QPoint& menuPos)
 {
 	m_contextMenuPos = menuPos;
@@ -2298,6 +2334,9 @@ void ccDBRoot::showContextMenu(const QPoint& menuPos)
 				menu.addSeparator();
 				menu.addAction(m_editLabelScalarValue);
 			}
+
+            menu.addSeparator();
+            menu.addAction(m_setClassificationField);
 
 			menu.addSeparator();
 		}

--- a/qCC/db_tree/ccDBRoot.h
+++ b/qCC/db_tree/ccDBRoot.h
@@ -216,6 +216,7 @@ private:
 	void alignCameraWithEntityIndirect() { alignCameraWithEntity(true); }
 	void enableBubbleViewMode();
 	void editLabelScalarValue();
+    void setClassificationField();
 
 signals:
 	void selectionChanged();
@@ -301,6 +302,8 @@ protected:
 	QAction* m_enableBubbleViewMode;
 	//! Context menu action: change current scalar value (via a 2D label)
 	QAction* m_editLabelScalarValue;
+    //! Context menu action: set current class
+    QAction* m_setClassificationField;
 
 	//! Last context menu pos
 	QPoint m_contextMenuPos;

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -601,6 +601,7 @@ void MainWindow::connectActions()
 	connect(m_UI->actionRenameSF,					&QAction::triggered, this, &MainWindow::doActionRenameSF);
 	connect(m_UI->actionOpenColorScalesManager,		&QAction::triggered, this, &MainWindow::doActionOpenColorScalesManager);
 	connect(m_UI->actionAddIdField,					&QAction::triggered, this, &MainWindow::doActionAddIdField);
+    connect(m_UI->actionSplitCloudUsingSF,          &QAction::triggered, this, &MainWindow::doActionSplitCloudUsingSF);
 	connect(m_UI->actionSetSFAsCoord,				&QAction::triggered, this, &MainWindow::doActionSetSFAsCoord);
 	connect(m_UI->actionInterpolateSFs,				&QAction::triggered, this, &MainWindow::doActionInterpolateScalarFields);
 	connect(m_UI->actionDeleteScalarField, &QAction::triggered, this, [=]() {
@@ -3134,6 +3135,15 @@ void MainWindow::doActionAddIdField()
 
 	refreshAll();
 	updateUI();
+}
+
+void MainWindow::doActionSplitCloudUsingSF()
+{
+    if (!ccEntityAction::sfSplitCloud(m_selectedEntities, this))
+        return;
+
+    refreshAll();
+    updateUI();
 }
 
 void MainWindow::doActionSFGaussianFilter()

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -3150,14 +3150,11 @@ void MainWindow::doActionSplitCloudUsingSF()
 
 void MainWindow::doActionSetClassificationField()
 {
-    ccSetClassificationField setClassificationField(this);
-    if (setClassificationField.exec())
-    {
-        setClassificationField.setClassificationField(m_selectedEntities);
-    }
-    else
+    ccSetClassificationFieldDlg setClassificationField(this);
+    if (!setClassificationField.exec())
         return;
 
+    setClassificationField.setClassificationField(m_selectedEntities);
     refreshAll();
     updateUI();
 }

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -602,6 +602,7 @@ void MainWindow::connectActions()
 	connect(m_UI->actionOpenColorScalesManager,		&QAction::triggered, this, &MainWindow::doActionOpenColorScalesManager);
 	connect(m_UI->actionAddIdField,					&QAction::triggered, this, &MainWindow::doActionAddIdField);
     connect(m_UI->actionSplitCloudUsingSF,          &QAction::triggered, this, &MainWindow::doActionSplitCloudUsingSF);
+    connect(m_UI->actionSetClassificationField,     &QAction::triggered, this, &MainWindow::doActionSetClassificationField);
 	connect(m_UI->actionSetSFAsCoord,				&QAction::triggered, this, &MainWindow::doActionSetSFAsCoord);
 	connect(m_UI->actionInterpolateSFs,				&QAction::triggered, this, &MainWindow::doActionInterpolateScalarFields);
 	connect(m_UI->actionDeleteScalarField, &QAction::triggered, this, [=]() {
@@ -3140,6 +3141,15 @@ void MainWindow::doActionAddIdField()
 void MainWindow::doActionSplitCloudUsingSF()
 {
     if (!ccEntityAction::sfSplitCloud(m_selectedEntities, this))
+        return;
+
+    refreshAll();
+    updateUI();
+}
+
+void MainWindow::doActionSetClassificationField()
+{
+    if (!ccEntityAction::sfSetClassificationField(m_selectedEntities))
         return;
 
     refreshAll();

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -111,6 +111,7 @@
 #include "ccSectionExtractionTool.h"
 #include "ccSensorComputeDistancesDlg.h"
 #include "ccSensorComputeScatteringAnglesDlg.h"
+#include "ccSetClassificationField.h"
 #include "ccSORFilterDlg.h"
 #include "ccSubsamplingDlg.h"
 #include "ccTracePolylineTool.h"
@@ -3149,7 +3150,12 @@ void MainWindow::doActionSplitCloudUsingSF()
 
 void MainWindow::doActionSetClassificationField()
 {
-    if (!ccEntityAction::sfSetClassificationField(m_selectedEntities))
+    ccSetClassificationField setClassificationField(this);
+    if (setClassificationField.exec())
+    {
+        setClassificationField.setClassificationField(m_selectedEntities);
+    }
+    else
         return;
 
     refreshAll();

--- a/qCC/mainwindow.h
+++ b/qCC/mainwindow.h
@@ -269,6 +269,7 @@ private:
 	void doActionRenameSF();
 	void doActionOpenColorScalesManager();
 	void doActionAddIdField();
+    void doActionSplitCloudUsingSF();
 	void doActionSetSFAsCoord();
 	void doActionInterpolateScalarFields();
 

--- a/qCC/mainwindow.h
+++ b/qCC/mainwindow.h
@@ -270,6 +270,7 @@ private:
 	void doActionOpenColorScalesManager();
 	void doActionAddIdField();
     void doActionSplitCloudUsingSF();
+    void doActionSetClassificationField();
 	void doActionSetSFAsCoord();
 	void doActionInterpolateScalarFields();
 

--- a/qCC/ui_templates/graphicalSegmentationDlg.ui
+++ b/qCC/ui_templates/graphicalSegmentationDlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>251</width>
-    <height>26</height>
+    <width>307</width>
+    <height>27</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -123,6 +123,13 @@
      <property name="icon">
       <iconset resource="../icons.qrc">
        <normaloff>:/CC/images/smallSegmentOut.png</normaloff>:/CC/images/smallSegmentOut.png</iconset>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QToolButton" name="toolButton_class">
+     <property name="text">
+      <string>CLASS</string>
      </property>
     </widget>
    </item>
@@ -245,6 +252,7 @@
   </action>
  </widget>
  <resources>
+  <include location="../icons.qrc"/>
   <include location="../icons.qrc"/>
  </resources>
  <connections/>

--- a/qCC/ui_templates/mainWindow.ui
+++ b/qCC/ui_templates/mainWindow.ui
@@ -39,7 +39,7 @@
      <x>0</x>
      <y>0</y>
      <width>1024</width>
-     <height>21</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -153,6 +153,7 @@
      <addaction name="actionExportNormalToSF"/>
      <addaction name="actionSetSFAsCoord"/>
      <addaction name="actionInterpolateSFs"/>
+     <addaction name="actionSplitCloudUsingSF"/>
      <addaction name="actionScalarFieldArithmetic"/>
      <addaction name="separator"/>
      <addaction name="actionOpenColorScalesManager"/>
@@ -3114,6 +3115,14 @@ QTreeView::branch:open:has-children:has-siblings  {
     <string>Ctrl+P</string>
    </property>
   </action>
+  <action name="actionSplitCloudUsingSF">
+   <property name="text">
+    <string>Split cloud using SF</string>
+   </property>
+   <property name="toolTip">
+    <string>Split the selected cloud using the current scalar field. The field should be a positive integer.</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -3128,6 +3137,7 @@ QTreeView::branch:open:has-children:has-siblings  {
   </customwidget>
  </customwidgets>
  <resources>
+  <include location="../icons.qrc"/>
   <include location="../icons.qrc"/>
  </resources>
  <connections>

--- a/qCC/ui_templates/mainWindow.ui
+++ b/qCC/ui_templates/mainWindow.ui
@@ -154,6 +154,7 @@
      <addaction name="actionSetSFAsCoord"/>
      <addaction name="actionInterpolateSFs"/>
      <addaction name="actionSplitCloudUsingSF"/>
+     <addaction name="actionSetClassificationField"/>
      <addaction name="actionScalarFieldArithmetic"/>
      <addaction name="separator"/>
      <addaction name="actionOpenColorScalesManager"/>
@@ -3121,6 +3122,11 @@ QTreeView::branch:open:has-children:has-siblings  {
    </property>
    <property name="toolTip">
     <string>Split the selected cloud using the current scalar field. The field should be a positive integer.</string>
+   </property>
+  </action>
+  <action name="actionSetClassificationField">
+   <property name="text">
+    <string>Set classification field</string>
    </property>
   </action>
  </widget>

--- a/qCC/ui_templates/setClassificationFieldDlg.ui
+++ b/qCC/ui_templates/setClassificationFieldDlg.ui
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ccSetClassificationField</class>
+ <widget class="QDialog" name="ccSetClassificationField">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>184</width>
+    <height>70</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Classification</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="spinBox_classification">
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ccSetClassificationField</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ccSetClassificationField</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
Two tools added to the "Edit" menu:
- Edit / Scalar fields / Split cloud using SF => split a cloud using the current scalar field
- Edit / Scalar fields / Set classification field => set the "Classification" field of the selected clouds (create the field if needed)

One option added to the "Segment" tool: 
The button "CLASS" enables to set the class of the current selection (the field "Classification" is created if needed).