### PR TITLE
Fix: "ccGLWindow" not responding to resizeEvent.

### DIFF
--- a/libs/qCC_glWindow/src/ccGLWindow.cpp
+++ b/libs/qCC_glWindow/src/ccGLWindow.cpp
@@ -1169,6 +1169,7 @@ bool ccGLWindow::event(QEvent* evt)
 	{
 		update();
 	}
+	break;
 #endif
 
 	default:

--- a/libs/qCC_glWindow/src/ccGLWindow.cpp
+++ b/libs/qCC_glWindow/src/ccGLWindow.cpp
@@ -1137,11 +1137,6 @@ bool ccGLWindow::event(QEvent* evt)
 	}
 	break;
 
-	case QEvent::Resize:
-	{
-		update();
-	}
-
 #ifdef CC_GL_WINDOW_USE_QWINDOW
 	case QEvent::Resize:
 	{
@@ -1169,7 +1164,11 @@ bool ccGLWindow::event(QEvent* evt)
 		evt->accept();
 	}
 	return true;
-
+#else
+	case QEvent::Resize:
+	{
+		update();
+	}
 #endif
 
 	default:

--- a/libs/qCC_glWindow/src/ccGLWindow.cpp
+++ b/libs/qCC_glWindow/src/ccGLWindow.cpp
@@ -1137,6 +1137,11 @@ bool ccGLWindow::event(QEvent* evt)
 	}
 	break;
 
+	case QEvent::Resize:
+	{
+		update();
+	}
+
 #ifdef CC_GL_WINDOW_USE_QWINDOW
 	case QEvent::Resize:
 	{


### PR DESCRIPTION
When tapping between "title" and "Cascade" in "3D view" menu, the views not show right.

![图片](https://user-images.githubusercontent.com/6083117/158978385-3de39dbb-fcf7-4ddd-9f2d-2bf4fb4a82d3.png)
