### PR TITLE
Remove uses of floating point math in constexprs

### DIFF
--- a/libs/qCC_db/include/ccColorTypes.h
+++ b/libs/qCC_db/include/ccColorTypes.h
@@ -119,7 +119,7 @@ namespace ccColor
 
 	// Predefined colors (default type)
 	constexpr Rgb whiteRGB					(MAX, MAX, MAX);
-	constexpr Rgb lightGreyRGB				(static_cast<ColorCompType>(MAX*0.8), static_cast<ColorCompType>(MAX*0.8), static_cast<ColorCompType>(MAX*0.8));
+	constexpr Rgb lightGreyRGB				(static_cast<ColorCompType>(MAX*8/10), static_cast<ColorCompType>(MAX*8/10), static_cast<ColorCompType>(MAX*8/10));
 	constexpr Rgb darkGreyRGB				(MAX / 2, MAX / 2, MAX / 2);
 	constexpr Rgb redRGB					(MAX, 0, 0);
 	constexpr Rgb greenRGB					(0, MAX, 0);
@@ -133,7 +133,7 @@ namespace ccColor
 
 	// Predefined colors (default type)
 	constexpr Rgba white					(MAX, MAX, MAX, MAX);
-	constexpr Rgba lightGrey				(static_cast<ColorCompType>(MAX*0.8), static_cast<ColorCompType>(MAX*0.8), static_cast<ColorCompType>(MAX*0.8), MAX);
+	constexpr Rgba lightGrey				(static_cast<ColorCompType>(MAX*8/10), static_cast<ColorCompType>(MAX*8/10), static_cast<ColorCompType>(MAX*8/10), MAX);
 	constexpr Rgba darkGrey					(MAX / 2, MAX / 2, MAX / 2, MAX);
 	constexpr Rgba red						(MAX, 0, 0, MAX);
 	constexpr Rgba green					(0, MAX, 0, MAX);

--- a/libs/qCC_db/src/ccCameraSensor.cpp
+++ b/libs/qCC_db/src/ccCameraSensor.cpp
@@ -53,8 +53,8 @@ void ccCameraSensor::IntrinsicParameters::GetKinectDefaults(IntrinsicParameters&
 	//default Kinect parameters from:
 	// "Accuracy and Resolution of Kinect Depth Data for Indoor Mapping Applications"
 	// Kourosh Khoshelham and Sander Oude Elberink
-	constexpr float focal_mm		= static_cast<float>(5.45 * 1.0e-3);	// focal length (real distance in meter)
-	constexpr float pixelSize_mm	= static_cast<float>(9.3 * 1.0e-6);		// pixel size (real distance in meter)
+	constexpr float focal_mm		= static_cast<float>(5.45e-3);	// focal length (real distance in meter)
+	constexpr float pixelSize_mm	= static_cast<float>(9.3e-6);		// pixel size (real distance in meter)
 	
 	params.vertFocal_pix      = ConvertFocalMMToPix(focal_mm, pixelSize_mm);
 	params.pixelSize_mm[0]    = pixelSize_mm;

--- a/plugins/core/Standard/qHoughNormals/src/qHoughNormalsDialog.cpp
+++ b/plugins/core/Standard/qHoughNormals/src/qHoughNormalsDialog.cpp
@@ -22,9 +22,6 @@ namespace {
 	#ifndef M_PI
 		constexpr double M_PI = 3.14159265358979323846264338327950288;
 	#endif	
-	
-	constexpr double RadiansToDegrees = 180.0 / M_PI;
-	constexpr double DegreesToRadians = M_PI / 180.0;
 }
 
 qHoughNormalsDialog::qHoughNormalsDialog(QWidget *parent)
@@ -45,7 +42,7 @@ void qHoughNormalsDialog::setParameters( const Parameters &params )
 	m_ui->tSpinBox->setValue(params.T);
 	m_ui->nPhiSpinBox->setValue(params.n_phi);
 	m_ui->nRotSpinBox->setValue(params.n_rot);
-	m_ui->tolAngleSpinBox->setValue(params.tol_angle_rad * RadiansToDegrees);
+	m_ui->tolAngleSpinBox->setValue(params.tol_angle_rad * (180.0 / M_PI));
 	m_ui->kDensitySpinBox->setValue(params.k_density);
 	m_ui->useDensityCheckBox->setChecked(params.use_density);
 }
@@ -56,7 +53,7 @@ void qHoughNormalsDialog::getParameters( Parameters &params )
 	params.T = m_ui->tSpinBox->value();
 	params.n_phi = m_ui->nPhiSpinBox->value();
 	params.n_rot = m_ui->nRotSpinBox->value();
-	params.tol_angle_rad = m_ui->tolAngleSpinBox->value() * DegreesToRadians;
+	params.tol_angle_rad = m_ui->tolAngleSpinBox->value() * (M_PI / 180.0);
 	params.k_density = m_ui->kDensitySpinBox->value();
 	params.use_density = m_ui->useDensityCheckBox->isChecked();
 }


### PR DESCRIPTION
Floating point math in C++ constexprs is [ill-defined in general](https://stackoverflow.com/questions/50959021/why-compile-time-floating-point-calculations-might-not-have-the-same-results-as) and [causes problems compiling with CGAL](https://github.com/CloudCompare/CloudCompare/issues/1258).

This PR removes all uses of it from the CloudCompare codebase, as there are only a few and the edits required are straightforward.