### PR TITLE
Add switch case 0 to ICP rotation box

### DIFF
--- a/qCC/ccRegistrationDlg.cpp
+++ b/qCC/ccRegistrationDlg.cpp
@@ -253,6 +253,8 @@ int ccRegistrationDlg::getTransformationFilters() const
 	int filters = CCCoreLib::RegistrationTools::SKIP_NONE;
 	switch (rotComboBox->currentIndex())
 	{
+	case 0:
+		break;
 	case 1:
 		filters |= CCCoreLib::RegistrationTools::SKIP_RYZ;
 		break;


### PR DESCRIPTION
## Related issue
This PR close #1640 , that causes a `segfault` running ICP without skipping any rotation.


## Analysis
I added a `case 0` to explicit allow this values instead of modifying `default`, that I think is more coherent to not hide any other errors that my happen and can go to `default` 

As it is a really small fix and I needed to fix here to use, I already opened this PR, see what you guys think.

Thanks!