### PR TITLE
qPDALIO bug resolved

### DIFF
--- a/plugins/core/IO/qPDALIO/include/LASFields.h
+++ b/plugins/core/IO/qPDALIO/include/LASFields.h
@@ -119,7 +119,7 @@ struct LasField
 	virtual inline QString getName() const { return type < LAS_INVALID ? QString(LAS_FIELD_NAMES[type]) : QString(); }
 
 	//! Returns the (compliant) LAS fields in a point cloud
-	static bool GetLASFields(ccPointCloud* cloud, std::vector<LasField>& fieldsToSave, uint8_t minPointFormat)
+    static bool GetLASFields(ccPointCloud* cloud, std::vector<LasField>& fieldsToSave, uint8_t& minPointFormat)
 	{
 		try
 		{


### PR DESCRIPTION
The minPointFormat value is not changed by GetLASFields::GetLASFields. In my opinion, an ampersand is missing.
This can lead to missing standard fields (GpsTime for instance) when exporting in las/laz. In my case, GpsTime was saved as an extra field instead of being saved directly in the point record.