### PR TITLE
reorder actions done at startup

### DIFF
--- a/qCC/main.cpp
+++ b/qCC/main.cpp
@@ -56,6 +56,30 @@
 #endif
 
 
+bool isCommandLine(int argc, char **argv)
+{
+#ifdef Q_OS_MAC
+    // On macOS, when double-clicking the application, the Finder (sometimes!) adds a command-line parameter
+    // like "-psn_0_582385" which is a "process serial number".
+    // We need to recognize this and discount it when determining if we are running on the command line or not.
+
+    int numRealArgs = argc;
+
+    for ( int i = 1; i < argc; ++i )
+    {
+        if ( strncmp( argv[i], "-psn_", 5 ) == 0 )
+        {
+            --numRealArgs;
+        }
+    }
+
+    bool commandLine = (numRealArgs > 1) && (argv[1][0] == '-');
+#else
+    bool commandLine = (argc > 1) && (argv[1][0] == '-');
+#endif
+    return commandLine;
+}
+
 int main(int argc, char **argv)
 {
 #ifdef _WIN32 //This will allow printf to function on windows when opened from command line	
@@ -70,46 +94,71 @@ int main(int argc, char **argv)
 	}
 #endif
 
-#ifdef Q_OS_MAC
-	// On macOS, when double-clicking the application, the Finder (sometimes!) adds a command-line parameter
-	// like "-psn_0_582385" which is a "process serial number".
-	// We need to recognize this and discount it when determining if we are running on the command line or not.
+    bool commandLine = isCommandLine(argc, argv);
 
-	int numRealArgs = argc;
-	
-	for ( int i = 1; i < argc; ++i )
-	{
-		if ( strncmp( argv[i], "-psn_", 5 ) == 0 )
-		{
-			--numRealArgs;
-		}
-	}
-	
-	bool commandLine = (numRealArgs > 1) && (argv[1][0] == '-');
-#else
-	bool commandLine = (argc > 1) && (argv[1][0] == '-');
-#endif
-   
-	ccApplication::InitOpenGL();
+    // Convert the input arguments to QString before the application is initialized
+    // (as it will force utf8, which might prevent from properly reading filenames from the command line)
+    QStringList argumentsLocal8Bit;
+    for (int i = 0; i < argc; ++i)
+    {
+        argumentsLocal8Bit << QString::fromLocal8Bit(argv[i]);
+    }
+
+    //specific commands
+    int lastArgumentIndex = 1;
+    if (commandLine)
+    {
+        //translation file selection
+        if (argumentsLocal8Bit[lastArgumentIndex].toUpper() == "-LANG")
+        {
+            QString langFilename = argumentsLocal8Bit[2];
+
+            ccTranslationManager::Get().loadTranslation(langFilename);
+            commandLine = false;
+            lastArgumentIndex += 2;
+        }
+    }
+
+    ccApplication::InitOpenGL();
 
 #ifdef CC_GAMEPAD_SUPPORT
 	QGamepadManager::instance(); //potential workaround to bug https://bugreports.qt.io/browse/QTBUG-61553
 #endif
 
-	// Convert the input arguments to QString before the application is initialized
-	// (as it will force utf8, which might prevent from properly reading filenmaes from the command line)
-	QStringList argumentsLocal8Bit;
-	for (int i = 0; i < argc; ++i)
-	{
-		argumentsLocal8Bit << QString::fromLocal8Bit(argv[i]);
-	}
-	
+
 	ccApplication app(argc, argv, commandLine);
 
 	//store the log message until a valid logging instance is registered
 	ccLog::EnableMessageBackup(true);
-	
-	//restore some global parameters
+
+    //splash screen
+    QScopedPointer<QSplashScreen> splash(nullptr);
+
+    //standard mode
+    if (!commandLine)
+    {
+        if ((QGLFormat::openGLVersionFlags() & QGLFormat::OpenGL_Version_2_1) == 0)
+        {
+            QMessageBox::critical(nullptr, "Error", "This application needs OpenGL 2.1 at least to run!");
+            return EXIT_FAILURE;
+        }
+
+        //splash screen
+        QPixmap pixmap(QString::fromUtf8(":/CC/images/imLogoV2Qt.png"));
+        splash.reset(new QSplashScreen(pixmap, Qt::WindowStaysOnTopHint));
+        splash->show();
+    }
+
+    //global structures initialization
+    FileIOFilter::InitInternalFilters(); //load all known I/O filters (plugins will come later!)
+    ccNormalVectors::GetUniqueInstance(); //force pre-computed normals array initialization
+    ccColorScalesManager::GetUniqueInstance(); //force pre-computed color tables initialization
+
+    //load the plugins
+    ccPluginManager& pluginManager = ccPluginManager::Get();
+    pluginManager.loadPlugins();
+
+    //restore some global parameters
 	{
 		QSettings settings;
 		settings.beginGroup(ccPS::GlobalShift());
@@ -123,50 +172,6 @@ int main(int argc, char **argv)
 		ccGlobalShiftManager::SetMaxBoundgBoxDiagonal(maxAbsDiag);
 	}
 
-	//specific commands
-	int lastArgumentIndex = 1;
-	if (commandLine)
-	{
-		//translation file selection
-		if (argumentsLocal8Bit[lastArgumentIndex].toUpper() == "-LANG")
-		{
-			QString langFilename = argumentsLocal8Bit[2];
-
-			ccTranslationManager::Get().loadTranslation(langFilename);
-			commandLine = false;
-			lastArgumentIndex += 2;
-		}
-	}
-
-	//splash screen
-	QScopedPointer<QSplashScreen> splash(nullptr);
-	QTimer splashTimer;
-
-	//standard mode
-	if (!commandLine)
-	{
-		if ((QGLFormat::openGLVersionFlags() & QGLFormat::OpenGL_Version_2_1) == 0)
-		{
-			QMessageBox::critical(nullptr, "Error", "This application needs OpenGL 2.1 at least to run!");
-			return EXIT_FAILURE;
-		}
-
-		//splash screen
-		QPixmap pixmap(QString::fromUtf8(":/CC/images/imLogoV2Qt.png"));
-		splash.reset(new QSplashScreen(pixmap, Qt::WindowStaysOnTopHint));
-		splash->show();
-		QApplication::processEvents();
-	}
-
-	//global structures initialization
-	FileIOFilter::InitInternalFilters(); //load all known I/O filters (plugins will come later!)
-	ccNormalVectors::GetUniqueInstance(); //force pre-computed normals array initialization
-	ccColorScalesManager::GetUniqueInstance(); //force pre-computed color tables initialization
-
-	//load the plugins
-	ccPluginManager& pluginManager = ccPluginManager::Get();
-	pluginManager.loadPlugins();
-	
 	int result = 0;
 
 	//command line mode
@@ -244,10 +249,7 @@ int main(int argc, char **argv)
 		}
 		else if (splash)
 		{
-			//count-down to hide the timer (only effective once the application will have actually started!)
-			QObject::connect(&splashTimer, &QTimer::timeout, [&]() { if (splash) splash->close(); QCoreApplication::processEvents(); splash.reset(); });
-			splashTimer.setInterval(1000);
-			splashTimer.start();
+            splash->close();
 		}
 
 		//change the default path to the application one (do this AFTER processing the command line)
@@ -268,7 +270,7 @@ int main(int argc, char **argv)
 		//let's rock!
 		try
 		{
-			result = app.exec();
+			result = QApplication::exec();
 		}
 		catch (const std::exception& e)
 		{

--- a/qCC/main.cpp
+++ b/qCC/main.cpp
@@ -55,8 +55,7 @@
 #include <vld.h>
 #endif
 
-
-bool isCommandLine(int argc, char **argv)
+static bool IsCommandLine(int argc, char **argv)
 {
 #ifdef Q_OS_MAC
     // On macOS, when double-clicking the application, the Finder (sometimes!) adds a command-line parameter
@@ -73,11 +72,10 @@ bool isCommandLine(int argc, char **argv)
         }
     }
 
-    bool commandLine = (numRealArgs > 1) && (argv[1][0] == '-');
+    return (numRealArgs > 1) && (argv[1][0] == '-');
 #else
-    bool commandLine = (argc > 1) && (argv[1][0] == '-');
+    return (argc > 1) && (argv[1][0] == '-');
 #endif
-    return commandLine;
 }
 
 int main(int argc, char **argv)
@@ -94,7 +92,7 @@ int main(int argc, char **argv)
 	}
 #endif
 
-    bool commandLine = isCommandLine(argc, argv);
+    bool commandLine = IsCommandLine(argc, argv);
 
     // Convert the input arguments to QString before the application is initialized
     // (as it will force utf8, which might prevent from properly reading filenames from the command line)
@@ -125,7 +123,6 @@ int main(int argc, char **argv)
 	QGamepadManager::instance(); //potential workaround to bug https://bugreports.qt.io/browse/QTBUG-61553
 #endif
 
-
 	ccApplication app(argc, argv, commandLine);
 
 	//store the log message until a valid logging instance is registered
@@ -143,7 +140,7 @@ int main(int argc, char **argv)
             return EXIT_FAILURE;
         }
 
-        //splash screen
+        //init splash screen
         QPixmap pixmap(QString::fromUtf8(":/CC/images/imLogoV2Qt.png"));
         splash.reset(new QSplashScreen(pixmap, Qt::WindowStaysOnTopHint));
         splash->show();
@@ -182,7 +179,7 @@ int main(int argc, char **argv)
 	}
 	else
 	{
-		//main window init.
+		//main window initialization
 		MainWindow* mainWindow = MainWindow::TheInstance();
 		if (!mainWindow)
 		{
@@ -200,13 +197,13 @@ int main(int argc, char **argv)
 				.arg(ccGlobalShiftManager::MaxBoundgBoxDiagonal(), 0, 'e', 0));
 		}
 
+		if (splash)
+		{
+			splash->close();
+		}
+
 		if (argc > lastArgumentIndex)
 		{
-			if (splash)
-			{
-				splash->close();
-			}
-
 			//any additional argument is assumed to be a filename --> we try to load it/them
 			QStringList filenames;
 			for (int i = lastArgumentIndex; i < argc; ++i)
@@ -247,13 +244,9 @@ int main(int argc, char **argv)
 
 			mainWindow->addToDB(filenames);
 		}
-		else if (splash)
-		{
-            splash->close();
-		}
 
 		//change the default path to the application one (do this AFTER processing the command line)
-		QDir  workingDir = QCoreApplication::applicationDirPath();
+		QDir workingDir = QCoreApplication::applicationDirPath();
 		
 	#ifdef Q_OS_MAC
 		// This makes sure that our "working directory" is not within the application bundle	


### PR DESCRIPTION
This reorders the order at which we do things at startup.

- We init and load plugins just after the splash screen is shown
- Don't call QApplication::ProcessEvents as its preferable to wait that we are more ready (plugins are loaded and other things) before processing events.
- Remove the splash screen timer

Fixes #1665