### PR TITLE
Bug fix: Check for valid E57 pose rotation

### DIFF
--- a/plugins/core/IO/qE57IO/src/E57Filter.cpp
+++ b/plugins/core/IO/qE57IO/src/E57Filter.cpp
@@ -1399,9 +1399,7 @@ static bool GetPoseInformation(const e57::StructureNode& node, ccGLMatrixd& pose
 	bool validPoseMat = false;
 	if (node.isDefined("pose"))
 	{
-		CCCoreLib::SquareMatrixd rotMat(3);
-		rotMat.toIdentity();
-		rotMat.toGlMatrix(poseMat.data());
+		poseMat.toIdentity();
 
 		e57::StructureNode pose(node.get("pose"));
 		if (pose.isDefined("rotation"))
@@ -1413,6 +1411,7 @@ static bool GetPoseInformation(const e57::StructureNode& node, ccGLMatrixd& pose
 			quaternion[2] = e57::FloatNode(rotNode.get("y")).value();
 			quaternion[3] = e57::FloatNode(rotNode.get("z")).value();
 
+			CCCoreLib::SquareMatrixd rotMat(3);
 			rotMat.initFromQuaternion(quaternion);
 			if (rotMat.computeDet() > 0.)
 			{


### PR DESCRIPTION
CloudCompare seems to be having trouble reading E57 that have a pose rotation quaternion set to all zeros.
Likely this is malformed according to the E57 specification, but this change adds a check.
See also: [libE57Format #107](https://github.com/asmaloney/libE57Format/issues/107)