### PR TITLE
ccConsole: avoid printing 2 times the messages to stdout

### DIFF
--- a/qCC/ccConsole.cpp
+++ b/qCC/ccConsole.cpp
@@ -322,7 +322,7 @@ void ccConsole::logMessage(const QString& message, int level)
 		m_mutex.unlock();
 	}
 #ifdef QT_DEBUG
-	else
+	else if (!s_redirectToStdOut)
 	{
 		//Error
 		if (level & LOG_ERROR)


### PR DESCRIPTION
When CloudCompare is compiled in debug mode,
and run in command line mode with the -SILENT option the messages "printed" to the ccConsole would be output 2 times in the users console (stdout).

Once due du to -SILENT  flag, then a second time due to being compiled in DEBUG mode (I guess to be able to debug the ccConsole itself).

This makes the output harder to read.

This commit makes it so that messages are only printed once in this configuration