### PR TITLE
QLAS_IO : one bug corrected and a feature added to the command line.

### DIFF
--- a/plugins/core/IO/qLASIO/include/LasScalarFieldSaver.h
+++ b/plugins/core/IO/qLASIO/include/LasScalarFieldSaver.h
@@ -65,24 +65,14 @@ class LasScalarFieldSaver
 		{
 			*reinterpret_cast<T*>(dest) = std::numeric_limits<T>::max();
 		}
-		else if (value < std::numeric_limits<T>::min())
+		else if (value < std::numeric_limits<T>::lowest())
 		{
-			*reinterpret_cast<T*>(dest) = std::numeric_limits<T>::min();
+			*reinterpret_cast<T*>(dest) = std::numeric_limits<T>::lowest();
 		}
 		else
 		{
 			*reinterpret_cast<T*>(dest) = static_cast<T>(value);
 		}
-	}
-	template <typename T>
-	static void WriteScalarValueAsFltDbl(ScalarType value, uint8_t* dest)
-	{
-		if (value > std::numeric_limits<T>::max())
-			*reinterpret_cast<T*>(dest) = std::numeric_limits<T>::max();
-		else if (value < -std::numeric_limits<T>::max())
-			*reinterpret_cast<T*>(dest) = -std::numeric_limits<T>::max();
-		else
-			*reinterpret_cast<T*>(dest) = static_cast<T>(value);
 	}
 
   private:

--- a/plugins/core/IO/qLASIO/include/LasScalarFieldSaver.h
+++ b/plugins/core/IO/qLASIO/include/LasScalarFieldSaver.h
@@ -74,6 +74,16 @@ class LasScalarFieldSaver
 			*reinterpret_cast<T*>(dest) = static_cast<T>(value);
 		}
 	}
+	template <typename T>
+	static void WriteScalarValueAsFltDbl(ScalarType value, uint8_t* dest)
+	{
+		if (value > std::numeric_limits<T>::max())
+			*reinterpret_cast<T*>(dest) = std::numeric_limits<T>::max();
+		else if (value < -std::numeric_limits<T>::max())
+			*reinterpret_cast<T*>(dest) = -std::numeric_limits<T>::max();
+		else
+			*reinterpret_cast<T*>(dest) = static_cast<T>(value);
+	}
 
   private:
 	std::vector<LasScalarField>      m_standardFields;

--- a/plugins/core/IO/qLASIO/src/LasIOFilter.cpp
+++ b/plugins/core/IO/qLASIO/src/LasIOFilter.cpp
@@ -610,10 +610,17 @@ CC_FILE_ERROR LasIOFilter::saveToFile(ccHObject* entity, const QString& filename
 			bool found = false;
 			for (auto& el : params.standardFields)
 				if (strcmp(sfName, el.name()) == 0)
+				{
 					found = true;
-			for (auto& el : params.extraFields)
-				if (strcmp(sfName, el.scalarFields[0]->getName()) == 0)
-					found = true;
+					break;
+				}
+			if (!found)
+				for (auto& el : params.extraFields)
+					if (strcmp(sfName, el.scalarFields[0]->getName()) == 0)
+					{
+						found = true;
+						break;
+					}
 			if (!found)
 			{
 				ccLog::Print("[LAS] scalar field " + QString(sfName) + " will be saved automatically in the extra fields of the output file");
@@ -621,18 +628,10 @@ CC_FILE_ERROR LasIOFilter::saveToFile(ccHObject* entity, const QString& filename
 				const std::string stdName = sfName;
 				strncpy(field.name, stdName.c_str(), LasExtraScalarField::MAX_NAME_SIZE);
 
-				const std::string stdDescription = "";
-				strncpy(field.description, stdDescription.c_str(), LasExtraScalarField::MAX_DESCRIPTION_SIZE);
-
 				if (stdName.size() > LasExtraScalarField::MAX_NAME_SIZE)
 				{
 					ccLog::Warning("[LAS] Extra Scalar field name '%s' is too long and will be truncated",
 								   stdName.c_str());
-				}
-				if (stdDescription.size() > LasExtraScalarField::MAX_DESCRIPTION_SIZE)
-				{
-					ccLog::Warning("[LAS] Extra scalar field description '%s' is too long and will be truncated",
-								   stdDescription.c_str());
 				}
 
 				field.type = LasExtraScalarField::DataType::f32;

--- a/plugins/core/IO/qLASIO/src/LasScalarFieldSaver.cpp
+++ b/plugins/core/IO/qLASIO/src/LasScalarFieldSaver.cpp
@@ -218,10 +218,10 @@ void LasScalarFieldSaver::handleExtraFields(size_t pointIndex, laszip_point& poi
 				WriteScalarValueAs<int64_t>(values[i], dataStart);
 				break;
 			case LasExtraScalarField::f32:
-				WriteScalarValueAsFltDbl<float>(values[i], dataStart);
+				WriteScalarValueAs<float>(values[i], dataStart);
 				break;
 			case LasExtraScalarField::f64:
-				WriteScalarValueAsFltDbl<double>(values[i], dataStart);
+				WriteScalarValueAs<double>(values[i], dataStart);
 				break;
 			case LasExtraScalarField::Undocumented:
 			case LasExtraScalarField::Invalid:

--- a/plugins/core/IO/qLASIO/src/LasScalarFieldSaver.cpp
+++ b/plugins/core/IO/qLASIO/src/LasScalarFieldSaver.cpp
@@ -218,10 +218,10 @@ void LasScalarFieldSaver::handleExtraFields(size_t pointIndex, laszip_point& poi
 				WriteScalarValueAs<int64_t>(values[i], dataStart);
 				break;
 			case LasExtraScalarField::f32:
-				WriteScalarValueAs<float>(values[i], dataStart);
+				WriteScalarValueAsFltDbl<float>(values[i], dataStart);
 				break;
 			case LasExtraScalarField::f64:
-				WriteScalarValueAs<double>(values[i], dataStart);
+				WriteScalarValueAsFltDbl<double>(values[i], dataStart);
 				break;
 			case LasExtraScalarField::Undocumented:
 			case LasExtraScalarField::Invalid:


### PR DESCRIPTION
1) The format was not correctly handled when saving float or double extra fields.
2) Added the automatic saving of additional scalar fields when using the command line : usefull when computing c2c distances and saving to LAZ format.