### PR TITLE
CI: Use Github action to create a .tar.gz that includes submodules

### DIFF
--- a/.github/workflows/source-release.yml
+++ b/.github/workflows/source-release.yml
@@ -1,0 +1,34 @@
+# This workflow creates a .tar.gz archive
+# with CloudCompare source code, including submodules
+# and should thus be suitable to be used to build CloudCompare.
+name: Create Source Bundle
+
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  create-tar-gz:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: CloudCompare
+          submodules: true
+
+      - name: Create tarball
+        # Note  `--exclude-vcs` is only available on GNU's tar
+        run: tar --exclude-vcs -zcvf CloudCompare-${{ github.ref_name }}.tar.gz CloudCompare/
+
+      - name: Create Sha256 Sum
+        run: sha256sum CloudCompare-${{ github.ref_name }}.tar.gz > CloudCompare-${{ github.ref_name }}.tar.gz.sha256sum
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            CloudCompare-${{ github.ref_name }}.tar.gz
+            CloudCompare-${{ github.ref_name }}.tar.gz.sha256sum


### PR DESCRIPTION
This adds a github action workflow that will create a .tar.gz archive with sumodule code inside,
so the .tar.gz is suitable to build cloudcompare.

It runs when a release (and its `vmajor.minor.patch` tag) is created on the github release page.

An example can be seen on my fork : https://github.com/tmontaigu/CloudCompare/releases/tag/v0.0.0


Fixes https://github.com/CloudCompare/CloudCompare/issues/1404 
Fixes https://github.com/CloudCompare/CloudCompare/issues/1724