### PR TITLE
Fixed a variable in the copy constructor call to maxValidIndex

### DIFF
--- a/libs/qCC_db/include/ccPointCloud.h
+++ b/libs/qCC_db/include/ccPointCloud.h
@@ -288,7 +288,7 @@ public: //associated (scan) grid structure
 			, h(grid.h)
 			, validCount(grid.validCount)
 			, minValidIndex(grid.minValidIndex)
-			, maxValidIndex(grid.minValidIndex)
+			, maxValidIndex(grid.maxValidIndex)
 			, indexes(grid.indexes)
 			, colors(grid.colors)
 			, sensorPosition(grid.sensorPosition)


### PR DESCRIPTION
Noticed the wrong variable assigned to maxValidIndex when using the copy constructor for the Grid structure