### PR TITLE
Add Incremental transform to interactive Rotate/Translate entities by a text defined increment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ v2.13.alpha (???) - (??/??/????)
 
 	- Edit > Normals > Shift points along normals
 		- to shift the points of a given quantity along their associated normal
+	
+	- Edit > Translate/Rotate: 
+		- In advanced section, added an option to rotate / translate entities of a small increment, with button or using left/right arrows (Thanks to [Lighpoint Scientific](https://lightpointdata.com)!)
 
 - Improvements:
 

--- a/qCC/TODO.txt
+++ b/qCC/TODO.txt
@@ -67,7 +67,6 @@ Various:
 [*] Save multiple clouds in a LAS file (or other file types that normally only store one cloud - https://www.cloudcompare.org/forum/viewtopic.php?p=27131)
 [*] Manage viewports as sensors to be able to move/edit them easily (https://www.cloudcompare.org/forum/posting.php?mode=reply&t=6112)
 [*] Option to automatically deleted the source cloud in the 'SF > Filter by value' tool (https://www.cloudcompare.org/forum/viewtopic.php?t=6113)
-[*] Rotate/translate tool: option to rotate entities of a small increment, with button or key (https://www.cloudcompare.org/forum/viewtopic.php?p=26986#p26986)
 [*] Scissors tool: option to inverse the segmentation or to remove visible points (https://www.cloudcompare.org/forum/viewtopic.php?p=26981)
 [*] Voxel display mode (https://towardsdatascience.com/how-to-automate-voxel-modelling-of-3d-point-cloud-with-python-459f4d43a227)
 [*] Export images in the Rasterize tool with a custom color ramp (https://www.cloudcompare.org/forum/viewtopic.php?f=10&t=6023)

--- a/qCC/ccGraphicalTransformationTool.cpp
+++ b/qCC/ccGraphicalTransformationTool.cpp
@@ -49,8 +49,6 @@ ccGraphicalTransformationTool::ccGraphicalTransformationTool(QWidget* parent)
 	connect(okButton,       &QAbstractButton::clicked, this, &ccGraphicalTransformationTool::apply);
 	connect(razButton,	    &QAbstractButton::clicked, this, &ccGraphicalTransformationTool::reset);
 	connect(cancelButton,   &QAbstractButton::clicked, this, &ccGraphicalTransformationTool::cancel);
-	connect(cancelButton,   &QAbstractButton::clicked, this, &ccGraphicalTransformationTool::cancel);
-	connect(cancelButton,   &QAbstractButton::clicked, this, &ccGraphicalTransformationTool::cancel);
 
 	connect(TxCheckBox,     &QCheckBox::clicked, this, &ccGraphicalTransformationTool::incrementalTranslationToggle);
 	connect(TyCheckBox,     &QCheckBox::clicked, this, &ccGraphicalTransformationTool::incrementalTranslationToggle);
@@ -95,7 +93,7 @@ void ccGraphicalTransformationTool::onShortcutTriggered(int key)
 	case Qt::Key_Escape:
 		cancelButton->click();
 		return;
-	
+
 	default:
 		//nothing to do
 		break;
@@ -539,7 +537,7 @@ void ccGraphicalTransformationTool::advTranslateRefUpdate(int index)
 
 void ccGraphicalTransformationTool::advRotateComboBoxUpdate(int index)
 {
-	rotComboBoxItems selectedAxis = (rotComboBoxItems)rotComboBox->itemData(index).toInt();
+	rotComboBoxItems selectedAxis = static_cast<rotComboBoxItems>(rotComboBox->itemData(index).toInt());
 	incrementalRotationToggle(selectedAxis);
 	if (!m_advMode || !m_advRotateRef)
 	{
@@ -617,7 +615,7 @@ void ccGraphicalTransformationTool::advRotateRefUpdate(int index)
 					objCenterRadio->setEnabled(true);
 				}
 			}
-			if (!setAdvRotationAxis(m_advRotateRef, (rotComboBoxItems)rotComboBox->itemData(rotComboBox->currentIndex()).toInt()))
+			if (!setAdvRotationAxis(m_advRotateRef, static_cast<rotComboBoxItems>(rotComboBox->itemData(index).toInt())))
 			{
 				ccLog::Error("Error setting adv rotation axis, cannot rotate around selected item");
 				advRotateComboBox->setCurrentIndex(0);
@@ -638,13 +636,15 @@ void ccGraphicalTransformationTool::advRefAxisRadioToggled(bool state)
 	}
 }
 
-void ccGraphicalTransformationTool::incrementalTranslationToggle() {
+void ccGraphicalTransformationTool::incrementalTranslationToggle()
+{
 	const bool isIncrementalActive = TxCheckBox->isChecked() || TxCheckBox->isChecked() || TzCheckBox->isChecked();
 	incrementalTransLabel->setEnabled(isIncrementalActive);
 	incrementalTransSpin->setEnabled(isIncrementalActive);
 }
 
-void ccGraphicalTransformationTool::incrementalRotationToggle(const rotComboBoxItems & selectedRotationItem) {
+void ccGraphicalTransformationTool::incrementalRotationToggle(const rotComboBoxItems & selectedRotationItem)
+{
 	if(selectedRotationItem == rotComboBoxItems::NONE || selectedRotationItem == rotComboBoxItems::XYZ) {
 		incrementalRotLabel->setDisabled(true);
 		incrementalRotSpin->setDisabled(true);
@@ -869,7 +869,7 @@ void ccGraphicalTransformationTool::glRotate(const ccGLMatrixd& rotMat)
 {
 	if (m_advMode && m_advRotateRef != nullptr)
 	{
-		rotComboBoxItems rotAxis = (rotComboBoxItems)rotComboBox->itemData(rotComboBox->currentIndex()).toInt();
+		rotComboBoxItems rotAxis = static_cast<rotComboBoxItems>(rotComboBox->itemData(rotComboBox->currentIndex()).toInt());
 		double angle = 0;
 		switch (rotAxis)
 		{
@@ -928,19 +928,21 @@ void ccGraphicalTransformationTool::incrementalTransform() {
 		if (m_advMode && m_advRotateRef != nullptr)
 		{
 			m_rotation = m_rotation * arbitraryVectorRotation(alpha, m_advRotationAxis);
-		} else {
+		} 
+		else 
+		{
 			ccGLMatrixd rotMat;
 			// compute rotation matrix from spinbox
-			switch ((rotComboBoxItems)rotComboBox->itemData(rotComboBox->currentIndex()).toInt())
+			switch (static_cast<rotComboBoxItems>(rotComboBox->itemData(rotComboBox->currentIndex()).toInt()))
 			{
 			case rotComboBoxItems::X:
-				rotMat.initFromParameters(alpha, CCVector3f(1.f,0.f,0.f), CCVector3f(0.f,0.f,0.f));
+				rotMat.initFromParameters(alpha, CCVector3d(1.0,0.0,0.0), CCVector3d(0.0,0.0,0.0));
 				break;
 			case rotComboBoxItems::Y:
-				rotMat.initFromParameters(alpha, CCVector3f(0.f,1.f,0.f), CCVector3f(0.f,0.f,0.f));
+				rotMat.initFromParameters(alpha, CCVector3d(0.0,1.0,0.0), CCVector3d(0.0,0.0,0.0));
 				break;
 			case rotComboBoxItems::Z:
-				rotMat.initFromParameters(alpha, CCVector3f(0.f,0.f,1.f), CCVector3f(0.f,0.f,0.f));
+				rotMat.initFromParameters(alpha, CCVector3d(0.0,0.0,1.0), CCVector3d(0.0,0.0,0.0));
 				break;
 			default:
 				return;

--- a/qCC/ccGraphicalTransformationTool.h
+++ b/qCC/ccGraphicalTransformationTool.h
@@ -103,10 +103,10 @@ protected:
 	//! Updates the axis center of rotation to the ref object in adv rotate/translate mode
 	void advRefAxisRadioToggled(bool state);
 	
-	//! Enable/disable incremental translation field in accordance to the state of tx/ty/tz checkboxes
+	//! Enables/disables incremental translation field in accordance with the state of tx/ty/tz checkboxes
 	void incrementalTranslationToggle();
 
-	//! Enable/disable incremental rotation field in accordance to the state of the rotComboBox
+	//! Enables/disables incremental rotation field in accordance with the state of the rotComboBox
 	void incrementalRotationToggle(const rotComboBoxItems & selectedRotationItem);
 
 	//! Updates the axis center of rotation to the object center in adv rotate/translate mode

--- a/qCC/ccGraphicalTransformationTool.h
+++ b/qCC/ccGraphicalTransformationTool.h
@@ -74,6 +74,9 @@ public:
 
 protected:
 
+	//! rotComboBox enum
+	enum rotComboBoxItems { XYZ, X, Y, Z, NONE };
+
 	//! Applies transformation to selected entities
 	void apply();
 
@@ -99,6 +102,12 @@ protected:
 
 	//! Updates the axis center of rotation to the ref object in adv rotate/translate mode
 	void advRefAxisRadioToggled(bool state);
+	
+	//! Enable/disable incremental translation field in accordance to the state of tx/ty/tz checkboxes
+	void incrementalTranslationToggle();
+
+	//! Enable/disable incremental rotation field in accordance to the state of the rotComboBox
+	void incrementalRotationToggle(const rotComboBoxItems & selectedRotationItem);
 
 	//! Updates the axis center of rotation to the object center in adv rotate/translate mode
 	void advObjectAxisRadioToggled(bool state);
@@ -112,13 +121,11 @@ protected:
 	//! Applies rotation (graphically) to selected entities
 	void glRotate(const ccGLMatrixd&);
 
+	//! Applies rotation and translation factors set on incremental Spin boxes to selected entities
+	void incrementalTransform();
+
 	//! To capture overridden shortcuts (pause button, etc.)
 	void onShortcutTriggered(int);
-
-protected:
-
-	//! rotComboBox enum
-	enum rotComboBoxItems { XYZ, X, Y, Z, NONE };
 
 	//! Clear all variables and 'unlink' dialog
 	void clear();
@@ -132,7 +139,7 @@ protected:
 	//! Sets the translation transform used in advanced translate/rotate mode
 	bool setAdvTranslationTransform(ccHObject* translateRef);
 
-	//! Sets the rotation transform used in advaced translate/rotate mode
+	//! Sets the rotation transform used in advanced translate/rotate mode
 	bool setAdvRotationAxis(ccHObject* rotateRef, rotComboBoxItems selectedAxis);
 
 	//! Check if the entitry is in m_toTransform

--- a/qCC/ui_templates/graphicalTransformationDlg.ui
+++ b/qCC/ui_templates/graphicalTransformationDlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>250</width>
-    <height>235</height>
+    <width>730</width>
+    <height>465</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -391,6 +391,131 @@
        </property>
        <property name="text">
         <string>Reference Axis</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="IncrementalTransformLabel">
+     <property name="text">
+      <string>Incremental tranform:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_8">
+     <item>
+      <widget class="QLabel" name="incrementalRotLabel">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Rotation</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="incrementalRotSpin">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="readOnly">
+        <bool>false</bool>
+       </property>
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
+       <property name="decimals">
+        <number>6</number>
+       </property>
+       <property name="minimum">
+        <double>-10000000.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>100000000.000000000000000</double>
+       </property>
+       <property name="stepType">
+        <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_9">
+     <item>
+      <widget class="QLabel" name="incrementalTransLabel">
+       <property name="text">
+        <string>Translation</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="incrementalTransSpin">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="readOnly">
+        <bool>false</bool>
+       </property>
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
+       <property name="decimals">
+        <number>6</number>
+       </property>
+       <property name="minimum">
+        <double>-10000000.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>100000000.000000000000000</double>
+       </property>
+       <property name="stepType">
+        <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_11">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="incrementalBackwardButton">
+       <property name="toolTip">
+        <string>Incremental transform: transform backward</string>
+       </property>
+       <property name="text">
+        <string>Backward</string>
+       </property>
+       <property name="shortcut">
+        <string>Left</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="incrementalForwardButton">
+       <property name="toolTip">
+        <string comment="Incremental transform: transform forward "/>
+       </property>
+       <property name="text">
+        <string>Forward</string>
+       </property>
+       <property name="shortcut">
+        <string>Right</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Thanks to [Lighpoint Scientific](https://lightpointdata.com) this change adds a feature to interactively rotate and/or translate entities by a given increment. This feature is accessible in the advanced section of rotate/translate dialog and the tranform or the inverse transform can be triggered by a button or by means of left/right arrow keys.