### PR TITLE
LAS: Allow entering custom scale values

### DIFF
--- a/plugins/core/IO/qLASIO/include/LasSaveDialog.h
+++ b/plugins/core/IO/qLASIO/include/LasSaveDialog.h
@@ -75,6 +75,7 @@ class LasSaveDialog : public QDialog
 	void handleSelectedVersionChange(const QString&);
 	void handleSelectedPointFormatChange(int index);
 	void handleComboBoxChange(int index);
+	void handleCustomScaleButtontoggled(bool checked);
 	void addExtraScalarFieldCard();
 
   private:

--- a/plugins/core/IO/qLASIO/src/LasSaveDialog.cpp
+++ b/plugins/core/IO/qLASIO/src/LasSaveDialog.cpp
@@ -28,8 +28,6 @@
 #include <ccPointCloud.h>
 #include <ccScalarField.h>
 
-static constexpr int ExtraScalarFieldsTabIndex = 2;
-
 //! Widget to map a predefined scalar field 'role' with a particular scalar field (combo box)
 class MappingLabel : public QWidget
 {
@@ -113,8 +111,21 @@ LasSaveDialog::LasSaveDialog(ccPointCloud* cloud, QWidget* parent)
 
 	bestScaleRadioButton->setChecked(false);
 	originalScaleRadioButton->setEnabled(false);
+
 	customScaleRadioButton->setEnabled(true);
-	customScaleRadioButton->setChecked(true);
+	customScaleRadioButton->setChecked(false);
+	QDoubleSpinBox* scaleButtons[3] = {customScaleXDoubleSpinBox, customScaleYDoubleSpinBox, customScaleZDoubleSpinBox};
+	for (size_t i = 0; i < 3; i++)
+	{
+		QDoubleSpinBox* spinBox = scaleButtons[i];
+		spinBox->setDecimals(8);
+		spinBox->setMinimum(0.0);
+		spinBox->setMaximum(100.0);
+		spinBox->setValue(0.001);
+		spinBox->setSingleStep(0.001);
+		spinBox->setEnabled(false);
+	}
+	connect(customScaleRadioButton, &QRadioButton::toggled, this, &LasSaveDialog::handleCustomScaleButtontoggled);
 
 	for (const char* versionStr : LasDetails::AvailableVersions())
 	{
@@ -123,12 +134,12 @@ LasSaveDialog::LasSaveDialog(ccPointCloud* cloud, QWidget* parent)
 	versionComboBox->setCurrentIndex(0);
 
 	connect(versionComboBox,
-	        (void (QComboBox::*)(const QString&))(&QComboBox::currentIndexChanged),
+	        (void(QComboBox::*)(const QString&))(&QComboBox::currentIndexChanged),
 	        this,
 	        &LasSaveDialog::handleSelectedVersionChange);
 
 	connect(pointFormatComboBox,
-	        (void (QComboBox::*)(int))(&QComboBox::currentIndexChanged),
+	        (void(QComboBox::*)(int))(&QComboBox::currentIndexChanged),
 	        this,
 	        &LasSaveDialog::handleSelectedPointFormatChange);
 
@@ -189,7 +200,8 @@ void LasSaveDialog::handleComboBoxChange(int index)
 	size_t   senderIndex  = std::distance(m_scalarFieldMapping.begin(),
                                        std::find_if(m_scalarFieldMapping.begin(),
                                                     m_scalarFieldMapping.end(),
-                                                    [senderObject](const std::pair<MappingLabel*, QComboBox*>& pair) { return pair.second == senderObject; }));
+                                                    [senderObject](const std::pair<MappingLabel*, QComboBox*>& pair)
+                                                    { return pair.second == senderObject; }));
 
 	if (qobject_cast<QComboBox*>(senderObject)->itemText(index).isEmpty())
 	{
@@ -226,7 +238,8 @@ void LasSaveDialog::handleComboBoxChange(int index)
 
 	size_t numWarnings = std::count_if(m_scalarFieldMapping.begin(),
 	                                   m_scalarFieldMapping.end(),
-	                                   [](const std::pair<MappingLabel*, QComboBox*>& pair) { return pair.first->hasWarning(); });
+	                                   [](const std::pair<MappingLabel*, QComboBox*>& pair)
+	                                   { return pair.first->hasWarning(); });
 
 	if (numWarnings > 0)
 	{
@@ -352,6 +365,13 @@ void LasSaveDialog::handleSelectedPointFormatChange(int index)
 	}
 }
 
+void LasSaveDialog::handleCustomScaleButtontoggled(bool checked)
+{
+	customScaleXDoubleSpinBox->setEnabled(checked);
+	customScaleYDoubleSpinBox->setEnabled(checked);
+	customScaleZDoubleSpinBox->setEnabled(checked);
+}
+
 LasExtraScalarFieldCard* LasSaveDialog::createCard() const
 {
 	auto* card = new LasExtraScalarFieldCard;
@@ -443,7 +463,7 @@ void LasSaveDialog::setOriginalScale(const CCVector3d& scale, bool canUseScale, 
 	originalScaleRadioButton->setEnabled(canUseScale);
 	if (!canUseScale)
 	{
-		labelOriginal->setText(QObject::tr("Original scale is too small for this cloud  ")); //add two whitespaces to avoid issues with italic characters justification
+		labelOriginal->setText(QObject::tr("Original scale is too small for this cloud  ")); // add two whitespaces to avoid issues with italic characters justification
 		labelOriginal->setStyleSheet("color: red;");
 		originalScaleRadioButton->setChecked(false);
 	}
@@ -515,12 +535,14 @@ CCVector3d LasSaveDialog::chosenScale() const
 	}
 	else if (customScaleRadioButton->isChecked())
 	{
-		double customScale = customScaleDoubleSpinBox->value();
-		return {customScale, customScale, customScale};
+		double customScaleX = customScaleXDoubleSpinBox->value();
+		double customScaleY = customScaleYDoubleSpinBox->value();
+		double customScaleZ = customScaleZDoubleSpinBox->value();
+		return {customScaleX, customScaleY, customScaleZ};
 	}
 
 	assert(false);
-	return {};
+	return {1.0, 1.0, 1.0};
 }
 
 std::vector<LasScalarField> LasSaveDialog::fieldsToSave() const

--- a/plugins/core/IO/qLASIO/ui/lassavedialog.ui
+++ b/plugins/core/IO/qLASIO/ui/lassavedialog.ui
@@ -173,7 +173,7 @@ font: italic;</string>
              </widget>
             </item>
             <item>
-             <widget class="QDoubleSpinBox" name="customScaleDoubleSpinBox">
+             <widget class="QDoubleSpinBox" name="customScaleXDoubleSpinBox">
               <property name="enabled">
                <bool>false</bool>
               </property>
@@ -193,6 +193,16 @@ font: italic;</string>
                <double>0.001000000000000</double>
               </property>
              </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="customScaleYDoubleSpinBox">
+              <property name="value">
+               <double>0.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="customScaleZDoubleSpinBox"/>
             </item>
             <item>
              <spacer name="horizontalSpacer_9">
@@ -322,8 +332,8 @@ font: italic;</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>618</width>
-            <height>292</height>
+            <width>784</width>
+            <height>288</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_9">


### PR DESCRIPTION
Clicking on the "custom scale" radio button did not enable the spin box, so the user could not enter the custom scale it wanted to use.

This commits adds 2 spin box, so that there a 3 (one per dimension X, Y, Z). Also this commits makes it so that when clicking on the custom scale radio button the 3 spin box are enabled and value can be changed, when the radio button is no longer selected, the 3 spin box are disabled

Fixes #1764 