### PR TITLE
Fix the Support for High DPI screens (4K) on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,6 +256,7 @@ v2.13.alpha (???) - (??/??/????)
 		- the display was not always updated when M3C2 computation was done
 		- some parameters were not properly restored when re-opening the plugin dialog (e.g. the 'normal source')
 	- Glitch fix: extracting a single slice via the Contour extraction option of the 'Cross Section' tool would not work
+	- Fix the Support for High DPI screens (4K) on Windows
 
 v2.12.4 (Kyiv) - (14/07/2022)
 ----------------------

--- a/ccViewer/main.cpp
+++ b/ccViewer/main.cpp
@@ -43,6 +43,12 @@
 
 int main(int argc, char *argv[])
 {
+
+#ifdef Q_OS_WIN
+	//enables automatic scaling based on the monitor's pixel density
+	ccViewerApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+
 	ccViewerApplication::InitOpenGL();
 	
 	// Convert the input arguments to QString before the application is initialized

--- a/libs/CCAppCommon/src/ccApplicationBase.cpp
+++ b/libs/CCAppCommon/src/ccApplicationBase.cpp
@@ -93,11 +93,6 @@ ccApplicationBase::ccApplicationBase(int& argc, char** argv, bool isCommandLine,
 
 	setupPaths();
 
-#ifdef Q_OS_WIN
-	//enables automatic scaling based on the monitor's pixel density
-	setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
-
 #ifdef Q_OS_MAC
 	// Mac OS X apps don't show icons in menus
 	setAttribute(Qt::AA_DontShowIconsInMenus);

--- a/qCC/main.cpp
+++ b/qCC/main.cpp
@@ -117,6 +117,11 @@ int main(int argc, char **argv)
         }
     }
 
+#ifdef Q_OS_WIN
+	//enables automatic scaling based on the monitor's pixel density
+	ccApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+
     ccApplication::InitOpenGL();
 
 	ccApplication app(argc, argv, commandLine);


### PR DESCRIPTION
the Qt::AA_EnableHighDpiScaling setting should be used before instanciation of QApplication.