### PR TITLE
Don't canonicalize OBJ path for MTL loading. Fixes #1772

### DIFF
--- a/plugins/core/IO/qCoreIO/src/ObjFilter.cpp
+++ b/plugins/core/IO/qCoreIO/src/ObjFilter.cpp
@@ -1134,7 +1134,7 @@ CC_FILE_ERROR ObjFilter::loadFile(const QString& filename, ccHObject& container,
 						mtlFilename = mtlFilename.left(mtlFilename.size() - 1);
 					}
 					ccLog::Print(QString("[OBJ] Material file: ") + mtlFilename);
-					QString mtlPath = QFileInfo(filename).canonicalPath();
+					QString mtlPath = QFileInfo(filename).path();
 					//we try to load it
 					if (!materials)
 					{


### PR DESCRIPTION
Fixes #1772.