### PR TITLE
streaming of floats does not work

### DIFF
--- a/plugins/core/IO/qLASIO/src/LasWaveformSaver.cpp
+++ b/plugins/core/IO/qLASIO/src/LasWaveformSaver.cpp
@@ -38,8 +38,16 @@ void LasWaveformSaver::handlePoint(size_t index, laszip_point& point)
 		stream << w.descriptorID();
 		stream << static_cast<quint64>(w.dataOffset() + LasDetails::EvlrHeader::SIZE);
 		stream << w.byteCount();
-		stream << w.echoTime_ps();
-		stream << w.beamDir().x << w.beamDir().y << w.beamDir().z;
+
+		float array[4];
+
+		array[0] = w.echoTime_ps();
+		array[1] = w.beamDir().x;
+		array[2] = w.beamDir().y;
+		array[3] = w.beamDir().z;
+
+		memcpy(&m_array.data()[13], array, 4 * 4);
+
 	}
 
 	memcpy(point.wave_packet, m_array.constData(), 29);


### PR DESCRIPTION
The values of return_point_wave_location, x_t, y_t and z_t were not properly saved in the las point records.