### PR TITLE
Find CGAL::CGAL_Core component in CMake

### DIFF
--- a/plugins/core/Standard/qMeshBoolean/cmake/LibIGLSupport.cmake
+++ b/plugins/core/Standard/qMeshBoolean/cmake/LibIGLSupport.cmake
@@ -23,7 +23,7 @@ else()
 	target_include_directories( ${PROJECT_NAME} PRIVATE ${EIGEN_ROOT_DIR} )
 endif()
 
-find_package( CGAL REQUIRED )
+find_package( CGAL REQUIRED COMPONENTS Core )
 
 # Link project with libigl library
 function( target_link_libIGL ) # 1 argument: ARGV0 = project name


### PR DESCRIPTION
cf. https://doc.cgal.org/latest/Manual/devman_create_and_use_a_cmakelist.html

This fixes a CMake error trying to build latest git master with CGAL 5.5.2.