### PR TITLE
LAS: add point format id 0 to 5 for version 1.4

### DIFF
--- a/plugins/core/IO/qLASIO/src/LasDetails.cpp
+++ b/plugins/core/IO/qLASIO/src/LasDetails.cpp
@@ -33,7 +33,7 @@
 
 static const std::vector<unsigned>      PointFormatForV1_2 = {0, 1, 2, 3};
 static const std::vector<unsigned>      PointFormatForV1_3 = {0, 1, 2, 3, 4, 5};
-static const std::vector<unsigned>      PointFormatForV1_4 = {6, 7, 8, 9, 10};
+static const std::vector<unsigned>      PointFormatForV1_4 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 static const std::array<const char*, 3> VersionsArray      = {"1.2", "1.3", "1.4"};
 
 namespace LasDetails


### PR DESCRIPTION
We locked las version 1.4 files to points format 6 to 10 as the standard says they are the prefered versions.

However, point format 0 to 5 are not prohibithed so we can add them.

Fixes https://github.com/CloudCompare/CloudCompare/issues/1834