### PR TITLE
Better to have "1." as a default value for the scales.

### DIFF
--- a/plugins/core/IO/qLASIO/include/LasExtraScalarField.h
+++ b/plugins/core/IO/qLASIO/include/LasExtraScalarField.h
@@ -125,7 +125,7 @@ class LasExtraScalarField
 	uint8_t noData[MAX_DIM_SIZE][8]           = {0};
 	uint8_t mins[MAX_DIM_SIZE][8]             = {0};
 	uint8_t maxs[MAX_DIM_SIZE][8]             = {0};
-	double  scales[MAX_DIM_SIZE]              = {0.0};
+	double  scales[MAX_DIM_SIZE]              = {1.0};
 	double  offsets[MAX_DIM_SIZE]             = {0.0};
 
 	// These are added by us

--- a/plugins/core/IO/qLASIO/include/LasExtraScalarField.h
+++ b/plugins/core/IO/qLASIO/include/LasExtraScalarField.h
@@ -125,7 +125,7 @@ class LasExtraScalarField
 	uint8_t noData[MAX_DIM_SIZE][8]           = {0};
 	uint8_t mins[MAX_DIM_SIZE][8]             = {0};
 	uint8_t maxs[MAX_DIM_SIZE][8]             = {0};
-	double  scales[MAX_DIM_SIZE]              = {1.0};
+	double  scales[MAX_DIM_SIZE]              = {0.0};
 	double  offsets[MAX_DIM_SIZE]             = {0.0};
 
 	// These are added by us

--- a/plugins/core/IO/qLASIO/src/LasIOFilter.cpp
+++ b/plugins/core/IO/qLASIO/src/LasIOFilter.cpp
@@ -599,7 +599,7 @@ CC_FILE_ERROR LasIOFilter::saveToFile(ccHObject* entity, const QString& filename
 		params.lasOffset = lasOffset;
 	}
 
-	// In case of command line call, add automatically all remaining scalar fiels as extra scalar fields
+	// In case of command line call, add automatically all remaining scalar fields as extra scalar fields
 	if (!parameters.alwaysDisplaySaveDialog)
 	{
 		uint sfCount = pointCloud->getNumberOfScalarFields();

--- a/plugins/core/IO/qLASIO/src/LasWaveformLoader.cpp
+++ b/plugins/core/IO/qLASIO/src/LasWaveformLoader.cpp
@@ -108,7 +108,7 @@ LasWaveformLoader::LasWaveformLoader(const laszip_header_struct& laszipHeader,
 			return;
 		}
 		fwfDataCount  = evlrHeader.recordLength;
-		fwfDataOffset = 0;
+		fwfDataOffset = LasDetails::EvlrHeader::SIZE;
 		if (fwfDataCount == 0)
 		{
 			ccLog::Warning(QString("[LAS] Invalid waveform data packet size (0). We'll load all the "


### PR DESCRIPTION
Better to have "1." as a default value for the scales.
fwfDataOffset was not correct for internal waveforms