### PR TITLE
New option for the command line COLOR_INTERP + bug correction.

### DIFF
--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -115,6 +115,7 @@ constexpr char COMMAND_SF_ARITHMETIC_IN_PLACE[]			= "IN_PLACE";
 constexpr char COMMAND_SF_OP[]							= "SF_OP";
 constexpr char COMMAND_SF_OP_SF[]						= "SF_OP_SF";
 constexpr char COMMAND_SF_INTERP[]						= "SF_INTERP";
+constexpr char COMMAND_COLOR_INTERP[]					= "COLOR_INTERP";
 constexpr char COMMAND_SF_INTERP_DEST_IS_FIRST[]		= "DEST_IS_FIRST";
 constexpr char COMMAND_SF_ADD_CONST[]                   = "SF_ADD_CONST";
 constexpr char COMMAND_RENAME_SF[]						= "RENAME_SF";
@@ -2643,6 +2644,7 @@ bool CommandRemoveSF::removeSF(int sfIndex, ccPointCloud& pc)
 {
 	if (sfIndex < static_cast<int>(pc.getNumberOfScalarFields()))
 	{
+		ccLog::Print("[REMOVE_SF] " + QString(pc.getScalarFieldName(sfIndex)));
 		pc.deleteScalarField(sfIndex);
 		if (pc.getNumberOfScalarFields() == 0)
 		{
@@ -5309,6 +5311,24 @@ bool CommandSFInterpolation::process(ccCommandLineInterface& cmd)
 	}
 
 	return ccEntityAction::interpolateSFs(source, dest, sfIndex, params, cmd.widgetParent());
+}
+
+CommandColorInterpolation::CommandColorInterpolation()
+	: ccCommandLineInterface::Command(QObject::tr("Color interpolation"), COMMAND_COLOR_INTERP)
+{}
+
+bool CommandColorInterpolation::process(ccCommandLineInterface& cmd)
+{
+	cmd.print(QObject::tr("[COLOR INTERPOLATION]"));
+
+	if (cmd.clouds().size() < 2)
+		return cmd.error(QObject::tr("Unexpected number of clouds for '%1' (at least 2 clouds expected: first = source, second = dest)").arg(COMMAND_COLOR_INTERP));
+
+	ccHObject::Container entities;
+	entities.push_back(cmd.clouds()[0].pc);
+	entities.push_back(cmd.clouds()[1].pc);
+
+	return 	ccEntityAction::interpolateColors(entities, cmd.widgetParent());
 }
 
 CommandSFRename::CommandSFRename()

--- a/qCC/ccCommandLineCommands.h
+++ b/qCC/ccCommandLineCommands.h
@@ -419,6 +419,13 @@ struct CommandSFInterpolation : public ccCommandLineInterface::Command
     bool process(ccCommandLineInterface& cmd) override;
 };
 
+struct CommandColorInterpolation : public ccCommandLineInterface::Command
+{
+	CommandColorInterpolation();
+
+	bool process(ccCommandLineInterface& cmd) override;
+};
+
 struct CommandSFRename : public ccCommandLineInterface::Command
 {
 	CommandSFRename();

--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -720,6 +720,7 @@ void ccCommandLineParser::registerBuiltInCommands()
 	registerCommand(Command::Shared(new CommandCrop));
 	registerCommand(Command::Shared(new CommandCrop2D));
 	registerCommand(Command::Shared(new CommandCoordToSF));
+	registerCommand(Command::Shared(new CommandSFToCoord));
 	registerCommand(Command::Shared(new CommandColorBanding));
 	registerCommand(Command::Shared(new CommandColorLevels));
 	registerCommand(Command::Shared(new CommandC2MDist));
@@ -731,6 +732,7 @@ void ccCommandLineParser::registerBuiltInCommands()
 	registerCommand(Command::Shared(new CommandSFOperation));
     registerCommand(Command::Shared(new CommandSFOperationSF));
     registerCommand(Command::Shared(new CommandSFInterpolation));
+    registerCommand(Command::Shared(new CommandColorInterpolation));
 	registerCommand(Command::Shared(new CommandSFRename));
     registerCommand(Command::Shared(new CommandSFAddConst));
 	registerCommand(Command::Shared(new CommandICP));


### PR DESCRIPTION
Option COLOR_INTERP allows the interpolation of the colors of one cloud to another cloud.

Bug correction: the command SF_TO_COORD was not registered.