### PR TITLE
Updated qMeshBoolean.cpp to prevent compilation failure

### DIFF
--- a/plugins/core/Standard/qMeshBoolean/src/qMeshBoolean.cpp
+++ b/plugins/core/Standard/qMeshBoolean/src/qMeshBoolean.cpp
@@ -39,12 +39,12 @@
 #endif
 
 //libIGL
+#include <igl/copyleft/cgal/mesh_boolean.h>
 #ifdef _MSC_VER
 #pragma warning( disable: 4018 )
 #pragma warning( disable: 4129 )
 #pragma warning( disable: 4267 )
 #pragma warning( disable: 4566 )
-#include <igl/copyleft/cgal/mesh_boolean.h>
 #endif
 
 //! ligIGL mesh


### PR DESCRIPTION
After the qMeshBoolean plugin compilation failure (see #1871), i changed the mesh_boolean.h path position in qMeshBolean.cpp and then the compilation finished without errors, CloudCompare works. It was probably hidden by ifdef-endif code part.