### PR TITLE
Cmd option SF_ADD_ID with AS_INT supboption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ v2.13.alpha (???) - (??/??/????)
 ----------------------
 - - New features:
 	- New command line option:
+		- SF_ADD_ID allows to add the index of the point as a scalar field (initially as a float32, so there is a loss of accuracy for values above 16777215)
+			- the AS_INT parameter allows to store the index as a raw uint32, allowing index values from 0 up to (2**32-1)
 		- FLIP_TRI (to flip the order of the triangle vertices of all opened meshes)
 		- SF_OP_SF {SF 1 name or index} {operation} {SF 2 name or index}
 			- to compute an arithmetic operation between two scalar fields (add, sub, mult, div)

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -119,6 +119,7 @@ constexpr char COMMAND_COLOR_INTERP[]					= "COLOR_INTERP";
 constexpr char COMMAND_SF_INTERP_DEST_IS_FIRST[]		= "DEST_IS_FIRST";
 constexpr char COMMAND_SF_ADD_CONST[]					= "SF_ADD_CONST";
 constexpr char COMMAND_SF_ADD_ID[]						= "SF_ADD_ID";
+constexpr char COMMAND_SF_ADD_ID_AS_INT[]				= "AS_INT";
 constexpr char COMMAND_RENAME_SF[]						= "RENAME_SF";
 constexpr char COMMAND_COORD_TO_SF[]					= "COORD_TO_SF";
 constexpr char COMMAND_SF_TO_COORD[]					= "SF_TO_COORD";
@@ -5491,16 +5492,33 @@ CommandSFAddId::CommandSFAddId()
 
 bool CommandSFAddId::process(ccCommandLineInterface& cmd)
 {
-	cmd.print(QObject::tr("[ADD ID]"));
+	cmd.print(QObject::tr("[SF_ADD_ID]"));
 
 	ccHObject::Container selectedEntities;
+
+	bool addIdAsInt = false;
+	while (!cmd.arguments().empty())
+	{
+		QString argument = cmd.arguments().front();
+		if (ccCommandLineInterface::IsCommand(argument, COMMAND_SF_ADD_ID_AS_INT))
+		{
+			cmd.print(QObject::tr("[AS_INT]"));
+			//local option confirmed, we can move on
+			cmd.arguments().pop_front();
+			addIdAsInt = true;
+		}
+		else
+		{
+			break; //as soon as we encounter an unrecognized argument, we break the local loop to go back to the main one!
+		}
+	}
 
 	for (CLCloudDesc& desc : cmd.clouds())
 	{
 		selectedEntities.push_back(desc.getEntity());
 	}
 
-	if ( !ccEntityAction::sfAddIdField(selectedEntities) )
+	if ( !ccEntityAction::sfAddIdField(selectedEntities, addIdAsInt) )
 		return false;
 
 	return true;

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -87,7 +87,7 @@ constexpr char COMMAND_NOISE_FILTER_RADIUS[]			= "RADIUS";
 constexpr char COMMAND_NOISE_FILTER_REL[]				= "REL";
 constexpr char COMMAND_NOISE_FILTER_ABS[]				= "ABS";
 constexpr char COMMAND_NOISE_FILTER_RIP[]				= "RIP";
-constexpr char COMMAND_REMOVE_DUPLICATE_POINTS[]	    = "RDP";
+constexpr char COMMAND_REMOVE_DUPLICATE_POINTS[]		= "RDP";
 constexpr char COMMAND_SAMPLE_MESH[]					= "SAMPLE_MESH";
 constexpr char COMMAND_COMPRESS_FWF[]					= "COMPRESS_FWF";
 constexpr char COMMAND_CROP[]							= "CROP";
@@ -99,9 +99,9 @@ constexpr char COMMAND_C2M_DIST[]						= "C2M_DIST";
 constexpr char COMMAND_C2M_DIST_FLIP_NORMALS[]			= "FLIP_NORMS";
 constexpr char COMMAND_C2M_DIST_UNSIGNED[]				= "UNSIGNED";
 constexpr char COMMAND_C2C_DIST[]						= "C2C_DIST";
-constexpr char COMMAND_CLOSEST_POINT_SET[]              = "CLOSEST_POINT_SET";
+constexpr char COMMAND_CLOSEST_POINT_SET[]				= "CLOSEST_POINT_SET";
 constexpr char COMMAND_C2C_SPLIT_XYZ[]					= "SPLIT_XYZ";
-constexpr char COMMAND_C2C_SPLIT_XY_Z[]                 = "SPLIT_XY_Z";
+constexpr char COMMAND_C2C_SPLIT_XY_Z[]					= "SPLIT_XY_Z";
 constexpr char COMMAND_C2C_LOCAL_MODEL[]				= "MODEL";
 constexpr char COMMAND_C2X_MAX_DISTANCE[]				= "MAX_DIST";
 constexpr char COMMAND_C2X_OCTREE_LEVEL[]				= "OCTREE_LEVEL";
@@ -117,7 +117,8 @@ constexpr char COMMAND_SF_OP_SF[]						= "SF_OP_SF";
 constexpr char COMMAND_SF_INTERP[]						= "SF_INTERP";
 constexpr char COMMAND_COLOR_INTERP[]					= "COLOR_INTERP";
 constexpr char COMMAND_SF_INTERP_DEST_IS_FIRST[]		= "DEST_IS_FIRST";
-constexpr char COMMAND_SF_ADD_CONST[]                   = "SF_ADD_CONST";
+constexpr char COMMAND_SF_ADD_CONST[]					= "SF_ADD_CONST";
+constexpr char COMMAND_SF_ADD_ID[]						= "SF_ADD_ID";
 constexpr char COMMAND_RENAME_SF[]						= "RENAME_SF";
 constexpr char COMMAND_COORD_TO_SF[]					= "COORD_TO_SF";
 constexpr char COMMAND_SF_TO_COORD[]					= "SF_TO_COORD";
@@ -5482,6 +5483,27 @@ bool CommandSFAddConst::process(ccCommandLineInterface& cmd)
     }
 
     return true;
+}
+
+CommandSFAddId::CommandSFAddId()
+    : ccCommandLineInterface::Command(QObject::tr("Add point indexes as scalar field"), COMMAND_SF_ADD_ID)
+{}
+
+bool CommandSFAddId::process(ccCommandLineInterface& cmd)
+{
+	cmd.print(QObject::tr("[ADD ID]"));
+
+	ccHObject::Container selectedEntities;
+
+	for (CLCloudDesc& desc : cmd.clouds())
+	{
+		selectedEntities.push_back(desc.getEntity());
+	}
+
+	if ( !ccEntityAction::sfAddIdField(selectedEntities) )
+		return false;
+
+	return true;
 }
 
 CommandICP::CommandICP()

--- a/qCC/ccCommandLineCommands.h
+++ b/qCC/ccCommandLineCommands.h
@@ -440,6 +440,13 @@ struct CommandSFAddConst : public ccCommandLineInterface::Command
     bool process(ccCommandLineInterface& cmd) override;
 };
 
+struct CommandSFAddId : public ccCommandLineInterface::Command
+{
+	CommandSFAddId();
+
+	bool process(ccCommandLineInterface& cmd) override;
+};
+
 struct CommandICP : public ccCommandLineInterface::Command
 {
 	CommandICP();

--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -734,7 +734,8 @@ void ccCommandLineParser::registerBuiltInCommands()
     registerCommand(Command::Shared(new CommandSFInterpolation));
     registerCommand(Command::Shared(new CommandColorInterpolation));
 	registerCommand(Command::Shared(new CommandSFRename));
-    registerCommand(Command::Shared(new CommandSFAddConst));
+	registerCommand(Command::Shared(new CommandSFAddConst));
+	registerCommand(Command::Shared(new CommandSFAddId));
 	registerCommand(Command::Shared(new CommandICP));
 	registerCommand(Command::Shared(new CommandChangeCloudOutputFormat));
 	registerCommand(Command::Shared(new CommandChangeMeshOutputFormat));

--- a/qCC/ccEntityAction.cpp
+++ b/qCC/ccEntityAction.cpp
@@ -1118,6 +1118,7 @@ namespace ccEntityAction
 					else
 					{
 #if defined CC_CORE_LIB_USES_DOUBLE
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 						unsigned char *valuePtr = (unsigned char *)(&idValue);
 						valuePtr[7] = static_cast<unsigned char>(j & 0xff);
 						valuePtr[6] = static_cast<unsigned char>(j >> 8 & 0xff);
@@ -1127,13 +1128,31 @@ namespace ccEntityAction
 						valuePtr[2] = static_cast<unsigned char>(j >> 40 & 0xff);
 						valuePtr[1] = static_cast<unsigned char>(j >> 48 & 0xff);
 						valuePtr[0] = static_cast<unsigned char>(j >> 56 & 0xff);
-						sf->setValue(j, idValue);
+#else
+						unsigned char *valuePtr = (unsigned char *)(&idValue);
+						valuePtr[0] = static_cast<unsigned char>(j & 0xff);
+						valuePtr[1] = static_cast<unsigned char>(j >> 8 & 0xff);
+						valuePtr[2] = static_cast<unsigned char>(j >> 16 & 0xff);
+						valuePtr[3] = static_cast<unsigned char>(j >> 24 & 0xff);
+						valuePtr[4] = static_cast<unsigned char>(j >> 32 & 0xff);
+						valuePtr[5] = static_cast<unsigned char>(j >> 40 & 0xff);
+						valuePtr[6] = static_cast<unsigned char>(j >> 48 & 0xff);
+						valuePtr[7] = static_cast<unsigned char>(j >> 56 & 0xff);
+#endif
 #elif defined CC_CORE_LIB_USES_FLOAT
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 						unsigned char *valuePtr = (unsigned char *)(&idValue);
 						valuePtr[0] = static_cast<unsigned char>(j & 0xff);
 						valuePtr[1] = static_cast<unsigned char>((j >> 8) & 0xff);
 						valuePtr[2] = static_cast<unsigned char>((j >> 16) & 0xff);
 						valuePtr[3] = static_cast<unsigned char>((j >> 24) & 0xff);
+#else
+						unsigned char *valuePtr = (unsigned char *)(&idValue);
+						valuePtr[3] = static_cast<unsigned char>(j & 0xff);
+						valuePtr[2] = static_cast<unsigned char>((j >> 8) & 0xff);
+						valuePtr[1] = static_cast<unsigned char>((j >> 16) & 0xff);
+						valuePtr[0] = static_cast<unsigned char>((j >> 24) & 0xff);
+#endif
 #else
 						static_assert(false, "type for ScalarType has not been declared");
 #endif

--- a/qCC/ccEntityAction.cpp
+++ b/qCC/ccEntityAction.cpp
@@ -1111,10 +1111,9 @@ namespace ccEntityAction
 				for (size_t j=0 ; j<cloud->size(); j++)
 				{
 					ScalarType idValue;
-					if (false)
+					if (!storeAsInt)
 					{
 						idValue = static_cast<ScalarType>(j);
-						sf->setValue(j, idValue);
 					}
 					else
 					{
@@ -1135,11 +1134,11 @@ namespace ccEntityAction
 						valuePtr[1] = static_cast<unsigned char>((j >> 8) & 0xff);
 						valuePtr[2] = static_cast<unsigned char>((j >> 16) & 0xff);
 						valuePtr[3] = static_cast<unsigned char>((j >> 24) & 0xff);
-						sf->setValue(j, idValue);
 #else
 						static_assert(false, "type for ScalarType has not been declared");
 #endif
 					}
+					sf->setValue(j, idValue);
 				}
 				
 				sf->computeMinAndMax();

--- a/qCC/ccEntityAction.cpp
+++ b/qCC/ccEntityAction.cpp
@@ -1087,7 +1087,7 @@ namespace ccEntityAction
 		return true;
 	}
 	
-	bool	sfAddIdField(const ccHObject::Container &selectedEntities)
+	bool	sfAddIdField(const ccHObject::Container &selectedEntities, bool storeAsInt)
 	{
 		for (ccHObject* ent : selectedEntities)
 		{
@@ -1107,11 +1107,39 @@ namespace ccEntityAction
 				
 				CCCoreLib::ScalarField* sf = pc->getScalarField(sfIdx);
 				Q_ASSERT(sf->currentSize() == pc->size());
-				
-				for (unsigned j=0 ; j<cloud->size(); j++)
+
+				for (size_t j=0 ; j<cloud->size(); j++)
 				{
-					ScalarType idValue = static_cast<ScalarType>(j);
-					sf->setValue(j, idValue);
+					ScalarType idValue;
+					if (false)
+					{
+						idValue = static_cast<ScalarType>(j);
+						sf->setValue(j, idValue);
+					}
+					else
+					{
+#if defined CC_CORE_LIB_USES_DOUBLE
+						unsigned char *valuePtr = (unsigned char *)(&idValue);
+						valuePtr[7] = static_cast<unsigned char>(j & 0xff);
+						valuePtr[6] = static_cast<unsigned char>(j >> 8 & 0xff);
+						valuePtr[5] = static_cast<unsigned char>(j >> 16 & 0xff);
+						valuePtr[4] = static_cast<unsigned char>(j >> 24 & 0xff);
+						valuePtr[3] = static_cast<unsigned char>(j >> 32 & 0xff);
+						valuePtr[2] = static_cast<unsigned char>(j >> 40 & 0xff);
+						valuePtr[1] = static_cast<unsigned char>(j >> 48 & 0xff);
+						valuePtr[0] = static_cast<unsigned char>(j >> 56 & 0xff);
+						sf->setValue(j, idValue);
+#elif defined CC_CORE_LIB_USES_FLOAT
+						unsigned char *valuePtr = (unsigned char *)(&idValue);
+						valuePtr[0] = static_cast<unsigned char>(j & 0xff);
+						valuePtr[1] = static_cast<unsigned char>((j >> 8) & 0xff);
+						valuePtr[2] = static_cast<unsigned char>((j >> 16) & 0xff);
+						valuePtr[3] = static_cast<unsigned char>((j >> 24) & 0xff);
+						sf->setValue(j, idValue);
+#else
+						static_assert(false, "type for ScalarType has not been declared");
+#endif
+					}
 				}
 				
 				sf->computeMinAndMax();

--- a/qCC/ccEntityAction.h
+++ b/qCC/ccEntityAction.h
@@ -42,7 +42,7 @@ namespace ccEntityAction
 	bool	sfConvertToRGB(const ccHObject::Container &selectedEntities, QWidget* parent);
 	bool	sfConvertToRandomRGB(const ccHObject::Container &selectedEntities, QWidget* parent);
 	bool	sfRename(const ccHObject::Container &selectedEntities, QWidget* parent);
-	bool	sfAddIdField(const ccHObject::Container &selectedEntities);
+	bool	sfAddIdField(const ccHObject::Container &selectedEntities, bool storeAsInt=false);
     bool	sfSplitCloud(const ccHObject::Container &selectedEntities, ccMainAppInterface *app);
 	bool	sfSetAsCoord(const ccHObject::Container &selectedEntities, QWidget* parent);
 	bool	exportCoordToSF(const ccHObject::Container &selectedEntities, QWidget* parent);


### PR DESCRIPTION
SF_ADD_ID allows to add the index of each point as a scalar field, initially as a float 32.
Possibility to store the index as a raw int32 to avoid a loss of accuracy for large integers and store values from 0 up to 2**32.