### PR TITLE
Added preference to use GLVND libraries for OpenGL and updated draco cmake file

### DIFF
--- a/cmake/CMakeExternalLibs.cmake
+++ b/cmake/CMakeExternalLibs.cmake
@@ -47,6 +47,10 @@ add_definitions( -DQT_USE_QSTRINGBUILDER )
 # ------------------------------------------------------------------------------
 # OpenGL
 # ------------------------------------------------------------------------------
+if ( UNIX )
+	set(OpenGL_GL_PREFERENCE GLVND)
+endif()
+
 if ( MSVC )
 	# Where to find OpenGL libraries
 	set(WINDOWS_OPENGL_LIBS "C:\\Program Files (x86)\\Windows Kits\\8.0\\Lib\\win8\\um\\x64" CACHE PATH "WindowsSDK libraries" )

--- a/plugins/core/IO/qDracoIO/CMakeLists.txt
+++ b/plugins/core/IO/qDracoIO/CMakeLists.txt
@@ -7,11 +7,24 @@ if( PLUGIN_IO_QDRACO )
 
 	AddPlugin( NAME ${PROJECT_NAME} TYPE io )
 	
-	target_include_directories( ${PROJECT_NAME} PRIVATE ${DRACO_INCLUDE_DIRS} )
-	if (MSVC)
+	target_include_directories( ${PROJECT_NAME} PRIVATE ${DRACO_INCLUDE_DIR} )
+	
+	if( MSVC )
 		target_link_libraries( ${PROJECT_NAME} ${Draco_DIR}/../../lib/${DRACO_LIBRARIES}.lib )
+	elseif( UNIX )
+		set ( DRACO_INCLUDE_DIR "" CACHE PATH "Draco include dir" )
+		set ( DRACO_LIB_DIR "" CACHE PATH "Draco library dir" )
+		
+		if( NOT DRACO_INCLUDE_DIR )
+			message( FATAL_ERROR "Draco include dir not specified (DRACO_INCLUDE_DIR)" )
+		endif()
+		if( NOT DRACO_LIB_DIR )
+			message( FATAL_ERROR "Draco library dir not specified (DRACO_LIB_DIR)" )
+		endif()
+		
+		target_link_libraries( ${PROJECT_NAME} ${DRACO_LIBRARIES} )
 	elseif()
-		target_link_libraries( ${DRACO_LIBRARIES} )
+		target_link_libraries( ${PROJECT_NAME} ${DRACO_LIBRARIES} )
 	endif()
 
 	add_subdirectory( include )


### PR DESCRIPTION
These modifies are related to Linux OS.
I added the preference to use GLVND libraries for OpenGL rather than Legacy library that it's commonly used by cmake 3.10 and below.
I also updated the draco cmake file to set include and library directorories, because in Linux OS, after CC compilation, libQDRACO_IO_PLUGIN isn't loaded due to missing link with draco libraries.