### PR TITLE
LAS: Allow to read/writenormals using extra scalar fields

### DIFF
--- a/plugins/core/IO/qLASIO/include/LasOpenDialog.h
+++ b/plugins/core/IO/qLASIO/include/LasOpenDialog.h
@@ -66,6 +66,9 @@ class LasOpenDialog : public QDialog
 	void filterOutNotChecked(std::vector<LasScalarField>&      scalarFields,
 	                         std::vector<LasExtraScalarField>& extraScalarFields);
 
+	/// Returns the array of extra scalar fields to be used as normals
+	std::array<LasExtraScalarField, 3> getExtraFieldsToBeLoadedAsNormals(const std::vector<LasExtraScalarField>& extraScalarFields) const ;
+
 	/// Returns whether the user wants to ignore (not load)
 	/// fields for which values are all default values.
 	bool shouldIgnoreFieldsWithDefaultValues() const;
@@ -111,6 +114,8 @@ class LasOpenDialog : public QDialog
 	void onAutomaticTimeShiftToggle(bool checked);
 
 	void onApplyAll();
+
+	void onNormalComboBoxChanged(const QString& name);
 
 	void onBrowseTilingOutputDir();
 

--- a/plugins/core/IO/qLASIO/include/LasSaveDialog.h
+++ b/plugins/core/IO/qLASIO/include/LasSaveDialog.h
@@ -64,6 +64,8 @@ class LasSaveDialog : public QDialog
 	bool shouldSaveRGB() const;
 	/// Returns whether the user wants to save the Waveforms
 	bool shouldSaveWaveform() const;
+	/// Returns whether the user wants to save normals as extra las scalar field
+	bool shouldSaveNormalsAsExtraScalarField() const;
 	/// Returns the vector of LAS scalar fields the user wants to save.
 	///
 	/// Each LAS scalar fields is mapped to an existing point cloud's ccScalarField.

--- a/plugins/core/IO/qLASIO/include/LasSaver.h
+++ b/plugins/core/IO/qLASIO/include/LasSaver.h
@@ -40,6 +40,7 @@ class LasSaver
 		std::vector<LasExtraScalarField> extraFields;
 		bool                             shouldSaveRGB{false};
 		bool                             shouldSaveWaveform{false};
+		bool                             shouldSaveNormalsAsExtraScalarField{false};
 		uint8_t                          versionMajor{1};
 		uint8_t                          versionMinor{0};
 		uint8_t                          pointFormat{0};
@@ -47,7 +48,7 @@ class LasSaver
 		CCVector3d                       lasOffset;
 	};
 
-	LasSaver(ccPointCloud& cloud, Parameters& parameters);
+	LasSaver(ccPointCloud& cloud, Parameters parameters);
 	~LasSaver() noexcept;
 
 	CC_FILE_ERROR open(const QString filePath);
@@ -70,4 +71,8 @@ class LasSaver
 	bool                              m_shouldSaveRGB{false};
 	std::unique_ptr<LasWaveformSaver> m_waveformSaver{nullptr};
 	laszip_point*                     m_laszipPoint{nullptr};
+	int                               m_originallySelectedScalarField = -1;
+	// contains for the x, y, z dims of the normals, whether it was temporarily
+	// exported to a scalar field. If true, then we have to remove the temporary sf.
+	bool m_normalDimWasTemporarillyExported[3] = {false, false, false};
 };

--- a/plugins/core/IO/qLASIO/include/LasScalarFieldLoader.h
+++ b/plugins/core/IO/qLASIO/include/LasScalarFieldLoader.h
@@ -44,11 +44,14 @@ class LasScalarFieldLoader
 
 	CC_FILE_ERROR handleScalarFields(ccPointCloud& pointCloud, const laszip_point& currentPoint);
 
+	/// Parses the extra scalar field described by extraField, from currentPoint, into outputValues
+	CC_FILE_ERROR parseExtraScalarField(const LasExtraScalarField& extraField, const laszip_point& currentPoint, ScalarType outputValues[3]);
+
 	/// In LAS files, the red, green and blue channels are normal LAS fields,
 	/// however in CloudCompare RGB is handled differently.
 	CC_FILE_ERROR handleRGBValue(ccPointCloud& pointCloud, const laszip_point& currentPoint);
 
-	CC_FILE_ERROR handleExtraScalarFields(ccPointCloud& pointCloud, const laszip_point& currentPoint);
+	CC_FILE_ERROR handleExtraScalarFields(const laszip_point& currentPoint);
 
 	inline void setIgnoreFieldsWithDefaultValues(bool state)
 	{
@@ -109,7 +112,7 @@ class LasScalarFieldLoader
 	void parseRawValues(const LasExtraScalarField& extraField, const uint8_t* dataStart);
 
 	template <typename T>
-	void handleOptionsFor(const LasExtraScalarField& extraField, T values[3]);
+	void handleOptionsFor(const LasExtraScalarField& extraField, T inputValues[3], ScalarType outputValues[3]);
 
   private:
 	bool                              m_force8bitRgbMode{false};
@@ -124,5 +127,5 @@ class LasScalarFieldLoader
 		uint64_t unsignedValues[LasExtraScalarField::MAX_DIM_SIZE];
 		int64_t  signedValues[LasExtraScalarField::MAX_DIM_SIZE];
 		double   floatingValues[LasExtraScalarField::MAX_DIM_SIZE];
-	} m_rawValues;
+	} m_rawValues{};
 };

--- a/plugins/core/IO/qLASIO/include/LasVlr.h
+++ b/plugins/core/IO/qLASIO/include/LasVlr.h
@@ -52,7 +52,7 @@ struct LasVlr
 		arch << static_cast<quint64>(object.vlrs.size());
 		for (const laszip_vlr_struct& v : object.vlrs)
 		{
-			//arch << v;
+			// arch << v;
 			arch << v.reserved;
 			arch.writeRawData(v.user_id, 16 * sizeof(laszip_CHAR));
 			arch << v.record_id;
@@ -64,7 +64,7 @@ struct LasVlr
 		arch << static_cast<quint64>(object.extraScalarFields.size());
 		for (const LasExtraScalarField& e : object.extraScalarFields)
 		{
-			//arch << e;
+			// arch << e;
 			arch.writeRawData((const char*)&e, sizeof(LasExtraScalarField));
 		}
 		return arch;
@@ -78,7 +78,7 @@ struct LasVlr
 		for (quint64 i = 0; i < vlrSize; ++i)
 		{
 			laszip_vlr_struct v;
-			//arch >> v;
+			// arch >> v;
 			arch >> v.reserved;
 			arch.readRawData((char*)v.user_id, 16 * sizeof(laszip_CHAR));
 			arch >> v.record_id;
@@ -88,7 +88,7 @@ struct LasVlr
 				v.data = new laszip_U8[v.record_length_after_header]; // TODO: potential memory leak
 				arch.readRawData((char*)v.data, v.record_length_after_header);
 			}
-			//arch >> QByteArray((const char*)v.data, v.record_length_after_header);
+			// arch >> QByteArray((const char*)v.data, v.record_length_after_header);
 			object.vlrs.push_back(v);
 		}
 
@@ -98,7 +98,7 @@ struct LasVlr
 		for (quint64 i = 0; i < extraScalarFieldCount; ++i)
 		{
 			LasExtraScalarField e;
-			//arch >> e;
+			// arch >> e;
 			{
 				char* data = (char*)&e;
 				uint  len  = sizeof(LasExtraScalarField);

--- a/plugins/core/IO/qLASIO/src/LasDetails.cpp
+++ b/plugins/core/IO/qLASIO/src/LasDetails.cpp
@@ -154,7 +154,8 @@ namespace LasDetails
 		return std::accumulate(vlrs,
 		                       vlrs + numVlrs,
 		                       0,
-		                       [=](laszip_U32 size, const laszip_vlr_struct& vlr) { return vlr.record_length_after_header + header_size + size; });
+		                       [=](laszip_U32 size, const laszip_vlr_struct& vlr)
+		                       { return vlr.record_length_after_header + header_size + size; });
 	}
 
 	const std::vector<unsigned>* PointFormatsAvailableForVersion(QString version)

--- a/plugins/core/IO/qLASIO/src/LasSaveDialog.cpp
+++ b/plugins/core/IO/qLASIO/src/LasSaveDialog.cpp
@@ -139,12 +139,12 @@ LasSaveDialog::LasSaveDialog(ccPointCloud* cloud, QWidget* parent)
 	versionComboBox->setCurrentIndex(0);
 
 	connect(versionComboBox,
-	        (void (QComboBox::*)(const QString&))(&QComboBox::currentIndexChanged),
+	        (void(QComboBox::*)(const QString&))(&QComboBox::currentIndexChanged),
 	        this,
 	        &LasSaveDialog::handleSelectedVersionChange);
 
 	connect(pointFormatComboBox,
-	        (void (QComboBox::*)(int))(&QComboBox::currentIndexChanged),
+	        (void(QComboBox::*)(int))(&QComboBox::currentIndexChanged),
 	        this,
 	        &LasSaveDialog::handleSelectedPointFormatChange);
 
@@ -163,6 +163,9 @@ LasSaveDialog::LasSaveDialog(ccPointCloud* cloud, QWidget* parent)
 	m_extraFieldsDataTypesModel->setStringList(extraFieldsDataTypeNames);
 
 	connect(addExtraScalarFieldButton, &QPushButton::clicked, this, &LasSaveDialog::addExtraScalarFieldCard);
+
+	normalsCheckBox->setEnabled(cloud->hasNormals());
+	normalsCheckBox->setCheckState(Qt::CheckState::Checked);
 }
 
 /// When the selected version changes, we need to update the combo box
@@ -524,6 +527,11 @@ bool LasSaveDialog::shouldSaveRGB() const
 bool LasSaveDialog::shouldSaveWaveform() const
 {
 	return waveformCheckBox->isChecked();
+}
+
+bool LasSaveDialog::shouldSaveNormalsAsExtraScalarField() const
+{
+	return normalsCheckBox->isChecked();
 }
 
 CCVector3d LasSaveDialog::chosenScale() const

--- a/plugins/core/IO/qLASIO/src/LasSaver.cpp
+++ b/plugins/core/IO/qLASIO/src/LasSaver.cpp
@@ -1,20 +1,61 @@
 #include "LasSaver.h"
 
+#include "LasExtraScalarField.h"
 #include "LasMetadata.h"
 
-//Qt
+// Qt
 #include <QDate>
 // qCC_db
 #include <ccGlobalShiftManager.h>
 #include <ccPointCloud.h>
 
-LasSaver::LasSaver(ccPointCloud& cloud, Parameters& parameters)
+constexpr const char* const CC_NORMAL_NAMES[3] = {"Nx", "Ny", "Nz"};
+
+LasSaver::LasSaver(ccPointCloud& cloud, Parameters parameters)
     : m_cloudToSave(cloud)
 {
 	// restore the global encoding (if any) - must be done before calling initLaszipHeader
 	LasMetadata::LoadGlobalEncoding(cloud, m_laszipHeader.global_encoding);
 	// restore the project UUID (if any)
 	LasMetadata::LoadProjectUUID(cloud, m_laszipHeader);
+
+	if (parameters.shouldSaveNormalsAsExtraScalarField)
+	{
+		// We export normals to extra scalar fields,
+		// the easiest way to integrate that into the LasScalarFieldSaver system
+		// is to temporarily export normals to scalar fields.
+		m_originallySelectedScalarField = cloud.getCurrentDisplayedScalarFieldIndex();
+		bool exportOptions[3]           {false, false, false}; // Export all
+		for (size_t i = 0; i < 3; ++i)
+		{
+			int idx          = cloud.getScalarFieldIndexByName(CC_NORMAL_NAMES[i]);
+			exportOptions[i] = (idx == -1); // Only export if not already exported
+		}
+
+		bool needsToExportAtLeastOne = (exportOptions[0] | exportOptions[1] | exportOptions[2]);
+		if (needsToExportAtLeastOne && !cloud.exportNormalToSF(exportOptions))
+		{
+			throw std::runtime_error("Failed to export normals to SF");
+		}
+		constexpr const char* const exportedNormalNames[3] {"NormalX", "NormalY", "NormalZ"};
+
+		for (size_t i = 0; i < 3; ++i)
+		{
+			int idx = cloud.getScalarFieldIndexByName(CC_NORMAL_NAMES[i]);
+			assert(idx != -1);
+			auto* sf = dynamic_cast<ccScalarField*>(cloud.getScalarField(idx));
+			assert(sf != nullptr);
+
+			LasExtraScalarField field;
+			strncpy(field.name, exportedNormalNames[i], LasExtraScalarField::MAX_NAME_SIZE);
+			field.type            = LasExtraScalarField::DataType::f64;
+			field.dimensions      = LasExtraScalarField::DimensionSize::One;
+			field.scalarFields[0] = sf;
+
+			parameters.extraFields.push_back(field);
+			m_normalDimWasTemporarillyExported[i] = exportOptions[i];
+		}
+	}
 
 	initLaszipHeader(parameters);
 
@@ -105,6 +146,25 @@ LasSaver::~LasSaver() noexcept
 		laszip_close_writer(m_laszipWriter);
 		laszip_clean(m_laszipWriter);
 		laszip_destroy(m_laszipWriter);
+	}
+
+	if (m_originallySelectedScalarField != -1)
+	{
+		m_cloudToSave.setCurrentDisplayedScalarField(m_originallySelectedScalarField);
+
+		// m_originallySelectedScalarField it means we did create temporary
+		// Nx, Ny, Nz scalar fields, so we remove them
+		for (size_t i = 0; i < 3; ++i)
+		{
+			if (m_normalDimWasTemporarillyExported[i])
+			{
+				const int idx = m_cloudToSave.getScalarFieldIndexByName(CC_NORMAL_NAMES[i]);
+				if (idx != -1)
+				{
+					m_cloudToSave.deleteScalarField(idx);
+				}
+			}
+		}
 	}
 }
 

--- a/plugins/core/IO/qLASIO/src/LasScalarFieldLoader.cpp
+++ b/plugins/core/IO/qLASIO/src/LasScalarFieldLoader.cpp
@@ -112,6 +112,40 @@ CC_FILE_ERROR LasScalarFieldLoader::handleScalarFields(ccPointCloud&       point
 
 	return CC_FERR_NO_ERROR;
 }
+CC_FILE_ERROR LasScalarFieldLoader::parseExtraScalarField(
+    const LasExtraScalarField& extraField,
+    const laszip_point&        currentPoint,
+    ScalarType                 outputValues[3])
+{
+
+	if (currentPoint.num_extra_bytes <= 0 || currentPoint.extra_bytes == nullptr)
+	{
+		return CC_FERR_NO_ERROR;
+	}
+
+	if (extraField.byteOffset + extraField.byteSize() > static_cast<unsigned>(currentPoint.num_extra_bytes))
+	{
+		assert(false);
+		return CC_FERR_READING;
+	}
+
+	laszip_U8* dataStart = currentPoint.extra_bytes + extraField.byteOffset;
+	parseRawValues(extraField, dataStart);
+	switch (extraField.kind())
+	{
+	case LasExtraScalarField::Unsigned:
+		handleOptionsFor(extraField, m_rawValues.unsignedValues, outputValues);
+		break;
+	case LasExtraScalarField::Signed:
+		handleOptionsFor(extraField, m_rawValues.signedValues, outputValues);
+		break;
+	case LasExtraScalarField::Floating:
+		handleOptionsFor(extraField, m_rawValues.floatingValues, outputValues);
+		break;
+	}
+
+	return CC_FERR_NO_ERROR;
+}
 
 CC_FILE_ERROR LasScalarFieldLoader::handleRGBValue(ccPointCloud& pointCloud, const laszip_point& currentPoint)
 {
@@ -155,8 +189,7 @@ CC_FILE_ERROR LasScalarFieldLoader::handleRGBValue(ccPointCloud& pointCloud, con
 	return CC_FERR_NO_ERROR;
 }
 
-CC_FILE_ERROR LasScalarFieldLoader::handleExtraScalarFields(ccPointCloud&       pointCloud,
-                                                            const laszip_point& currentPoint)
+CC_FILE_ERROR LasScalarFieldLoader::handleExtraScalarFields(const laszip_point& currentPoint)
 {
 	if (currentPoint.num_extra_bytes <= 0 || currentPoint.extra_bytes == nullptr)
 	{
@@ -165,25 +198,17 @@ CC_FILE_ERROR LasScalarFieldLoader::handleExtraScalarFields(ccPointCloud&       
 
 	for (const LasExtraScalarField& extraField : m_extraScalarFields)
 	{
-		if (extraField.byteOffset + extraField.byteSize() > static_cast<unsigned>(currentPoint.num_extra_bytes))
+		ScalarType finalValues[3] {0.0};
+
+		const CC_FILE_ERROR err = parseExtraScalarField(extraField, currentPoint, finalValues);
+		if (err != CC_FERR_NO_ERROR)
 		{
-			assert(false);
-			return CC_FERR_READING;
+			return err;
 		}
 
-		laszip_U8* dataStart = currentPoint.extra_bytes + extraField.byteOffset;
-		parseRawValues(extraField, dataStart);
-		switch (extraField.kind())
+		for (unsigned dimIndex = 0; dimIndex < extraField.numElements(); ++dimIndex)
 		{
-		case LasExtraScalarField::Unsigned:
-			handleOptionsFor(extraField, m_rawValues.unsignedValues);
-			break;
-		case LasExtraScalarField::Signed:
-			handleOptionsFor(extraField, m_rawValues.signedValues);
-			break;
-		case LasExtraScalarField::Floating:
-			handleOptionsFor(extraField, m_rawValues.floatingValues);
-			break;
+			extraField.scalarFields[dimIndex]->addElement(finalValues[dimIndex]);
 		}
 	}
 	return CC_FERR_NO_ERROR;
@@ -380,7 +405,7 @@ void LasScalarFieldLoader::parseRawValues(const LasExtraScalarField& extraField,
 }
 
 template <typename T>
-void LasScalarFieldLoader::handleOptionsFor(const LasExtraScalarField& extraField, T values[3])
+void LasScalarFieldLoader::handleOptionsFor(const LasExtraScalarField& extraField, T inputValues[3], ScalarType outputValues[3])
 {
 	assert(extraField.numElements() <= 3);
 	for (unsigned dimIndex = 0; dimIndex < extraField.numElements(); ++dimIndex)
@@ -388,19 +413,19 @@ void LasScalarFieldLoader::handleOptionsFor(const LasExtraScalarField& extraFiel
 		if (extraField.noDataIsRelevant())
 		{
 			auto noDataValue = ParseValueOfTypeAs<T, T>(static_cast<const uint8_t*>(extraField.noData[dimIndex]));
-			if (noDataValue == values[dimIndex])
+			if (noDataValue == inputValues[dimIndex])
 			{
-				extraField.scalarFields[dimIndex]->addElement(ccScalarField::NaN());
+				outputValues[dimIndex] = ccScalarField::NaN();
 			}
 		}
 		else if (extraField.scaleIsRelevant())
 		{
-			double scaledValue = (values[dimIndex] * extraField.scales[dimIndex]) + (extraField.offsets[dimIndex]);
-			extraField.scalarFields[dimIndex]->addElement(static_cast<ScalarType>(scaledValue));
+			double scaledValue     = (inputValues[dimIndex] * extraField.scales[dimIndex]) + (extraField.offsets[dimIndex]);
+			outputValues[dimIndex] = static_cast<ScalarType>(scaledValue);
 		}
 		else
 		{
-			extraField.scalarFields[dimIndex]->addElement(static_cast<ScalarType>(values[dimIndex]));
+			outputValues[dimIndex] = static_cast<ScalarType>(inputValues[dimIndex]);
 		}
 	}
 }

--- a/plugins/core/IO/qLASIO/src/LasWaveformLoader.cpp
+++ b/plugins/core/IO/qLASIO/src/LasWaveformLoader.cpp
@@ -194,10 +194,10 @@ void LasWaveformLoader::loadWaveform(ccPointCloud& pointCloud, const laszip_poin
 	float    returnPointLocation = 0;
 	float    x_t = 0, y_t = 0, z_t = 0;
 
-	returnPointLocation = ((float *) &currentPoint.wave_packet[13])[0];
-	x_t = ((float *) &currentPoint.wave_packet[17])[0];
-	y_t = ((float *) &currentPoint.wave_packet[21])[0];
-	z_t = ((float *) &currentPoint.wave_packet[25])[0];
+	returnPointLocation = ((float*)&currentPoint.wave_packet[13])[0];
+	x_t                 = ((float*)&currentPoint.wave_packet[17])[0];
+	y_t                 = ((float*)&currentPoint.wave_packet[21])[0];
+	z_t                 = ((float*)&currentPoint.wave_packet[25])[0];
 
 	stream >> descriptorIndex >> byteOffset >> byteCount;
 

--- a/plugins/core/IO/qLASIO/src/LasWaveformSaver.cpp
+++ b/plugins/core/IO/qLASIO/src/LasWaveformSaver.cpp
@@ -47,7 +47,6 @@ void LasWaveformSaver::handlePoint(size_t index, laszip_point& point)
 		array[3] = w.beamDir().z;
 
 		memcpy(&m_array.data()[13], array, 4 * 4);
-
 	}
 
 	memcpy(point.wave_packet, m_array.constData(), 29);

--- a/plugins/core/IO/qLASIO/ui/lasopendialog.ui
+++ b/plugins/core/IO/qLASIO/ui/lasopendialog.ui
@@ -354,6 +354,45 @@
                  <item>
                   <widget class="QListWidget" name="availableExtraScalarFields"/>
                  </item>
+                 <item>
+                  <widget class="QGroupBox" name="loadAsNormalsGroup">
+                   <property name="title">
+                    <string>Load As Normals</string>
+                   </property>
+                   <layout class="QHBoxLayout" name="horizontalLayout_2">
+                    <item>
+                     <widget class="QLabel" name="label_4">
+                      <property name="text">
+                       <string>X:</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QComboBox" name="xNormalComboBox"/>
+                    </item>
+                    <item>
+                     <widget class="QLabel" name="label_2">
+                      <property name="text">
+                       <string>Y:</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QComboBox" name="yNormalComboBox"/>
+                    </item>
+                    <item>
+                     <widget class="QLabel" name="label_7">
+                      <property name="text">
+                       <string>Z:</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QComboBox" name="zNormalComboBox"/>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
                 </layout>
                </widget>
               </widget>

--- a/plugins/core/IO/qLASIO/ui/lassavedialog.ui
+++ b/plugins/core/IO/qLASIO/ui/lassavedialog.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="basicParamTab">
       <attribute name="title">
@@ -289,6 +289,16 @@ font: italic;</string>
            <widget class="QCheckBox" name="rgbCheckBox">
             <property name="text">
              <string>RGB</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="normalsCheckBox">
+            <property name="toolTip">
+             <string>Saves normals as extra scalar field using the names &quot;NormalX&quot;, &quot;NormalY&quot; and &quot;NormalZ&quot;.</string>
+            </property>
+            <property name="text">
+             <string>Normals (As Extra Scalarfield)</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
This adds:

- When saving, a checkbox that allows user to save normals (if the point cloud has them) as extra scalar field. We use PDAL convention: names are "NormalX", "NormalY", "NormalZ", and double as the datatype.

- When loading, we allow to select which extra scalar field should be loaded into normals. We auto select the ones with names "NormalX", "NormalY", "NormalZ".

![Capture](https://github.com/CloudCompare/CloudCompare/assets/15125341/59517734-5108-4885-b3d6-5b79ca08339c)
![24-09-23-202459](https://github.com/CloudCompare/CloudCompare/assets/15125341/0f74d464-8df7-458b-a3d3-4793c79b60d8)
