### PR TITLE
LasSaveDialog fix initial state of normals check box

### DIFF
--- a/plugins/core/IO/qLASIO/src/LasSaveDialog.cpp
+++ b/plugins/core/IO/qLASIO/src/LasSaveDialog.cpp
@@ -165,7 +165,7 @@ LasSaveDialog::LasSaveDialog(ccPointCloud* cloud, QWidget* parent)
 	connect(addExtraScalarFieldButton, &QPushButton::clicked, this, &LasSaveDialog::addExtraScalarFieldCard);
 
 	normalsCheckBox->setEnabled(cloud->hasNormals());
-	normalsCheckBox->setCheckState(Qt::CheckState::Checked);
+	normalsCheckBox->setCheckState(cloud->hasNormals() ? Qt::CheckState::Checked:Qt::Unchecked);
 }
 
 /// When the selected version changes, we need to update the combo box

--- a/plugins/core/IO/qLASIO/src/LasSaver.cpp
+++ b/plugins/core/IO/qLASIO/src/LasSaver.cpp
@@ -19,7 +19,7 @@ LasSaver::LasSaver(ccPointCloud& cloud, Parameters parameters)
 	// restore the project UUID (if any)
 	LasMetadata::LoadProjectUUID(cloud, m_laszipHeader);
 
-	if (parameters.shouldSaveNormalsAsExtraScalarField)
+	if (parameters.shouldSaveNormalsAsExtraScalarField && cloud.hasNormals())
 	{
 		// We export normals to extra scalar fields,
 		// the easiest way to integrate that into the LasScalarFieldSaver system


### PR DESCRIPTION
The checkbox was initialized to checked even when the cloud had no normals, leading to the saver trying to save non existant normals

Fixes #1887 