### PR TITLE
Create a Command Line command RENAME_CLOUDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ v2.13.alpha (???) - (??/??/????)
 		- DEBUG
 			- display various information to help one debug and tweak the command line
 			- can be placed at difference positions
+		- RENAME_ENTITIES {base name}
+			- rename all loaded entities (clouds or meshes) with the provided base name.
+				A numerical suffix is added if multiple entities are loaded.
 
 	- New display feature: near and far clipping planes in 3D views
 		- extension of the previously existing feature to set a near clipping plane

--- a/qCC/ccCommandLineCommands.h
+++ b/qCC/ccCommandLineCommands.h
@@ -425,9 +425,10 @@ struct CommandColorInterpolation : public ccCommandLineInterface::Command
 
 	bool process(ccCommandLineInterface& cmd) override;
 };
-struct CommandCloudRename : public ccCommandLineInterface::Command
+
+struct CommandRenameEntities : public ccCommandLineInterface::Command
 {
-	CommandCloudRename();
+	CommandRenameEntities();
 
 	bool process(ccCommandLineInterface& cmd) override;
 };

--- a/qCC/ccCommandLineCommands.h
+++ b/qCC/ccCommandLineCommands.h
@@ -425,6 +425,12 @@ struct CommandColorInterpolation : public ccCommandLineInterface::Command
 
 	bool process(ccCommandLineInterface& cmd) override;
 };
+struct CommandCloudRename : public ccCommandLineInterface::Command
+{
+	CommandCloudRename();
+
+	bool process(ccCommandLineInterface& cmd) override;
+};
 
 struct CommandSFRename : public ccCommandLineInterface::Command
 {

--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -733,6 +733,7 @@ void ccCommandLineParser::registerBuiltInCommands()
     registerCommand(Command::Shared(new CommandSFOperationSF));
     registerCommand(Command::Shared(new CommandSFInterpolation));
     registerCommand(Command::Shared(new CommandColorInterpolation));
+	registerCommand(Command::Shared(new CommandCloudRename));
 	registerCommand(Command::Shared(new CommandSFRename));
 	registerCommand(Command::Shared(new CommandSFAddConst));
 	registerCommand(Command::Shared(new CommandSFAddId));

--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -733,7 +733,7 @@ void ccCommandLineParser::registerBuiltInCommands()
     registerCommand(Command::Shared(new CommandSFOperationSF));
     registerCommand(Command::Shared(new CommandSFInterpolation));
     registerCommand(Command::Shared(new CommandColorInterpolation));
-	registerCommand(Command::Shared(new CommandCloudRename));
+	registerCommand(Command::Shared(new CommandRenameEntities));
 	registerCommand(Command::Shared(new CommandSFRename));
 	registerCommand(Command::Shared(new CommandSFAddConst));
 	registerCommand(Command::Shared(new CommandSFAddId));


### PR DESCRIPTION
RENAME_CLOUDS "new_name", command will rename clouds and meshes, to "new_name" and if there are multiple entities then it gives an increasing suffix padded to 3 digit. cc forum reference https://www.danielgm.net/cc/forum/viewtopic.php?f=14&t=6697&sid=545a7ceae939eb9fb09d6115f195c8b1&p=28692#p28692

It will produce a log something like this.
```
[RENAME CLOUDS]
Cloud 'pointcloud1 - Cloud' renamed to 'newBaseName-001'
Mesh 'Mesh' renamed to 'newBaseName-002'
Mesh 'Mesh' renamed to 'newBaseName-003'
```

if the name contains invalid chars it will thrown an error, and exit.
```
[RENAME CLOUDS]
Name cannot contain any of these characters: :/\*?"\|<>
```