### PR TITLE
CLI command -COMMAND_FILE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,14 @@ v2.13.alpha (???) - (??/??/????)
 		- RENAME_ENTITIES {base name}
 			- rename all loaded entities (clouds or meshes) with the provided base name.
 				A numerical suffix is added if multiple entities are loaded.
+		- COMMAND_FILE {file}
+			- loads commands from file
+				multiple line allowed
+				multiple arguments in each line allowed
+				handle quoted arguments
+				commands after this will run after every commands finished in the file
 
+		
 	- New display feature: near and far clipping planes in 3D views
 		- extension of the previously existing feature to set a near clipping plane
 		- can be enabled and modifed in the Camera Parameters dialog or via

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -614,7 +614,7 @@ bool CommandLoadCommandFile::process(ccCommandLineInterface& cmd)
 		{
 			QString line = in.readLine();
 			QStringList argumentsInLine = line.split(" ");
-			QStringList processedArguments;
+			QStringList processedArgs;
 
 			// 'massage' the arguments to handle single/double quotes
 			//TODO handle escaped quotes/spaces
@@ -635,7 +635,7 @@ bool CommandLoadCommandFile::process(ccCommandLineInterface& cmd)
 						{
 							if (arg.endsWith(SingleQuote))
 							{
-								arg=arg.replace(SingleQuote,"");
+								arg.remove(SingleQuote);
 								// nothing to do, non*truncated argument
 							}
 							else
@@ -652,7 +652,7 @@ bool CommandLoadCommandFile::process(ccCommandLineInterface& cmd)
 							{
 								insideSingleQuoteSection = false;
 								arg = buffer.left(buffer.length() - 1); // remove the single quote
-								arg.replace(SingleQuote, "");
+								arg.remove(SingleQuote);
 							}
 						}
 					}
@@ -663,7 +663,7 @@ bool CommandLoadCommandFile::process(ccCommandLineInterface& cmd)
 						{
 							if (arg.endsWith(DoubleQuote))
 							{
-								arg = arg.replace(DoubleQuote, "");
+								arg.remove(DoubleQuote);
 								// nothing to do, non*truncated argument
 							}
 							else
@@ -680,13 +680,13 @@ bool CommandLoadCommandFile::process(ccCommandLineInterface& cmd)
 							{
 								insideDoubleQuoteSection = false;
 								arg = buffer.left(buffer.length() - 1); // remove the double quote
-								arg.replace(DoubleQuote, "");
+								arg.remove(DoubleQuote);
 							}
 						}
 					}
 					if (!insideSingleQuoteSection && !insideDoubleQuoteSection)
 					{
-						processedArguments.append(arg);
+						processedArgs.append(arg);
 					}
 				}
 				if (insideSingleQuoteSection||insideDoubleQuoteSection)
@@ -694,14 +694,14 @@ bool CommandLoadCommandFile::process(ccCommandLineInterface& cmd)
 					// the single/double quote section was not closed...
 					cmd.warning("Probably malformed command (missing closing quote)");
 					// ...still, we'll try to proceed
-					processedArguments.append(buffer);
+					processedArgs.append(buffer);
 				}
 			}
 
 			//inject back all the arguments to the cmd.arguments()
-			while (!processedArguments.isEmpty()) {
-				QString processedArg = processedArguments.takeFirst();
-				if (processedArg != "") {
+			while (!processedArgs.isEmpty()) {
+				QString processedArg = processedArgs.takeFirst();
+				if (!processedArg.isEmpty()) {
 					cmd.print(QObject::tr("\t[%1] %2").arg(insertingIndex).arg(processedArg));
 					cmd.arguments().insert(insertingIndex, processedArg);
 					insertingIndex++;

--- a/qCC/ccCommandLineCommands.h
+++ b/qCC/ccCommandLineCommands.h
@@ -41,6 +41,13 @@ struct CommandLoad : public ccCommandLineInterface::Command
 	bool process(ccCommandLineInterface& cmd) override;
 };
 
+struct CommandLoadCommandFile : public ccCommandLineInterface::Command
+{
+	CommandLoadCommandFile();
+
+	bool process(ccCommandLineInterface& cmd) override;
+};
+
 struct CommandClearNormals : public ccCommandLineInterface::Command
 {
 	CommandClearNormals();

--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -689,6 +689,7 @@ void ccCommandLineParser::registerBuiltInCommands()
 {
 	registerCommand(Command::Shared(new CommandDebugCmdLine));
 	registerCommand(Command::Shared(new CommandLoad));
+	registerCommand(Command::Shared(new CommandLoadCommandFile));
 	registerCommand(Command::Shared(new CommandSubsample));
 	registerCommand(Command::Shared(new CommandExtractCCs));
 	registerCommand(Command::Shared(new CommandCurvature));


### PR DESCRIPTION
As said in the commit:

Forum: https://www.cloudcompare.org/forum/viewtopic.php?f=14&t=6708&p=28710#p28710

CLI command

-COMMAND_FILE {file}

-File can contain multiple lines
-Lines can contain multiple arguments
-spaces should be quoted with single or double quotes
-commands after this will run after every commands finished in the file
-escaped spaces or quotes are not supported

I'v tested it with different edge cases. Produces a simple log to the output

file contents
```
-O 'C:\Users\...\Documents\pointcloud1.txt'
-RENAME_ENTITIES asdfas
-O 
-SKIP
2 
-GLOBAL_SHIFT 1 1 1
"C:\Users\...\Documents\poi' ntc  loud2.txt"
```

```
./cloudcompare.exe -SILENT -COMMAND_FILE "C:\Users\...\Documents\list_of_files.txt" -RENAME_ENTITIES "LAST"
...
[LOADING COMMANDS FROM FILE]
        [0] -O
        [1] C:\Users\...\Documents\pointcloud1.txt
        [2] -RENAME_ENTITIES
        [3] asdfas
        [4] -O
        [5] -SKIP
        [6] 2
        [7] -GLOBAL_SHIFT
        [8] 1
        [9] 1
        [10] 1
        [11] C:\Users\...\Documents\poi' ntc  loud2.txt
[LOADING]
Opening file: 'C:\Users\...\Documents\pointcloud1.txt'
[I/O] File 'C:\Users\...\Documents\pointcloud1.txt' loaded successfully
Found one cloud with 6 points
[RENAME ENTITIES]
Cloud 'pointcloud1 - Cloud' renamed to 'asdfas'
[LOADING]
Will skip 2 lines
Opening file: 'C:\Users\...\Documents\poi' ntc  loud2.txt'
[ASCIIFilter::loadFile] Cloud has been recentered! Translation: (1.00 ; 1.00 ; 1.00)
[I/O] File 'C:\Users\...\Documents\poi' ntc  loud2.txt' loaded successfully
Found one cloud with 6 points
[RENAME ENTITIES]
Cloud 'asdfas' renamed to 'LAST-001'
Cloud 'poi' ntc  loud2 - Cloud' renamed to 'LAST-002'
Processed finished in 0.15 s.
```