### PR TITLE
Implement SET_GLOBAL_SHIFT cli command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ v2.13.alpha (???) - (??/??/????)
 				multiple arguments in each line allowed
 				handle quoted arguments
 				commands after this one will run after all commands in the file have been processed
+		- SET_GLOBAL_SHIFT -KEEP_ORIGIN {TRUE/FALSE} {x} {y} {z}
+			- set global shift on all entities, if KEEP_ORIGIN set to TRUE then apply transformation to keep it in the same place. (it will warn if coordinate transformation is too big.)
+			- KEEP_ORIGIN is optional, default value is FALSE
 		
 	- New display feature: near and far clipping planes in 3D views
 		- extension of the previously existing feature to set a near clipping plane

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,9 @@ v2.13.alpha (???) - (??/??/????)
 				multiple arguments in each line allowed
 				handle quoted arguments
 				commands after this one will run after all commands in the file have been processed
-		- SET_GLOBAL_SHIFT -KEEP_ORIGIN {TRUE/FALSE} {x} {y} {z}
-			- set global shift on all entities, if KEEP_ORIGIN set to TRUE then apply transformation to keep it in the same place. (it will warn if coordinate transformation is too big.)
-			- KEEP_ORIGIN is optional, default value is FALSE
+		- SET_GLOBAL_SHIFT {x} {y} {z} -KEEP_ORIG_FIXED
+			- set global shift on all entities, if -KEEP_ORIG_FIXED set then apply transformation to keep it in the same place. (it will warn if coordinate transformation is too big.)
+			- KEEP_ORIG_FIXED is optional, default value is FALSE
 		
 	- New display feature: near and far clipping planes in 3D views
 		- extension of the previously existing feature to set a near clipping plane

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,8 @@ v2.13.alpha (???) - (??/??/????)
 				handle quoted arguments
 				commands after this one will run after all commands in the file have been processed
 		- SET_GLOBAL_SHIFT {x} {y} {z} -KEEP_ORIG_FIXED
-			- set global shift on all entities, if -KEEP_ORIG_FIXED set then apply transformation to keep it in the same place. (it will warn if coordinate transformation is too big.)
-			- KEEP_ORIG_FIXED is optional, default value is FALSE
+			- set global shift on all entities
+			- sub-option -KEEP_ORIG_FIXED: if set, global origin will be preserved (a warning might be issued if the resulting coordinate transformation is too big)
 		
 	- New display feature: near and far clipping planes in 3D views
 		- extension of the previously existing feature to set a near clipping plane

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -2726,7 +2726,8 @@ bool CommandSetGlobalShift::process(ccCommandLineInterface& cmd)
 			keepOrigFixed = true;
 			cmd.print(QObject::tr("[%1]").arg(COMMAND_SET_GLOBAL_SHIFT_KEEP_ORIG_FIXED));
 		}
-		else {
+		else
+		{
 			break;
 		}
 	}
@@ -2763,7 +2764,7 @@ bool CommandSetGlobalShift::process(ccCommandLineInterface& cmd)
 	//process both clouds and meshes
 	for (size_t i = 0; i < nrOfEntities; i++)
 	{
-		QPair<ccShiftedObject*, CLEntityDesc*> entity=entities[i];
+		QPair<ccShiftedObject*, CLEntityDesc*> entity = entities[i];
 		CLEntityDesc& desc = *entity.second;
 		ccShiftedObject* shiftedObject = entity.first;
 		CCVector3d originalShift = shiftedObject->getGlobalShift();
@@ -2774,7 +2775,7 @@ bool CommandSetGlobalShift::process(ccCommandLineInterface& cmd)
 			.arg(desc.basename)
 			.arg(shiftedObject->getName()));
 
-		//translate entity to keep the same origin
+		//translate entity to keep the initial global origin
 		if (keepOrigFixed)
 		{
 			CCVector3d T = newShift - originalShift;
@@ -2782,7 +2783,7 @@ bool CommandSetGlobalShift::process(ccCommandLineInterface& cmd)
 			double maxCoordValue = ccGlobalShiftManager::MaxCoordinateAbsValue();
 			if (T.x > maxCoordValue || T.y > maxCoordValue || T.z > maxCoordValue)
 			{
-				cmd.warning(QObject::tr("\t[%5 - %6] Applied transformation is bigger {%1,%2,%3} than the threshold {%4}, precision loss may occure.")
+				cmd.warning(QObject::tr("\t[%5 - %6] Applied transformation is bigger {%1,%2,%3} than the threshold {%4}, precision loss may occur.")
 					.arg(T.x)
 					.arg(T.y)
 					.arg(T.z)
@@ -2821,8 +2822,6 @@ bool CommandSetGlobalShift::process(ccCommandLineInterface& cmd)
 		{
 			//set the mesh name instead of the vertices cloud inside the mesh
 			ccHObject* parent = shiftedObject->getParent();
-
-			//do i really need this check? all the mesh vertices cloud should have a parent...
 			if (parent)
 			{
 				parent->setName(QObject::tr("%1%2").arg(parent->getName()).arg(nameSuffix));

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -72,7 +72,7 @@ constexpr char COMMAND_MERGE_CLOUDS[]					= "MERGE_CLOUDS";
 constexpr char COMMAND_MERGE_MESHES[]                   = "MERGE_MESHES";
 constexpr char COMMAND_SET_ACTIVE_SF[]					= "SET_ACTIVE_SF";
 constexpr char COMMAND_SET_GLOBAL_SHIFT[]				= "SET_GLOBAL_SHIFT"; // + global shift {x,y,z}
-constexpr char COMMAND_SET_GLOBAL_SHIFT_KEEP_ORIGIN[]	= "KEEP_ORIGIN";
+constexpr char COMMAND_SET_GLOBAL_SHIFT_KEEP_ORIG_FIXED[]= "KEEP_ORIG_FIXED";
 constexpr char COMMAND_REMOVE_ALL_SFS[]					= "REMOVE_ALL_SFS";
 constexpr char COMMAND_REMOVE_SF[]						= "REMOVE_SF";
 constexpr char COMMAND_REMOVE_SCAN_GRIDS[]				= "REMOVE_SCAN_GRIDS";
@@ -2702,154 +2702,138 @@ bool CommandSetGlobalShift::process(ccCommandLineInterface& cmd)
 	{
 		return cmd.error(QObject::tr("No loaded entity! (be sure to open one with \"-%1 [filename]\" before \"-%2\")").arg(COMMAND_OPEN, COMMAND_SET_GLOBAL_SHIFT));
 	}
+
+	//process globalshift options first
 	ccCommandLineInterface::GlobalShiftOptions globalShiftOptions;
-
-	//handle keepOrigin command option
-	bool keepOrigin = false;
-	if (!cmd.arguments().empty() && ccCommandLineInterface::IsCommand(cmd.arguments().front(), COMMAND_SET_GLOBAL_SHIFT_KEEP_ORIGIN)) {
-
-		//local option confirmed, pop that from front
-		cmd.arguments().pop_front();
-
-		QString	keepOriginStr = cmd.arguments().takeFirst();
-		if (keepOriginStr == "TRUE")
-		{
-			keepOrigin = true;
-		}
-		else if (keepOriginStr != "FALSE")
-		{
-			return cmd.error(QObject::tr("Invalid boolean value after \"-%1\". Got '%2' instead of TRUE or FALSE.").arg(COMMAND_SET_GLOBAL_SHIFT_KEEP_ORIGIN, keepOriginStr));
-		}
-		if (keepOrigin) {
-			cmd.print("Current origin will be preserved.");
-		}
-	}
-
 	cmd.processGlobalShiftCommand(globalShiftOptions);
-	if (globalShiftOptions.mode != ccCommandLineInterface::GlobalShiftOptions::Mode::CUSTOM_GLOBAL_SHIFT) {
-		return cmd.error(QObject::tr("Global shift must be in the form of three coordinate 'x y z'."));
+	//if it is not a valid global shift then an error msg already issued.
+	if (globalShiftOptions.mode != ccCommandLineInterface::GlobalShiftOptions::Mode::CUSTOM_GLOBAL_SHIFT)
+	{
+		return cmd.error(QObject::tr("Global shift must be in the form of three coordinates 'x' 'y' 'z'"));
 	}
 	CCVector3d newShift = globalShiftOptions.customGlobalShift;
 
-	//process clouds
-	for (CLCloudDesc& desc : cmd.clouds())
+	//look for additional parameters
+	bool keepOrigFixed = false;
+	while (!cmd.arguments().empty())
 	{
-		CCVector3d originalShift = desc.pc->getGlobalShift();
+		QString argument = cmd.arguments().front();
+		if (ccCommandLineInterface::IsCommand(argument, COMMAND_SET_GLOBAL_SHIFT_KEEP_ORIG_FIXED))
+		{
+			//local option confirmed, pop that from front
+			cmd.arguments().pop_front();
+
+			keepOrigFixed = true;
+			cmd.print(QObject::tr("[%1]").arg(COMMAND_SET_GLOBAL_SHIFT_KEEP_ORIG_FIXED));
+		}
+		else {
+			break;
+		}
+	}
+
+	//create an entity vector
+	size_t nrOfClouds = cmd.clouds().size();
+	size_t nrOfMeshes = cmd.meshes().size();
+	size_t nrOfEntities = nrOfClouds + nrOfMeshes;
+	QVector<QPair<ccShiftedObject*, CLEntityDesc*>> entities;
+
+	//add clouds to the vector
+	for (size_t i = 0; i < nrOfClouds; i++)
+	{
+		QPair<ccShiftedObject*, CLEntityDesc*> entity;
+		entity.first = cmd.clouds()[i].pc;
+		entity.second = &cmd.clouds()[i];
+		entities.append(entity);
+	}
+
+	//add meshes to the vector
+	for (size_t i = 0; i < nrOfMeshes; i++)
+	{
+		QPair<ccShiftedObject*, CLEntityDesc*> entity;
+		bool isLocked = false;
+		ccShiftedObject* shifted = ccHObjectCaster::ToShifted(cmd.meshes()[i].mesh, &isLocked);
+		if (shifted && !isLocked)
+		{
+			entity.first = shifted;
+			entity.second = &cmd.meshes()[i];
+			entities.append(entity);
+		}
+	}
+
+	//process both clouds and meshes
+	for (size_t i = 0; i < nrOfEntities; i++)
+	{
+		QPair<ccShiftedObject*, CLEntityDesc*> entity=entities[i];
+		CLEntityDesc& desc = *entity.second;
+		ccShiftedObject* shiftedObject = entity.first;
+		CCVector3d originalShift = shiftedObject->getGlobalShift();
 		cmd.print(QObject::tr("\t[%4 - %5] Original global shift {%1,%2,%3}")
 			.arg(originalShift.x)
 			.arg(originalShift.y)
 			.arg(originalShift.z)
 			.arg(desc.basename)
-			.arg(desc.pc->getName()));
+			.arg(shiftedObject->getName()));
 
-		if (keepOrigin) {
-			//translate cloud to keep the same origin
+		//translate entity to keep the same origin
+		if (keepOrigFixed)
+		{
 			CCVector3d T = newShift - originalShift;
 			ccGLMatrix transMat;
 			double maxCoordValue = ccGlobalShiftManager::MaxCoordinateAbsValue();
-			if ( T.x > maxCoordValue || T.y > maxCoordValue || T.z > maxCoordValue)
+			if (T.x > maxCoordValue || T.y > maxCoordValue || T.z > maxCoordValue)
 			{
-				cmd.warning(QObject::tr("\t[%5 - %6] Applied transformation is bigger {%1,%2,%3} then the treshold {%4}, precision loss could occured.")
+				cmd.warning(QObject::tr("\t[%5 - %6] Applied transformation is bigger {%1,%2,%3} than the threshold {%4}, precision loss may occure.")
 					.arg(T.x)
 					.arg(T.y)
 					.arg(T.z)
 					.arg(maxCoordValue)
 					.arg(desc.basename)
-					.arg(desc.pc->getName()));
+					.arg(shiftedObject->getName()));
 			}
+
 			cmd.print(QObject::tr("\t[%4 - %5] Applied Transformation {%1,%2,%3}")
 				.arg(T.x)
 				.arg(T.y)
 				.arg(T.z)
 				.arg(desc.basename)
-				.arg(desc.pc->getName()));
+				.arg(shiftedObject->getName()));
 			transMat.toIdentity();
 			transMat.setTranslation(T);
-			desc.pc->applyGLTransformation_recursive(&transMat);
+			shiftedObject->applyGLTransformation_recursive(&transMat);
 		}
-		desc.pc->setGlobalShift(newShift.x, newShift.y, newShift.z);
+
+		//apply new global shift
+		shiftedObject->setGlobalShift(newShift.x, newShift.y, newShift.z);
 		cmd.print(QObject::tr("\t[%4 - %5] Global shift set to {%1,%2,%3}")
 			.arg(newShift.x)
 			.arg(newShift.y)
 			.arg(newShift.z)
 			.arg(desc.basename)
-			.arg(desc.pc->getName()));
-		QString nameExtension = QObject::tr("_SHIFTED_FROM_%1_%2_%3_TO_%4_%5_%6")
+			.arg(shiftedObject->getName()));
+		QString nameSuffix = QObject::tr("_SHIFTED_FROM_%1_%2_%3_TO_%4_%5_%6")
 			.arg(originalShift.x)
 			.arg(originalShift.y)
 			.arg(originalShift.z)
 			.arg(newShift.x)
 			.arg(newShift.y)
 			.arg(newShift.z);
-		desc.pc->setName(QObject::tr("%1%2").arg(desc.pc->getName()).arg(nameExtension));
-		desc.basename += nameExtension;
-		//save it as well
-		if (cmd.autoSaveMode())
+		if ((&desc)->getCLEntityType() == CL_ENTITY_TYPE::MESH)
 		{
-			QString errorStr = cmd.exportEntity(desc);
-			if (!errorStr.isEmpty())
+			//set the mesh name instead of the vertices cloud inside the mesh
+			ccHObject* parent = shiftedObject->getParent();
+
+			//do i really need this check? all the mesh vertices cloud should have a parent...
+			if (parent)
 			{
-				return cmd.error(errorStr);
+				parent->setName(QObject::tr("%1%2").arg(parent->getName()).arg(nameSuffix));
 			}
 		}
-	}
-
-	for (CLMeshDesc& desc : cmd.meshes())
-	{
-		bool isLocked = false;
-		ccShiftedObject* shifted = ccHObjectCaster::ToShifted(desc.mesh, &isLocked);
-		if (shifted && !isLocked)
+		else
 		{
-			CCVector3d originalShift = shifted->getGlobalShift();
-			cmd.print(QObject::tr("\t[%4 - %5] Original global shift {%1,%2,%3}")
-				.arg(originalShift.x)
-				.arg(originalShift.y)
-				.arg(originalShift.z)
-				.arg(desc.basename)
-				.arg(desc.mesh->getName()));
-
-			if (keepOrigin) {
-				//translate shifted mesh object to keep the same origin
-				CCVector3d T = newShift - originalShift;
-				ccGLMatrix transMat;
-				double maxCoordValue = ccGlobalShiftManager::MaxCoordinateAbsValue();
-				if (T.x > maxCoordValue || T.y > maxCoordValue || T.z > maxCoordValue)
-				{
-					cmd.warning(QObject::tr("\t[%5 - %6] Applied transformation is bigger {%1,%2,%3} then the treshold {%4}, precision loss could occured.")
-						.arg(T.x)
-						.arg(T.y)
-						.arg(T.z)
-						.arg(maxCoordValue)
-						.arg(desc.basename)
-						.arg(desc.mesh->getName()));
-				}
-				cmd.print(QObject::tr("\t[%4 - %5] Applied Transformation {%1,%2,%3}")
-					.arg(T.x)
-					.arg(T.y)
-					.arg(T.z)
-					.arg(desc.basename)
-					.arg(desc.mesh->getName()));
-				transMat.toIdentity();
-				transMat.setTranslation(T);
-				shifted->applyGLTransformation_recursive(&transMat);
-			}
-			shifted->setGlobalShift(newShift.x, newShift.y, newShift.z);
-			cmd.print(QObject::tr("\t[%4 - %5] Global shift set to {%1,%2,%3}")
-				.arg(newShift.x)
-				.arg(newShift.y)
-				.arg(newShift.z)
-				.arg(desc.basename)
-				.arg(desc.mesh->getName()));
-			QString nameExtension = QObject::tr("_SHIFTED_FROM_%1_%2_%3_TO_%4_%5_%6")
-				.arg(originalShift.x)
-				.arg(originalShift.y)
-				.arg(originalShift.z)
-				.arg(newShift.x)
-				.arg(newShift.y)
-				.arg(newShift.z);
-			desc.mesh->setName(QObject::tr("%1%2").arg(desc.mesh->getName()).arg(nameExtension));
-			desc.basename += nameExtension;
+			shiftedObject->setName(QObject::tr("%1%2").arg(shiftedObject->getName()).arg(nameSuffix));
 		}
+		desc.basename += nameSuffix;
+
 		//save it as well
 		if (cmd.autoSaveMode())
 		{

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -71,6 +71,8 @@ constexpr char COMMAND_FILTER_SF_BY_VALUE[]				= "FILTER_SF";
 constexpr char COMMAND_MERGE_CLOUDS[]					= "MERGE_CLOUDS";
 constexpr char COMMAND_MERGE_MESHES[]                   = "MERGE_MESHES";
 constexpr char COMMAND_SET_ACTIVE_SF[]					= "SET_ACTIVE_SF";
+constexpr char COMMAND_SET_GLOBAL_SHIFT[]				= "SET_GLOBAL_SHIFT"; // + global shift {x,y,z}
+constexpr char COMMAND_SET_GLOBAL_SHIFT_KEEP_ORIGIN[]	= "KEEP_ORIGIN";
 constexpr char COMMAND_REMOVE_ALL_SFS[]					= "REMOVE_ALL_SFS";
 constexpr char COMMAND_REMOVE_SF[]						= "REMOVE_SF";
 constexpr char COMMAND_REMOVE_SCAN_GRIDS[]				= "REMOVE_SCAN_GRIDS";
@@ -2688,6 +2690,144 @@ bool CommandMergeClouds::process(ccCommandLineInterface& cmd)
 	return true;
 }
 
+CommandSetGlobalShift::CommandSetGlobalShift()
+	: ccCommandLineInterface::Command(QObject::tr("Set active SF"), COMMAND_SET_GLOBAL_SHIFT)
+{}
+
+bool CommandSetGlobalShift::process(ccCommandLineInterface& cmd)
+{
+	cmd.print(QObject::tr("[SET GLOBAL SHIFT]"));
+
+	if (cmd.clouds().empty() && cmd.meshes().empty())
+	{
+		return cmd.error(QObject::tr("No loaded entity! (be sure to open one with \"-%1 [filename]\" before \"-%2\")").arg(COMMAND_OPEN, COMMAND_SET_GLOBAL_SHIFT));
+	}
+	ccCommandLineInterface::GlobalShiftOptions globalShiftOptions;
+
+	//handle keepOrigin command option
+	bool keepOrigin = false;
+	if (!cmd.arguments().empty() && ccCommandLineInterface::IsCommand(cmd.arguments().front(), COMMAND_SET_GLOBAL_SHIFT_KEEP_ORIGIN)) {
+
+		//local option confirmed, pop that from front
+		cmd.arguments().pop_front();
+
+		QString	keepOriginStr = cmd.arguments().takeFirst();
+		if (keepOriginStr == "TRUE")
+		{
+			keepOrigin = true;
+		}
+		else if (keepOriginStr != "FALSE")
+		{
+			return cmd.error(QObject::tr("Invalid boolean value after \"-%1\". Got '%2' instead of TRUE or FALSE.").arg(COMMAND_SET_GLOBAL_SHIFT_KEEP_ORIGIN, keepOriginStr));
+		}
+		if (keepOrigin) {
+			cmd.print("Current origin will be preserved.");
+		}
+	}
+
+	cmd.processGlobalShiftCommand(globalShiftOptions);
+	if (globalShiftOptions.mode != ccCommandLineInterface::GlobalShiftOptions::Mode::CUSTOM_GLOBAL_SHIFT) {
+		return cmd.error(QObject::tr("Global shift must be in the form of three coordinate 'x y z'."));
+	}
+	CCVector3d newShift = globalShiftOptions.customGlobalShift;
+
+	//process clouds
+	for (const CLCloudDesc& desc : cmd.clouds())
+	{
+		CCVector3d originalShift = desc.pc->getGlobalShift();
+		cmd.print(QObject::tr("\t[%4 - %5] Original global shift {%1,%2,%3}")
+			.arg(originalShift.x)
+			.arg(originalShift.y)
+			.arg(originalShift.z)
+			.arg(desc.basename)
+			.arg(desc.pc->getName()));
+
+		if (keepOrigin) {
+			//translate cloud to keep the same origin
+			CCVector3d T = newShift - originalShift;
+			ccGLMatrix transMat;
+			double maxCoordValue = ccGlobalShiftManager::MaxCoordinateAbsValue();
+			if ( T.x > maxCoordValue || T.y > maxCoordValue || T.z > maxCoordValue)
+			{
+				cmd.warning(QObject::tr("\t[%5 - %6] Applied transformation is bigger {%1,%2,%3} then the treshold {%4}, precision loss could occured.")
+					.arg(T.x)
+					.arg(T.y)
+					.arg(T.z)
+					.arg(maxCoordValue)
+					.arg(desc.basename)
+					.arg(desc.pc->getName()));
+			}
+			cmd.print(QObject::tr("\t[%4 - %5] Applied Transformation {%1,%2,%3}")
+				.arg(T.x)
+				.arg(T.y)
+				.arg(T.z)
+				.arg(desc.basename)
+				.arg(desc.pc->getName()));
+			transMat.toIdentity();
+			transMat.setTranslation(T);
+			desc.pc->applyGLTransformation_recursive(&transMat);
+		}
+		desc.pc->setGlobalShift(newShift.x, newShift.y, newShift.z);
+		cmd.print(QObject::tr("\t[%4 - %5] Global shift set to {%1,%2,%3}")
+			.arg(newShift.x)
+			.arg(newShift.y)
+			.arg(newShift.z)
+			.arg(desc.basename)
+			.arg(desc.pc->getName()));
+	}
+
+	for (const CLMeshDesc& desc : cmd.meshes())
+	{
+		bool isLocked = false;
+		ccShiftedObject* shifted = ccHObjectCaster::ToShifted(desc.mesh, &isLocked);
+		if (shifted && !isLocked)
+		{
+			CCVector3d originalShift = shifted->getGlobalShift();
+			cmd.print(QObject::tr("\t[%4 - %5] Original global shift {%1,%2,%3}")
+				.arg(originalShift.x)
+				.arg(originalShift.y)
+				.arg(originalShift.z)
+				.arg(desc.basename)
+				.arg(desc.mesh->getName()));
+
+			if (keepOrigin) {
+				//translate shifted mesh object to keep the same origin
+				CCVector3d T = newShift - originalShift;
+				ccGLMatrix transMat;
+				double maxCoordValue = ccGlobalShiftManager::MaxCoordinateAbsValue();
+				if (T.x > maxCoordValue || T.y > maxCoordValue || T.z > maxCoordValue)
+				{
+					cmd.warning(QObject::tr("\t[%5 - %6] Applied transformation is bigger {%1,%2,%3} then the treshold {%4}, precision loss could occured.")
+						.arg(T.x)
+						.arg(T.y)
+						.arg(T.z)
+						.arg(maxCoordValue)
+						.arg(desc.basename)
+						.arg(desc.mesh->getName()));
+				}
+				cmd.print(QObject::tr("\t[%4 - %5] Applied Transformation {%1,%2,%3}")
+					.arg(T.x)
+					.arg(T.y)
+					.arg(T.z)
+					.arg(desc.basename)
+					.arg(desc.mesh->getName()));
+				transMat.toIdentity();
+				transMat.setTranslation(T);
+				shifted->applyGLTransformation_recursive(&transMat);
+			}
+			shifted->setGlobalShift(newShift.x, newShift.y, newShift.z);
+			cmd.print(QObject::tr("\t[%4 - %5] Global shift set to {%1,%2,%3}")
+				.arg(newShift.x)
+				.arg(newShift.y)
+				.arg(newShift.z)
+				.arg(desc.basename)
+				.arg(desc.mesh->getName()));
+		}
+	}
+
+	return true;
+}
+
 CommandSetActiveSF::CommandSetActiveSF()
 	: ccCommandLineInterface::Command(QObject::tr("Set active SF"), COMMAND_SET_ACTIVE_SF)
 {}
@@ -2698,16 +2838,16 @@ bool CommandSetActiveSF::process(ccCommandLineInterface& cmd)
 	{
 		return cmd.error(QObject::tr("Missing parameter: scalar field index after \"-%1\"").arg(COMMAND_SET_ACTIVE_SF));
 	}
-	
+
 	int sfIndex = -1;
 	QString sfName;
 	GetSFIndexOrName(cmd, sfIndex, sfName);
-	
+
 	if (cmd.clouds().empty() && cmd.meshes().empty())
 	{
 		return cmd.error(QObject::tr("No point cloud nor mesh loaded! (be sure to open one with \"-%1 [cloud filename]\" before \"-%2\")").arg(COMMAND_OPEN, COMMAND_SET_ACTIVE_SF));
 	}
-	
+
 	for (CLCloudDesc& desc : cmd.clouds())
 	{
 		if (desc.pc)
@@ -2719,7 +2859,7 @@ bool CommandSetActiveSF::process(ccCommandLineInterface& cmd)
 			}
 		}
 	}
-	
+
 	for (CLMeshDesc& desc : cmd.meshes())
 	{
 		ccPointCloud* pc = ccHObjectCaster::ToPointCloud(desc.mesh);

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -2732,7 +2732,7 @@ bool CommandSetGlobalShift::process(ccCommandLineInterface& cmd)
 	CCVector3d newShift = globalShiftOptions.customGlobalShift;
 
 	//process clouds
-	for (const CLCloudDesc& desc : cmd.clouds())
+	for (CLCloudDesc& desc : cmd.clouds())
 	{
 		CCVector3d originalShift = desc.pc->getGlobalShift();
 		cmd.print(QObject::tr("\t[%4 - %5] Original global shift {%1,%2,%3}")
@@ -2774,9 +2774,18 @@ bool CommandSetGlobalShift::process(ccCommandLineInterface& cmd)
 			.arg(newShift.z)
 			.arg(desc.basename)
 			.arg(desc.pc->getName()));
+		QString nameExtension = QObject::tr("_SHIFTED_FROM_%1_%2_%3_TO_%4_%5_%6")
+			.arg(originalShift.x)
+			.arg(originalShift.y)
+			.arg(originalShift.z)
+			.arg(newShift.x)
+			.arg(newShift.y)
+			.arg(newShift.z);
+		desc.pc->setName(QObject::tr("%1%2").arg(desc.pc->getName()).arg(nameExtension));
+		desc.basename += nameExtension;
 	}
 
-	for (const CLMeshDesc& desc : cmd.meshes())
+	for (CLMeshDesc& desc : cmd.meshes())
 	{
 		bool isLocked = false;
 		ccShiftedObject* shifted = ccHObjectCaster::ToShifted(desc.mesh, &isLocked);
@@ -2822,6 +2831,15 @@ bool CommandSetGlobalShift::process(ccCommandLineInterface& cmd)
 				.arg(newShift.z)
 				.arg(desc.basename)
 				.arg(desc.mesh->getName()));
+			QString nameExtension = QObject::tr("_SHIFTED_FROM_%1_%2_%3_TO_%4_%5_%6")
+				.arg(originalShift.x)
+				.arg(originalShift.y)
+				.arg(originalShift.z)
+				.arg(newShift.x)
+				.arg(newShift.y)
+				.arg(newShift.z);
+			desc.mesh->setName(QObject::tr("%1%2").arg(desc.mesh->getName()).arg(nameExtension));
+			desc.basename += nameExtension;
 		}
 	}
 

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -2783,6 +2783,15 @@ bool CommandSetGlobalShift::process(ccCommandLineInterface& cmd)
 			.arg(newShift.z);
 		desc.pc->setName(QObject::tr("%1%2").arg(desc.pc->getName()).arg(nameExtension));
 		desc.basename += nameExtension;
+		//save it as well
+		if (cmd.autoSaveMode())
+		{
+			QString errorStr = cmd.exportEntity(desc);
+			if (!errorStr.isEmpty())
+			{
+				return cmd.error(errorStr);
+			}
+		}
 	}
 
 	for (CLMeshDesc& desc : cmd.meshes())
@@ -2840,6 +2849,15 @@ bool CommandSetGlobalShift::process(ccCommandLineInterface& cmd)
 				.arg(newShift.z);
 			desc.mesh->setName(QObject::tr("%1%2").arg(desc.mesh->getName()).arg(nameExtension));
 			desc.basename += nameExtension;
+		}
+		//save it as well
+		if (cmd.autoSaveMode())
+		{
+			QString errorStr = cmd.exportEntity(desc);
+			if (!errorStr.isEmpty())
+			{
+				return cmd.error(errorStr);
+			}
 		}
 	}
 

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -2691,7 +2691,7 @@ bool CommandMergeClouds::process(ccCommandLineInterface& cmd)
 }
 
 CommandSetGlobalShift::CommandSetGlobalShift()
-	: ccCommandLineInterface::Command(QObject::tr("Set active SF"), COMMAND_SET_GLOBAL_SHIFT)
+	: ccCommandLineInterface::Command(QObject::tr("Set global shift"), COMMAND_SET_GLOBAL_SHIFT)
 {}
 
 bool CommandSetGlobalShift::process(ccCommandLineInterface& cmd)

--- a/qCC/ccCommandLineCommands.h
+++ b/qCC/ccCommandLineCommands.h
@@ -209,6 +209,14 @@ struct CommandSetActiveSF : public ccCommandLineInterface::Command
 	bool process(ccCommandLineInterface& cmd) override;
 };
 
+struct CommandSetGlobalShift : public ccCommandLineInterface::Command
+{
+	CommandSetGlobalShift();
+
+	bool process(ccCommandLineInterface& cmd) override;
+};
+
+
 struct CommandRemoveAllSFs : public ccCommandLineInterface::Command
 {
 	CommandRemoveAllSFs();

--- a/qCC/ccCommandLineCommands.h
+++ b/qCC/ccCommandLineCommands.h
@@ -216,7 +216,6 @@ struct CommandSetGlobalShift : public ccCommandLineInterface::Command
 	bool process(ccCommandLineInterface& cmd) override;
 };
 
-
 struct CommandRemoveAllSFs : public ccCommandLineInterface::Command
 {
 	CommandRemoveAllSFs();

--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -703,6 +703,7 @@ void ccCommandLineParser::registerBuiltInCommands()
 	registerCommand(Command::Shared(new CommandMergeClouds));
 	registerCommand(Command::Shared(new CommandMergeMeshes));
 	registerCommand(Command::Shared(new CommandSetActiveSF));
+	registerCommand(Command::Shared(new CommandSetGlobalShift));
 	registerCommand(Command::Shared(new CommandRemoveAllSFs));
 	registerCommand(Command::Shared(new CommandRemoveSF));
 	registerCommand(Command::Shared(new CommandRemoveRGB));


### PR DESCRIPTION
man: -SET_GLOBAL_SHIFT -KEEP_ORIGIN {TRUE/FALSE} {x} {y} {z}

KEEP_ORIGIN {TRUE/FALSE} optional. Default value is FALSE.

it will set global shift on all entity and apply transformation if KEEP_ORIGIN set to true. If the transformation is too big it will warn the user, but still transform it.

log with KEEP_ORIGIN TRUE
```
[SET GLOBAL SHIFT]
Current origin will be preserved.
        [asdfas - asdfas] Original global shift {0,0,0}
        [asdfas - asdfas] Applied Transformation {0,0,0}
        [asdfas - asdfas] Global shift set to {0,0,0}
        [poi' ntc  loud2 - poi' ntc  loud2 - Cloud] Original global shift {1000,1000,1000}
        [poi' ntc  loud2 - poi' ntc  loud2 - Cloud] Applied Transformation {-1000,-1000,-1000}
        [poi' ntc  loud2 - poi' ntc  loud2 - Cloud] Global shift set to {0,0,0}
```
with KEEP_ORIGIN TRUE

```
[SET GLOBAL SHIFT]
        [asdfas - asdfas] Original global shift {0,0,0}
        [asdfas - asdfas] Global shift set to {0,0,0}
        [poi' ntc  loud2 - poi' ntc  loud2 - Cloud] Original global shift {1000,1000,1000}
        [poi' ntc  loud2 - poi' ntc  loud2 - Cloud] Global shift set to {0,0,0}
```
#1843