### PR TITLE
CLI subsample improvements:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,9 +252,10 @@ v2.13.alpha (???) - (??/??/????)
 		- New sub-option for the -SF_ARITHMETIC command: -IN_PLACE, to update the scalar field in place, without creating a new SF
 		- Most methods using scalar fields as input will now also accept the scalar field name (in lieu of the SF index)
 		- New sub-option for -APPLY_TRANS command: -INVERSE to inverse the transformation matrix before it is applied.
-		- New sub-option for -SS OCTREE command: MAX_NUMBER_OF_POINTS {number} to subsample with the highest octree number where the the resulting point count won't exceed the given number of points
+		- New sub-option for -SS OCTREE command: NUMBER_OF_POINTS {number} to subsample with the highest octree number where the the resulting point count won't exceed the given number of points
 		- New sub-option for -SS OCTREE command: CELL_SIZE {size} to calculate octree number from bounding box, and the given cell_size
-		- New sub-option for -SS RANDOM command: PERCENT {number} to calculate count from number. Number should be a decimal number between 0 and 100.
+		- New sub-option for -SS RANDOM command: PERCENT {number} to calculate count from PERCENT. PERCENT should be a decimal number between 0 and 100.
+		- New sub-option for -SS OCTREE NUMBER_OF_POINTS command: PERCENT {number} to calculate NUMBER_OF_POINTS from PERCENT. PERCENT should be a decimal number between 0 and 100.
 
 	- New entity picking mechanism (to not rely on the deprecated OpenGL 'names' pushing mechanism)
 		- Should hopefully solve most of the random issues with picking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,10 +252,11 @@ v2.13.alpha (???) - (??/??/????)
 		- New sub-option for the -SF_ARITHMETIC command: -IN_PLACE, to update the scalar field in place, without creating a new SF
 		- Most methods using scalar fields as input will now also accept the scalar field name (in lieu of the SF index)
 		- New sub-option for -APPLY_TRANS command: -INVERSE to inverse the transformation matrix before it is applied.
-		- New sub-option for -SS OCTREE command: NUMBER_OF_POINTS {number} to subsample with the highest octree number where the the resulting point count won't exceed the given number of points
-		- New sub-option for -SS OCTREE command: CELL_SIZE {size} to calculate octree number from bounding box, and the given cell_size
-		- New sub-option for -SS RANDOM command: PERCENT {number} to calculate count from PERCENT. PERCENT should be a decimal number between 0 and 100.
-		- New sub-option for -SS OCTREE NUMBER_OF_POINTS command: PERCENT {number} to calculate NUMBER_OF_POINTS from PERCENT. PERCENT should be a decimal number between 0 and 100.
+		- New sub-options for -SS command:
+			* -SS OCTREE NUMBER_OF_POINTS {number} to subsample with the highest octree level for which the resulting point count won't exceed the given number of points
+			* -SS OCTREE NUMBER_OF_POINTS PERCENT {number} to calculate NUMBER_OF_POINTS from PERCENT. PERCENT should be a decimal number between 0 and 100.
+			* -SS OCTREE CELL_SIZE {size} to deduce the octree level from the given cell size.
+			* -SS RANDOM PERCENT {number} to calculate the number of sampled points from PERCENT. PERCENT should be a decimal number between 0 and 100.
 
 	- New entity picking mechanism (to not rely on the deprecated OpenGL 'names' pushing mechanism)
 		- Should hopefully solve most of the random issues with picking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,8 @@ v2.13.alpha (???) - (??/??/????)
 		- New sub-option for the -SF_ARITHMETIC command: -IN_PLACE, to update the scalar field in place, without creating a new SF
 		- Most methods using scalar fields as input will now also accept the scalar field name (in lieu of the SF index)
 		- New sub-option for -APPLY_TRANS command: -INVERSE to inverse the transformation matrix before it is applied.
+		- New sub-option for -SS OCTREE command: MAX_NUMBER_OF_POINTS {number} to subsample with the highest octree number where the the resulting point count won't exceed the given number of points
+		- New sub-option for -SS OCTREE command: CELL_SIZE {size} to calculate octree number from bounding box, and the given cell_size
 
 	- New entity picking mechanism (to not rely on the deprecated OpenGL 'names' pushing mechanism)
 		- Should hopefully solve most of the random issues with picking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,7 @@ v2.13.alpha (???) - (??/??/????)
 		- New sub-option for -APPLY_TRANS command: -INVERSE to inverse the transformation matrix before it is applied.
 		- New sub-option for -SS OCTREE command: MAX_NUMBER_OF_POINTS {number} to subsample with the highest octree number where the the resulting point count won't exceed the given number of points
 		- New sub-option for -SS OCTREE command: CELL_SIZE {size} to calculate octree number from bounding box, and the given cell_size
+		- New sub-option for -SS RANDOM command: PERCENT {number} to calculate count from number. Number should be a decimal number between 0 and 100.
 
 	- New entity picking mechanism (to not rely on the deprecated OpenGL 'names' pushing mechanism)
 		- Should hopefully solve most of the random issues with picking

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -1478,16 +1478,16 @@ bool CommandSubsample::process(ccCommandLineInterface& cmd)
 				{
 					//predict a new octree level based on new information. It is faster than going through one by one. And it is predicting on the safe side. It will not overshoot in any circumstances.
 					unsigned sampledNumOfPoints = refCloud->size();
-					unsigned sampledNumOfCells = pow(2, 3 * octreeLevel);
+					unsigned sampledNumOfCells = static_cast<unsigned>(pow(2, 3 * octreeLevel));
 					unsigned predictedNumOfPoints = sampledNumOfPoints;
 					int octreeInc = 0;
 					while (predictedNumOfPoints < maxNumberOfPoints && octreeInc + octreeLevel < CCCoreLib::DgmOctree::MAX_OCTREE_LEVEL)
 					{
 						octreeInc++;
-						unsigned newNumOfCells = pow(2, 3 * (octreeLevel + octreeInc));
-						predictedNumOfPoints = static_cast<unsigned>((newNumOfCells * sampledNumOfPoints) / sampledNumOfCells);
+						unsigned newNumOfCells = static_cast<unsigned>(pow(2, 3 * (octreeLevel + octreeInc)));
+						predictedNumOfPoints = static_cast<unsigned>((static_cast<double>(newNumOfCells) * static_cast<double>(sampledNumOfPoints) / static_cast<double>(sampledNumOfCells)));
 						
-						cmd.print(QObject::tr("\t\tNumber of predicted points at octree %3 : %1 / %2 = %4").arg(predictedNumOfPoints).arg(maxNumberOfPoints).arg(octreeLevel+octreeInc).arg(predictedNumOfPoints/maxNumberOfPoints));
+						cmd.print(QObject::tr("\t\tNumber of predicted points at octree %3 : %1 / %2 = %4").arg(predictedNumOfPoints).arg(maxNumberOfPoints).arg(octreeLevel+octreeInc).arg((double)predictedNumOfPoints / (double)maxNumberOfPoints));
 					}
 					octreeLevel += octreeInc;
 					refCloud2 = CCCoreLib::CloudSamplingTools::subsampleCloudWithOctreeAtLevel(desc.pc,
@@ -1503,7 +1503,7 @@ bool CommandSubsample::process(ccCommandLineInterface& cmd)
 					{
 						delete refCloud;
 						refCloud = refCloud2;
-						if (((double)pointCount2 / (double)pointCount) < 1.05)
+						if ((static_cast<double>(pointCount2) / static_cast<double>(pointCount)) < 1.05)
 						{
 							cmd.print("Not enough point in the input cloud");
 							//do not process further if the current cloud is only 5% larger (hard code maybe param?)

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -1458,17 +1458,16 @@ bool CommandSubsample::process(ccCommandLineInterface& cmd)
 				octreeLevel = CCCoreLib::DgmOctree::MAX_OCTREE_LEVEL;
 				unsigned numberOfPoints = sizeOfInputCloud;
 				//go through max->min until previous point count and current point count is different then break
-				for (int currentOctreeLevel = CCCoreLib::DgmOctree::MAX_OCTREE_LEVEL; currentOctreeLevel > 1; --currentOctreeLevel)
+				for (int currentOctreeLevel = CCCoreLib::DgmOctree::MAX_OCTREE_LEVEL; currentOctreeLevel > 0; --currentOctreeLevel)
 				{
-					octreeLevel = currentOctreeLevel;
 					unsigned currentNumberOfPoints = octree->getCellNumber(currentOctreeLevel);
 					if (currentNumberOfPoints != numberOfPoints && numberOfPoints < maxNumberOfPoints)
 					{
 						break;
 					}
+					octreeLevel = currentOctreeLevel;
 					numberOfPoints = currentNumberOfPoints;
 				}
-				octreeLevel++;
 			}
 
 			//only process further if CELL_SIZE or octree level was given, or the numberOfPoints smaller than the input cloud

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -1457,18 +1457,17 @@ bool CommandSubsample::process(ccCommandLineInterface& cmd)
 				//calculate OCTREE level for each cloud based on required number of points
 				octreeLevel = CCCoreLib::DgmOctree::MAX_OCTREE_LEVEL;
 				unsigned numberOfPoints = sizeOfInputCloud;
-				//go through max->min untill previous ptsCount and current ptsCount is different then break;
-				do
+				//go through max->min until previous point count and current point count is different then break
+				for (int currentOctreeLevel = CCCoreLib::DgmOctree::MAX_OCTREE_LEVEL; currentOctreeLevel > 1; --currentOctreeLevel)
 				{
-					unsigned currentNumberOfPoints = octree->getCellNumber(octreeLevel);
-					octreeLevel--;
+					octreeLevel = currentOctreeLevel;
+					unsigned currentNumberOfPoints = octree->getCellNumber(currentOctreeLevel);
 					if (currentNumberOfPoints != numberOfPoints && numberOfPoints < maxNumberOfPoints)
 					{
 						break;
 					}
 					numberOfPoints = currentNumberOfPoints;
 				}
-				while (numberOfPoints > maxNumberOfPoints && octreeLevel > 0);
 				octreeLevel++;
 			}
 
@@ -1478,6 +1477,7 @@ bool CommandSubsample::process(ccCommandLineInterface& cmd)
 				//overwrite and print out finalized OCTREE level.
 				if (byCellSize || byMaxNumberOfPoints)
 				{
+
 					if (octreeLevel < 1)
 					{
 						//overwrite with min value instead of throwing an error

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -1476,17 +1476,8 @@ bool CommandSubsample::process(ccCommandLineInterface& cmd)
 				//overwrite and print out finalized OCTREE level.
 				if (byCellSize || byMaxNumberOfPoints)
 				{
-
-					if (octreeLevel < 1)
-					{
-						//overwrite with min value instead of throwing an error
-						octreeLevel = 1;
-					}
-					else if (octreeLevel > CCCoreLib::DgmOctree::MAX_OCTREE_LEVEL)
-					{
-						//overwrite with max value instead of throwing an error
-						octreeLevel = CCCoreLib::DgmOctree::MAX_OCTREE_LEVEL;
-					}
+					//clamp octree level
+					octreeLevel = std::max(std::min(octreeLevel, CCCoreLib::DgmOctree::MAX_OCTREE_LEVEL), 1);
 					cmd.print(QObject::tr("\tCalculated octree level: %1").arg(octreeLevel));
 				}
 				refCloud = CCCoreLib::CloudSamplingTools::subsampleCloudWithOctreeAtLevel(	desc.pc,

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -1335,6 +1335,7 @@ bool CommandSubsample::process(ccCommandLineInterface& cmd)
 		unsigned maxNumberOfPoints = 0;
 		bool isPercent = false;
 		double percent = 0.0;
+		const int maxOctreeLevel = CCCoreLib::DgmOctree::MAX_OCTREE_LEVEL;
 
 		if (!cmd.arguments().empty())
 		{
@@ -1410,7 +1411,7 @@ bool CommandSubsample::process(ccCommandLineInterface& cmd)
 
 				bool ok = false;
 				octreeLevel = cmd.arguments().takeFirst().toInt(&ok);
-				if (!ok || octreeLevel < 1 || octreeLevel > CCCoreLib::DgmOctree::MAX_OCTREE_LEVEL)
+				if (!ok || octreeLevel < 1 || octreeLevel > maxOctreeLevel)
 				{
 					return cmd.error(QObject::tr("Invalid octree level!"));
 				}
@@ -1455,10 +1456,10 @@ bool CommandSubsample::process(ccCommandLineInterface& cmd)
 				}
 
 				//calculate OCTREE level for each cloud based on required number of points
-				octreeLevel = CCCoreLib::DgmOctree::MAX_OCTREE_LEVEL;
+				octreeLevel = maxOctreeLevel;
 				unsigned numberOfPoints = sizeOfInputCloud;
 				//go through max->min until previous point count and current point count is different then break
-				for (int currentOctreeLevel = CCCoreLib::DgmOctree::MAX_OCTREE_LEVEL; currentOctreeLevel > 0; --currentOctreeLevel)
+				for (int currentOctreeLevel = maxOctreeLevel; currentOctreeLevel > 0; --currentOctreeLevel)
 				{
 					unsigned currentNumberOfPoints = octree->getCellNumber(currentOctreeLevel);
 					if (currentNumberOfPoints != numberOfPoints && numberOfPoints < maxNumberOfPoints)
@@ -1477,7 +1478,7 @@ bool CommandSubsample::process(ccCommandLineInterface& cmd)
 				if (byCellSize || byMaxNumberOfPoints)
 				{
 					//clamp octree level
-					octreeLevel = std::max(std::min(octreeLevel, CCCoreLib::DgmOctree::MAX_OCTREE_LEVEL), 1);
+					octreeLevel = std::max(std::min(octreeLevel, maxOctreeLevel), 1);
 					cmd.print(QObject::tr("\tCalculated octree level: %1").arg(octreeLevel));
 				}
 				refCloud = CCCoreLib::CloudSamplingTools::subsampleCloudWithOctreeAtLevel(	desc.pc,


### PR DESCRIPTION
Hello,

I added two suboption for -SS OCTREE
		- New sub-option for -SS OCTREE command: NUMBER_OF_POINTS {number} to subsample with the highest octree number where the the resulting point count won't exceed the given number of points (it does mean that it will run multiple octree, but saves only the last one)
		- New sub-option for -SS OCTREE command: CELL_SIZE {size} to calculate octree number from bounding box, and the given cell_size
		- New sub-option for -SS OCTREE NUMBER_OF_POINTS command: PERCENT {number} to calculate count from PERCENT . PERCENT should be a decimal between 0 and 100.
		- New sub-option for -SS RANDOM command: PERCENT {number} to calculate count from PERCENT . PERCENT should be a decimal between 0 and 100.

References
#1922 
https://www.cloudcompare.org/forum/viewtopic.php?f=14&t=6357