### PR TITLE
CLI Apply_trans use global shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,7 +267,12 @@ v2.13.alpha (???) - (??/??/????)
 		- New sub-option for the -C2M_DIST command: -UNSIGNED, to compute unsigned distances
 		- New sub-option for the -SF_ARITHMETIC command: -IN_PLACE, to update the scalar field in place, without creating a new SF
 		- Most methods using scalar fields as input will now also accept the scalar field name (in lieu of the SF index)
-		- New sub-option for -APPLY_TRANS command: -INVERSE to inverse the transformation matrix before it is applied.
+		- Changes to the -APPLY_TRANS command:
+			- -APPLY_TRANS will now apply the transformation to the global coordinate system by default
+				Warning: the Global Shift may be automatically updated to maintain precision
+			- -NOT_APPLY_TO_GLOBAL: to force CC to apply the transformation to the local coordinate system
+				(i.e. after the Global Shift has been applied)
+			- -INVERSE: to inverse the transformation matrix before applying it.
 		- New sub-options for -SS command:
 			* -SS OCTREE NUMBER_OF_POINTS {number} to subsample with the highest octree level for which the resulting point count won't exceed the given number of points
 			* -SS OCTREE NUMBER_OF_POINTS PERCENT {number} to calculate NUMBER_OF_POINTS from PERCENT. PERCENT should be a decimal number between 0 and 100.

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -2271,7 +2271,8 @@ bool CommandApplyTransformation::process(ccCommandLineInterface& cmd)
 			}
 		}
 
-		shiftedEntity->applyGLTransformation_recursive(&ccGLMatrix(transMat.data()));
+		ccGLMatrix matrixToApply = ccGLMatrix(transMat.data());
+		shiftedEntity->applyGLTransformation_recursive(&matrixToApply);
 		QString nameSuffix = "_TRANSFORMED";
 		if ((&desc)->getCLEntityType() == CL_ENTITY_TYPE::MESH)
 		{

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -2088,7 +2088,7 @@ bool CommandApplyTransformation::process(ccCommandLineInterface& cmd)
 	//optional parameters
 	bool inverse = false;
 	bool applyToGlobal = false;
-	bool applyToGlobalForce = false;
+	bool forceApplyToGlobal = false;
 	while (!cmd.arguments().empty())
 	{
 		QString argument = cmd.arguments().front();
@@ -2109,7 +2109,7 @@ bool CommandApplyTransformation::process(ccCommandLineInterface& cmd)
 		else if (ccCommandLineInterface::IsCommand(argument, OPTION_FORCE))
 		{
 			//local option confirmed, we can move on
-			applyToGlobalForce = true;
+			forceApplyToGlobal = true;
 			cmd.arguments().pop_front();
 			cmd.print("Transformation will be applied to the global coordinates even if the entity already has large coordinates");
 		}
@@ -2196,7 +2196,7 @@ bool CommandApplyTransformation::process(ccCommandLineInterface& cmd)
 			ccBBox localBBox = shiftedEntity->getOwnBB();
 			CCVector3d Pl = localBBox.minCorner();
 			double Dl = localBBox.getDiagNormd();
-			if (!ccGlobalShiftManager::NeedShift(Pl) && !ccGlobalShiftManager::NeedRescale(Dl) || applyToGlobalForce)
+			if (forceApplyToGlobal || (!ccGlobalShiftManager::NeedShift(Pl) && !ccGlobalShiftManager::NeedRescale(Dl)))
 			{
 				//test if the translated (local) cloud coordinates are too large
 				ccBBox transformedLocalBox = localBBox * transMat;
@@ -2264,7 +2264,7 @@ bool CommandApplyTransformation::process(ccCommandLineInterface& cmd)
 			}
 			else
 			{
-				cmd.warning(QObject::tr("Entity '%1' has already very large local coordinates. Global shift/scale won't be automatically adjusted to preserve accuracy. Consider using the -%2 option to force global shift/scale adjustment.").arg(shiftedEntity->getName()).arg(OPTION_FORCE));
+				cmd.warning(QObject::tr("Entity '%1' already has very large local coordinates. Global shift/scale won't be automatically adjusted to preserve accuracy. Consider using the -%2 option to force global shift/scale adjustment.").arg(shiftedEntity->getName()).arg(OPTION_FORCE));
 			}
 		}
 		else

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -1155,10 +1155,10 @@ void MainWindow::applyTransformation(const ccGLMatrixd& mat, bool applyToGlobal)
 				if (	!ccGlobalShiftManager::NeedShift(Pl)
 					&&	!ccGlobalShiftManager::NeedRescale(Dl) )
 				{
-					//test if the translated cloud coordinates are too large (in local coordinate space)
-					ccBBox transformedBox = entity->getOwnBB() * transMat;
-					CCVector3d transformedPl = transformedBox.minCorner();
-					double transformedDl = transformedBox.getDiagNormd();
+					//test if the translated cloud (local) coordinates are too large
+					ccBBox transformedLocalBox = entity->getOwnBB() * transMat;
+					CCVector3d transformedPl = transformedLocalBox.minCorner();
+					double transformedDl = transformedLocalBox.getDiagNormd();
 
 					bool needShift = ccGlobalShiftManager::NeedShift(transformedPl) || ccGlobalShiftManager::NeedRescale(transformedDl);
 					if (needShift)


### PR DESCRIPTION
#1908
- -APPLY_TRANS uses (default) global shift to maintain precision
- New sub-option for -APPLY_TRANS command: -NOT_APPLY_TO_GLOBAL it will not use global shift.

And a little correction for -SET_GLOBAL_SHIFT