### PR TITLE
cli new command -SELECT_ENTITIES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,22 +53,22 @@ v2.13.alpha (???) - (??/??/????)
 		- SET_GLOBAL_SHIFT {x} {y} {z} -KEEP_ORIG_FIXED
 			- set global shift on all entities
 			- sub-option -KEEP_ORIG_FIXED: if set, global origin will be preserved (a warning might be issued if the resulting coordinate transformation is too big)
-		- SELECT_ENTITIES -{FIRST/LAST} {nr} {-ALL} {-NOT} {-REGEX} {regex_pattern}
-			-sub-option -FIRST {nr}: if set, first nr of entities will be selected (optional). example: xx.....
-			-sub-option -LAST {nr}: if set, last nr of entities will be selected (optional). example: .....xx
-			-sub-option -ALL: if set, all entities will be selected. It has higher priority than FIRST/LAST/REGEX. (optional). example: xxxxxxx
-			-sub-option -REGEX {regex_pattern}: if set, all entities with matching names will be selected. It has higher priority than FIRST/LAST. (optional). example: x(merged)..x(merged)...
-			-sub-option -NOT: if set, all condition will be reversed (optional)
-				- first {nr} -> except first {nr} (optional). example: ..xxxxx
-				- last {nr} -> except last {nr} (optional). example: xxxxx..
+		- SELECT_ENTITIES -{FIRST/LAST} {count} {-ALL} {-NOT} {-REGEX} {regex_pattern}
+			- sub-option -FIRST {count}: if set, first count of entities will be selected (optional). example: xx.....
+			- sub-option -LAST {count}: if set, last count of entities will be selected (optional). example: .....xx
+			- sub-option -ALL: if set, all entities will be selected. It has higher priority than FIRST/LAST/REGEX. (optional). example: xxxxxxx
+			- sub-option -REGEX {regex_pattern}: if set, all entities with matching names will be selected. It has higher priority than FIRST/LAST. (optional). example: x(merged)..x(merged)...
+			- sub-option -NOT: if set, all condition will be reversed (optional)
+				- first {count} -> except first {count} (optional). example: ..xxxxx
+				- last {count} -> except last {count} (optional). example: xxxxx..
 				- all -> none (optional). example: .......
 				- regex matched -> regex not matched (optional). example: .(merged)xx.(merged)xxx
-				- special case: first and last set -> all except first {nr} AND last {nr}. example: ..xxx..
-			-sub-option -CLOUD: if set, clouds will be affected (optional)
-			-sub-option -MESH: if set, meshes will be affected (optional)
-			-if -CLOUD and -MESH is not set then both of them affected
-			-sub-options can be set in any order
-			-if FIRST,LAST set both of them select entities. example: xx...xx
+				- special case: first and last set -> all except first {count} AND last {count}. example: ..xxx..
+			- sub-option -CLOUD: if set, clouds will be selected (optional)
+			- sub-option -MESH: if set, meshes will be selected (optional)
+			- if neither -CLOUD nor -MESH are set then both of them will be selected
+			- sub-options can be set in any order
+			- it is possible to use FIRST and LAST at the same time. example: xx...xx
 		
 	- New display feature: near and far clipping planes in 3D views
 		- extension of the previously existing feature to set a near clipping plane

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,22 +53,22 @@ v2.13.alpha (???) - (??/??/????)
 		- SET_GLOBAL_SHIFT {x} {y} {z} -KEEP_ORIG_FIXED
 			- set global shift on all entities
 			- sub-option -KEEP_ORIG_FIXED: if set, global origin will be preserved (a warning might be issued if the resulting coordinate transformation is too big)
-		- SELECT_ENTITIES -{FIRST/LAST} {count} {-ALL} {-NOT} {-REGEX} {regex_pattern}
-			- sub-option -FIRST {count}: if set, first count of entities will be selected (optional). example: xx.....
-			- sub-option -LAST {count}: if set, last count of entities will be selected (optional). example: .....xx
-			- sub-option -ALL: if set, all entities will be selected. It has higher priority than FIRST/LAST/REGEX. (optional). example: xxxxxxx
-			- sub-option -REGEX {regex_pattern}: if set, all entities with matching names will be selected. It has higher priority than FIRST/LAST. (optional). example: x(merged)..x(merged)...
+		- SELECT_ENTITIES -{FIRST} {first count} -{LAST} {last count} {-ALL} {-NOT} {-REGEX} {regex_pattern}
+			- sub-option -FIRST {count}: if set, first count of entities will be selected (optional). Example: xx.....
+			- sub-option -LAST {count}: if set, last count of entities will be selected (optional). Example: .....xx
+			- sub-option -ALL: if set, all entities will be selected (optional). It has higher priority than FIRST/LAST/REGEX. Example: xxxxxxx
+			- sub-option -REGEX {regex_pattern}: if set, all entities with matching names will be selected (optional). It has higher priority than FIRST/LAST. Example: x(merged)..x(merged)...
 			- sub-option -NOT: if set, all condition will be reversed (optional)
-				- first {count} -> except first {count} (optional). example: ..xxxxx
-				- last {count} -> except last {count} (optional). example: xxxxx..
-				- all -> none (optional). example: .......
-				- regex matched -> regex not matched (optional). example: .(merged)xx.(merged)xxx
-				- special case: first and last set -> all except first {count} AND last {count}. example: ..xxx..
-			- sub-option -CLOUD: if set, clouds will be selected (optional)
-			- sub-option -MESH: if set, meshes will be selected (optional)
-			- if neither -CLOUD nor -MESH are set then both of them will be selected
+				- -NOT -FIRST {count} -> all but first {count}. Example: ..xxxxx
+				- -NOT -LAST {count} -> all but last {count}. Example: xxxxx..
+				- -NOT -ALL -> none. Example: .......
+				- -NOT -REGEX matched -> regex not matched. Example: .(merged)xx.(merged)xxx
+				- special case: -NOT -FIRST c1 -LAST c2 -> all except first 'c1' AND last 'c2' entities. Example: ..xxx..
+			- sub-option -CLOUD: if set, only clouds will be selected (optional)
+			- sub-option -MESH: if set, only meshes will be selected (optional)
+			- if neither -CLOUD nor -MESH are set then both types of entities will be selected
 			- sub-options can be set in any order
-			- it is possible to use FIRST and LAST at the same time. example: xx...xx
+			- it is possible to use FIRST and LAST at the same time. Example: xx...xx
 		
 	- New display feature: near and far clipping planes in 3D views
 		- extension of the previously existing feature to set a near clipping plane

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,22 @@ v2.13.alpha (???) - (??/??/????)
 		- SET_GLOBAL_SHIFT {x} {y} {z} -KEEP_ORIG_FIXED
 			- set global shift on all entities
 			- sub-option -KEEP_ORIG_FIXED: if set, global origin will be preserved (a warning might be issued if the resulting coordinate transformation is too big)
+		- SELECT_ENTITIES -{FIRST/LAST} {nr} {-ALL} {-NOT} {-REGEX} {regex_pattern}
+			-sub-option -FIRST {nr}: if set, first nr of entities will be selected (optional). example: xx.....
+			-sub-option -LAST {nr}: if set, last nr of entities will be selected (optional). example: .....xx
+			-sub-option -ALL: if set, all entities will be selected. It has higher priority than FIRST/LAST/REGEX. (optional). example: xxxxxxx
+			-sub-option -REGEX {regex_pattern}: if set, all entities with matching names will be selected. It has higher priority than FIRST/LAST. (optional). example: x(merged)..x(merged)...
+			-sub-option -NOT: if set, all condition will be reversed (optional)
+				- first {nr} -> except first {nr} (optional). example: ..xxxxx
+				- last {nr} -> except last {nr} (optional). example: xxxxx..
+				- all -> none (optional). example: .......
+				- regex matched -> regex not matched (optional). example: .(merged)xx.(merged)xxx
+				- special case: first and last set -> all except first {nr} AND last {nr}. example: ..xxx..
+			-sub-option -CLOUD: if set, clouds will be affected (optional)
+			-sub-option -MESH: if set, meshes will be affected (optional)
+			-if -CLOUD and -MESH is not set then both of them affected
+			-sub-options can be set in any order
+			-if FIRST,LAST set both of them select entities. example: xx...xx
 		
 	- New display feature: near and far clipping planes in 3D views
 		- extension of the previously existing feature to set a near clipping plane

--- a/libs/CCPluginAPI/include/ccCommandLineInterface.h
+++ b/libs/CCPluginAPI/include/ccCommandLineInterface.h
@@ -212,10 +212,10 @@ public: //virtual methods
 	virtual void removeMeshes(bool onlyLast = false) = 0;
 
 	//! moves the clouds to a storage and only keep the selected ones in the cloud array
-	virtual bool selectClouds(bool selectAll, bool not, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex) = 0;
+	virtual bool selectClouds(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex) = 0;
 
 	//! moves the meshes to a storage and only keep the selected ones in the cloud array
-	virtual bool selectMeshes(bool selectAll, bool not, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex) = 0;
+	virtual bool selectMeshes(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex) = 0;
 
 	//! Returns the list of arguments
 	virtual QStringList& arguments() = 0;

--- a/libs/CCPluginAPI/include/ccCommandLineInterface.h
+++ b/libs/CCPluginAPI/include/ccCommandLineInterface.h
@@ -135,6 +135,19 @@ public: //constructor
 	
 	virtual ~ccCommandLineInterface() = default;
 
+	//! Select Entities options
+	struct SelectEntitiesOptions
+	{
+		bool reverse = false;
+		bool selectRegex = false;
+		bool selectFirst = false;
+		bool selectLast = false;
+		bool selectAll = false;
+		unsigned firstNr = 0;
+		unsigned lastNr = 0;
+		QRegExp regex;
+	};
+
 	enum class ExportOption {
 		NoOptions = 0x0,
 		ForceCloud = 0x1,
@@ -212,10 +225,10 @@ public: //virtual methods
 	virtual void removeMeshes(bool onlyLast = false) = 0;
 
 	//! Keep only the selected clouds in the active set (m_clouds) and stores the others in an separate set (m_unselectedClouds)
-	virtual bool selectClouds(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, unsigned firstNr, unsigned lastNr, QRegExp regex) = 0;
+	virtual bool selectClouds(ccCommandLineInterface::SelectEntitiesOptions options) = 0;
 
 	//! Keep only the selected meshes in the active set (m_meshes) and stores the others in an separate set (m_unselectedMeshes)
-	virtual bool selectMeshes(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, unsigned firstNr, unsigned lastNr, QRegExp regex) = 0;
+	virtual bool selectMeshes(ccCommandLineInterface::SelectEntitiesOptions options) = 0;
 
 	//! Returns the list of arguments
 	virtual QStringList& arguments() = 0;

--- a/libs/CCPluginAPI/include/ccCommandLineInterface.h
+++ b/libs/CCPluginAPI/include/ccCommandLineInterface.h
@@ -211,6 +211,12 @@ public: //virtual methods
 	//! Removes all meshes (or only the last one ;)
 	virtual void removeMeshes(bool onlyLast = false) = 0;
 
+	//! moves the clouds to a storage and only keep the selected ones in the cloud array
+	virtual bool selectClouds(bool selectAll, bool not, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex) = 0;
+
+	//! moves the meshes to a storage and only keep the selected ones in the cloud array
+	virtual bool selectMeshes(bool selectAll, bool not, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex) = 0;
+
 	//! Returns the list of arguments
 	virtual QStringList& arguments() = 0;
 	//! Returns the list of arguments (const version)
@@ -323,11 +329,17 @@ public: //Global shift management
 
 protected: //members
 
-	//! Currently opened point clouds and their filename
+	//! Currently opened point clouds and their filename SELECTED
 	std::vector< CLCloudDesc > m_clouds;
 
-	//! Currently opened meshes and their filename
+	//! Currently opened point clouds and their filename NOT SELECTED
+	std::vector< CLCloudDesc > m_clouds_rest;
+
+	//! Currently opened meshes and their filename SELECTED
 	std::vector< CLMeshDesc > m_meshes;
+
+	//! Currently opened meshes and their filename NOT SELECTED
+	std::vector< CLMeshDesc > m_meshes_rest;
 
 	//! Silent mode
 	bool m_silentMode;

--- a/libs/CCPluginAPI/include/ccCommandLineInterface.h
+++ b/libs/CCPluginAPI/include/ccCommandLineInterface.h
@@ -211,11 +211,11 @@ public: //virtual methods
 	//! Removes all meshes (or only the last one ;)
 	virtual void removeMeshes(bool onlyLast = false) = 0;
 
-	//! moves the clouds to a storage and only keep the selected ones in the cloud array
-	virtual bool selectClouds(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex) = 0;
+	//! Keep only the selected clouds in the active set (m_clouds) and stores the others in an separate set (m_unselectedClouds)
+	virtual bool selectClouds(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, unsigned firstNr, unsigned lastNr, QRegExp regex) = 0;
 
-	//! moves the meshes to a storage and only keep the selected ones in the cloud array
-	virtual bool selectMeshes(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex) = 0;
+	//! Keep only the selected meshes in the active set (m_meshes) and stores the others in an separate set (m_unselectedMeshes)
+	virtual bool selectMeshes(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, unsigned firstNr, unsigned lastNr, QRegExp regex) = 0;
 
 	//! Returns the list of arguments
 	virtual QStringList& arguments() = 0;
@@ -329,17 +329,17 @@ public: //Global shift management
 
 protected: //members
 
-	//! Currently opened point clouds and their filename SELECTED
+	//! Currently opened AND SELECTED point clouds and their respective filename
 	std::vector< CLCloudDesc > m_clouds;
 
-	//! Currently opened point clouds and their filename NOT SELECTED
-	std::vector< CLCloudDesc > m_clouds_rest;
+	//! Currently opened BUT NOT SELECTED point clouds and their respective filename
+	std::vector< CLCloudDesc > m_unselectedClouds;
 
-	//! Currently opened meshes and their filename SELECTED
+	//! Currently opened AND SELECTED meshes and their respective filename
 	std::vector< CLMeshDesc > m_meshes;
 
-	//! Currently opened meshes and their filename NOT SELECTED
-	std::vector< CLMeshDesc > m_meshes_rest;
+	//! Currently opened BUT NOT SELECTED meshes and their respective filename
+	std::vector< CLMeshDesc > m_unselectedMeshes;
 
 	//! Silent mode
 	bool m_silentMode;

--- a/libs/CCPluginAPI/include/ccCommandLineInterface.h
+++ b/libs/CCPluginAPI/include/ccCommandLineInterface.h
@@ -133,6 +133,7 @@ public: //constructor
 	//! Default constructor
 	ccCommandLineInterface();
 	
+	//! Destructor
 	virtual ~ccCommandLineInterface() = default;
 
 	//! Select Entities options
@@ -148,7 +149,9 @@ public: //constructor
 		QRegExp regex;
 	};
 
-	enum class ExportOption {
+	//! Export options
+	enum class ExportOption
+	{
 		NoOptions = 0x0,
 		ForceCloud = 0x1,
 		ForceMesh = 0x2,
@@ -225,10 +228,10 @@ public: //virtual methods
 	virtual void removeMeshes(bool onlyLast = false) = 0;
 
 	//! Keep only the selected clouds in the active set (m_clouds) and stores the others in an separate set (m_unselectedClouds)
-	virtual bool selectClouds(ccCommandLineInterface::SelectEntitiesOptions options) = 0;
+	virtual bool selectClouds(const SelectEntitiesOptions& options) = 0;
 
 	//! Keep only the selected meshes in the active set (m_meshes) and stores the others in an separate set (m_unselectedMeshes)
-	virtual bool selectMeshes(ccCommandLineInterface::SelectEntitiesOptions options) = 0;
+	virtual bool selectMeshes(const SelectEntitiesOptions& options) = 0;
 
 	//! Returns the list of arguments
 	virtual QStringList& arguments() = 0;

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -6547,8 +6547,8 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 	bool selectAll = false;
 	bool selectMeshes = false;
 	bool selectClouds = false;
-	int firstNr = 0;
-	int lastNr = 0;
+	unsigned firstNr = 0;
+	unsigned lastNr = 0;
 	QRegExp regex;
 	while (!cmd.arguments().empty())
 	{
@@ -6570,8 +6570,8 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 				return cmd.error(QObject::tr("Missing parameter: number of entities after %1").arg(OPTION_FIRST));
 			}
 			bool ok;
-			firstNr = cmd.arguments().takeFirst().toInt(&ok);
-			if (!ok || firstNr < 0)
+			firstNr = cmd.arguments().takeFirst().toUInt(&ok);
+			if (!ok)
 			{
 				return cmd.error(QObject::tr("Invalid number after -%1").arg(OPTION_FIRST));
 			}
@@ -6587,8 +6587,8 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 				return cmd.error(QObject::tr("Missing parameter: number of entities after %1").arg(OPTION_LAST));
 			}
 			bool ok;
-			lastNr = cmd.arguments().takeFirst().toInt(&ok);
-			if (!ok || lastNr < 0)
+			lastNr = cmd.arguments().takeFirst().toUInt(&ok);
+			if (!ok)
 			{
 				return cmd.error(QObject::tr("Invalid number after -%1").arg(OPTION_LAST));
 			}
@@ -6650,7 +6650,7 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 		else
 		{
 			//ALL
-			cmd.print("All entities will be selected. Rest of the options disabled except not.");
+			cmd.print("All entities will be selected. Other options will be ignored except -NOT.");
 		}
 	}
 
@@ -6661,18 +6661,18 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 			if (selectLast)
 			{
 				//not first {nr} and not last {nr}
-				cmd.print(QObject::tr("First {%1} entities and last {%2} will not be selected").arg(firstNr).arg(lastNr));
+				cmd.print(QObject::tr("First %1 and last %2 entity(ies) will not be selected").arg(firstNr).arg(lastNr));
 			}
 			else
 			{
 				//not first {nr}
-				cmd.print(QObject::tr("First {%1} entities will not be selected").arg(firstNr));
+				cmd.print(QObject::tr("First %1 entity(ies) will not be selected").arg(firstNr));
 			}
 		}
 		else
 		{
 			//first {nr}
-			cmd.print(QObject::tr("First {%1} entities will be selected").arg(firstNr));
+			cmd.print(QObject::tr("First %1 entity(ies) will be selected").arg(firstNr));
 		}
 
 	}
@@ -6684,13 +6684,13 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 			if (!selectFirst)
 			{
 				//not last {nr}
-				cmd.print(QObject::tr("Last {%1} entities will not be selected").arg(lastNr));
+				cmd.print(QObject::tr("Last %1 entity(ies) will not be selected").arg(lastNr));
 			}
 		}
 		else
 		{
 			//last {nr}
-			cmd.print(QObject::tr("Last {%1} entities will be selected").arg(lastNr));
+			cmd.print(QObject::tr("Last %1 entity(ies) will be selected").arg(lastNr));
 		}
 	}
 
@@ -6709,10 +6709,10 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 		}
 	}
 
-	//there are no options given
+	//no option was set
 	if (!selectFirst && !selectLast && !selectRegex && !selectAll)
 	{
-		return cmd.error(QObject::tr("Missing parameter(s): any of the option (%1,%2,%3,%4) found after %5")
+		return cmd.error(QObject::tr("Missing parameter(s): any of the option (%1,%2,%3,%4) expected after %5")
 			.arg(OPTION_ALL)
 			.arg(OPTION_FIRST)
 			.arg(OPTION_LAST)

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -6540,7 +6540,7 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 
 	//option handling
 	//look for additional parameters
-	bool not = false;
+	bool reverse = false;
 	bool selectRegex = false;
 	bool selectFirst = false;
 	bool selectLast = false;
@@ -6615,7 +6615,7 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 		{
 			//local option confirmed, we can move on
 			cmd.arguments().pop_front();
-			not = true;
+			reverse = true;
 			//no other params needed
 		}
 		else if (ccCommandLineInterface::IsCommand(argument, OPTION_CLOUD))
@@ -6642,7 +6642,7 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 		selectFirst = false;
 		selectLast = false;
 		selectRegex = false;
-		if (not)
+		if (reverse)
 		{
 			//NONE
 			cmd.print("No entities will be selected.");
@@ -6656,7 +6656,7 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 
 	if (selectFirst)
 	{
-		if (not)
+		if (reverse)
 		{
 			if (selectLast)
 			{
@@ -6679,7 +6679,7 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 
 	if (selectLast)
 	{
-		if (not)
+		if (reverse)
 		{
 			if (!selectFirst)
 			{
@@ -6696,7 +6696,7 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 
 	if (selectRegex)
 	{
-		if (not)
+		if (reverse)
 		{
 			//regex not matches
 			cmd.print(QObject::tr("Entities with name matches the regex /%1/ will not be selected.").arg(regex.pattern()));
@@ -6730,7 +6730,7 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 	if (selectClouds)
 	{
 		cmd.print(QObject::tr("[Select clouds]"));
-		if (!cmd.selectClouds(selectAll, not, selectFirst, selectLast, selectRegex, firstNr, lastNr, regex))
+		if (!cmd.selectClouds(selectAll, reverse, selectFirst, selectLast, selectRegex, firstNr, lastNr, regex))
 		{
 			//error message already sent
 			return false;
@@ -6740,7 +6740,7 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 	if (selectMeshes)
 	{
 		cmd.print(QObject::tr("[Select meshes]"));
-		if (!cmd.selectMeshes(selectAll, not, selectFirst, selectLast, selectRegex, firstNr, lastNr, regex))
+		if (!cmd.selectMeshes(selectAll, reverse, selectFirst, selectLast, selectRegex, firstNr, lastNr, regex))
 		{
 			//error message already sent
 			return false;

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -6540,16 +6540,9 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 
 	//option handling
 	//look for additional parameters
-	bool reverse = false;
-	bool selectRegex = false;
-	bool selectFirst = false;
-	bool selectLast = false;
-	bool selectAll = false;
+	ccCommandLineInterface::SelectEntitiesOptions options;
 	bool selectMeshes = false;
 	bool selectClouds = false;
-	unsigned firstNr = 0;
-	unsigned lastNr = 0;
-	QRegExp regex;
 	while (!cmd.arguments().empty())
 	{
 		QString argument = cmd.arguments().front().toUpper();
@@ -6557,7 +6550,7 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 		{
 			//local option confirmed, we can move on
 			cmd.arguments().pop_front();
-			selectAll = true;
+			options.selectAll = true;
 			//no other params needed
 		}
 		else if (ccCommandLineInterface::IsCommand(argument, OPTION_FIRST))
@@ -6570,12 +6563,12 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 				return cmd.error(QObject::tr("Missing parameter: number of entities after %1").arg(OPTION_FIRST));
 			}
 			bool ok;
-			firstNr = cmd.arguments().takeFirst().toUInt(&ok);
+			options.firstNr = cmd.arguments().takeFirst().toUInt(&ok);
 			if (!ok)
 			{
 				return cmd.error(QObject::tr("Invalid number after -%1").arg(OPTION_FIRST));
 			}
-			selectFirst = true;
+			options.selectFirst = true;
 		}
 		else if (ccCommandLineInterface::IsCommand(argument, OPTION_LAST))
 		{
@@ -6587,35 +6580,35 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 				return cmd.error(QObject::tr("Missing parameter: number of entities after %1").arg(OPTION_LAST));
 			}
 			bool ok;
-			lastNr = cmd.arguments().takeFirst().toUInt(&ok);
+			options.lastNr = cmd.arguments().takeFirst().toUInt(&ok);
 			if (!ok)
 			{
 				return cmd.error(QObject::tr("Invalid number after -%1").arg(OPTION_LAST));
 			}
-			selectLast = true;
+			options.selectLast = true;
 		}
 		else if (ccCommandLineInterface::IsCommand(argument, OPTION_REGEX))
 		{
 			//local option confirmed, we can move on
 			cmd.arguments().pop_front();
-			selectRegex = true;
+			options.selectRegex = true;
 			//it requires a string after the argument
 			if (cmd.arguments().empty())
 			{
 				return cmd.error(QObject::tr("Missing parameter: regex string after %1").arg(OPTION_REGEX));
 			}
 			QString regexString = cmd.arguments().takeFirst();
-			regex.setPattern(regexString);
-			if (!regex.isValid())
+			options.regex.setPattern(regexString);
+			if (!options.regex.isValid())
 			{
-				return cmd.error(QObject::tr("Invalid regex pattern: %1").arg(regex.errorString()));
+				return cmd.error(QObject::tr("Invalid regex pattern: %1").arg(options.regex.errorString()));
 			}
 		}
 		else if (ccCommandLineInterface::IsCommand(argument, OPTION_NOT))
 		{
 			//local option confirmed, we can move on
 			cmd.arguments().pop_front();
-			reverse = true;
+			options.reverse = true;
 			//no other params needed
 		}
 		else if (ccCommandLineInterface::IsCommand(argument, OPTION_CLOUD))
@@ -6636,13 +6629,13 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 		}
 	}
 
-	if (selectAll)
+	if (options.selectAll)
 	{
 		//overwrite any other mode (first/last/regex)
-		selectFirst = false;
-		selectLast = false;
-		selectRegex = false;
-		if (reverse)
+		options.selectFirst = false;
+		options.selectLast = false;
+		options.selectRegex = false;
+		if (options.reverse)
 		{
 			//NONE
 			cmd.print("No entities will be selected.");
@@ -6654,63 +6647,63 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 		}
 	}
 
-	if (selectFirst)
+	if (options.selectFirst)
 	{
-		if (reverse)
+		if (options.reverse)
 		{
-			if (selectLast)
+			if (options.selectLast)
 			{
 				//not first {nr} and not last {nr}
-				cmd.print(QObject::tr("First %1 and last %2 entity(ies) will not be selected").arg(firstNr).arg(lastNr));
+				cmd.print(QObject::tr("First %1 and last %2 entity(ies) will not be selected").arg(options.firstNr).arg(options.lastNr));
 			}
 			else
 			{
 				//not first {nr}
-				cmd.print(QObject::tr("First %1 entity(ies) will not be selected").arg(firstNr));
+				cmd.print(QObject::tr("First %1 entity(ies) will not be selected").arg(options.firstNr));
 			}
 		}
 		else
 		{
 			//first {nr}
-			cmd.print(QObject::tr("First %1 entity(ies) will be selected").arg(firstNr));
+			cmd.print(QObject::tr("First %1 entity(ies) will be selected").arg(options.firstNr));
 		}
 
 	}
 
-	if (selectLast)
+	if (options.selectLast)
 	{
-		if (reverse)
+		if (options.reverse)
 		{
-			if (!selectFirst)
+			if (!options.selectFirst)
 			{
 				//not last {nr}
-				cmd.print(QObject::tr("Last %1 entity(ies) will not be selected").arg(lastNr));
+				cmd.print(QObject::tr("Last %1 entity(ies) will not be selected").arg(options.lastNr));
 			}
 		}
 		else
 		{
 			//last {nr}
-			cmd.print(QObject::tr("Last %1 entity(ies) will be selected").arg(lastNr));
+			cmd.print(QObject::tr("Last %1 entity(ies) will be selected").arg(options.lastNr));
 		}
 	}
 
-	if (selectRegex)
+	if (options.selectRegex)
 	{
-		if (reverse)
+		if (options.reverse)
 		{
 			//regex not matches
-			cmd.print(QObject::tr("Entities with name matches the regex /%1/ will not be selected.").arg(regex.pattern()));
+			cmd.print(QObject::tr("Entities with name matches the regex /%1/ will not be selected.").arg(options.regex.pattern()));
 		}
 		else
 		{
 			//regex matches
-			cmd.print(QObject::tr("Entities with name matches the regex /%1/ will be selected.").arg(regex.pattern()));
+			cmd.print(QObject::tr("Entities with name matches the regex /%1/ will be selected.").arg(options.regex.pattern()));
 
 		}
 	}
 
 	//no option was set
-	if (!selectFirst && !selectLast && !selectRegex && !selectAll)
+	if (!options.selectFirst && !options.selectLast && !options.selectRegex && !options.selectAll)
 	{
 		return cmd.error(QObject::tr("Missing parameter(s): any of the option (%1,%2,%3,%4) expected after %5")
 			.arg(OPTION_ALL)
@@ -6730,7 +6723,7 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 	if (selectClouds)
 	{
 		cmd.print(QObject::tr("[Select clouds]"));
-		if (!cmd.selectClouds(selectAll, reverse, selectFirst, selectLast, selectRegex, firstNr, lastNr, regex))
+		if (!cmd.selectClouds(options))
 		{
 			//error message already sent
 			return false;
@@ -6740,7 +6733,7 @@ bool CommandSelectEntities::process(ccCommandLineInterface& cmd)
 	if (selectMeshes)
 	{
 		cmd.print(QObject::tr("[Select meshes]"));
-		if (!cmd.selectMeshes(selectAll, reverse, selectFirst, selectLast, selectRegex, firstNr, lastNr, regex))
+		if (!cmd.selectMeshes(options))
 		{
 			//error message already sent
 			return false;

--- a/qCC/ccCommandLineCommands.h
+++ b/qCC/ccCommandLineCommands.h
@@ -526,6 +526,13 @@ struct CommandLogFile : public ccCommandLineInterface::Command
 	bool process(ccCommandLineInterface& cmd) override;
 };
 
+struct CommandSelectEntities : public ccCommandLineInterface::Command
+{
+	CommandSelectEntities();
+
+	bool process(ccCommandLineInterface& cmd) override;
+};
+
 struct CommandClear : public ccCommandLineInterface::Command
 {
 	CommandClear();

--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -390,7 +390,7 @@ QString ccCommandLineParser::exportEntity(	CLEntityDesc& entityDesc,
 	return (result != CC_FERR_NO_ERROR ? QString("Failed to save result in file '%1'").arg(outputFilename) : QString());
 }
 
-bool ccCommandLineParser::selectClouds(bool selectAll, bool not, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex)
+bool ccCommandLineParser::selectClouds(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex)
 {
 	if (selectRegex && !regex.isValid())
 	{
@@ -414,7 +414,7 @@ bool ccCommandLineParser::selectClouds(bool selectAll, bool not, bool selectFirs
 	{
 		QString nameToValidate = QObject::tr("%1/%2").arg(it->basename).arg(it->pc->getName());
 		bool required = false;
-		if (!not)
+		if (!reverse)
 		{
 			//first {n}
 			if (selectFirst && index < firstNr)
@@ -455,19 +455,19 @@ bool ccCommandLineParser::selectClouds(bool selectAll, bool not, bool selectFirs
 			if (regex.indexIn(nameToValidate) > -1)
 			{
 				//regex matched
-				required = !not;
+				required = !reverse;
 			}
 			else
 			{
 				//regex not matched
-				required = not;
+				required = reverse;
 			}
 		}
 
 		//selectAll has higher priority than first/last/regex overwrite
 		if (selectAll)
 		{
-			required = !not;
+			required = !reverse;
 		}
 
 		if (required)
@@ -486,7 +486,7 @@ bool ccCommandLineParser::selectClouds(bool selectAll, bool not, bool selectFirs
 	return true;
 }
 
-bool ccCommandLineParser::selectMeshes(bool selectAll, bool not, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex)
+bool ccCommandLineParser::selectMeshes(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex)
 {
 	//HeadLessHUN: i don't really know if it is possible or worth it to make selectClouds and selectMeshes one function.
 	//"Only" difference between the two function is the two vector, and the differences between CLCLoudDesc and CLMeshDesc.
@@ -512,7 +512,7 @@ bool ccCommandLineParser::selectMeshes(bool selectAll, bool not, bool selectFirs
 	{
 		QString nameToValidate = QObject::tr("%1/%2").arg(it->basename).arg(it->mesh->getName());
 		bool required = false;
-		if (!not)
+		if (!reverse)
 		{
 			//first {n}
 			if (selectFirst && index < firstNr)
@@ -553,19 +553,19 @@ bool ccCommandLineParser::selectMeshes(bool selectAll, bool not, bool selectFirs
 			if (regex.indexIn(nameToValidate) > -1)
 			{
 				//regex matched
-				required = !not;
+				required = !reverse;
 			}
 			else
 			{
 				//regex not matched
-				required = not;
+				required = reverse;
 			}
 		}
 
 		//selectAll has higher priority than first/last/regex overwrite
 		if (selectAll)
 		{
-			required = !not;
+			required = !reverse;
 		}
 
 		if (required)

--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -419,7 +419,7 @@ template<class EntityDesc > bool SelectEntities(ccCommandLineInterface::SelectEn
 	//put elements to the front facing vector
 	unsigned index = 0;
 	size_t lastIndex = unselectedEntities.size() - 1;
-	for (std::vector<EntityDesc>::iterator it = unselectedEntities.begin(); it != unselectedEntities.end();)
+	for (typename std::vector<EntityDesc>::iterator it = unselectedEntities.begin(); it != unselectedEntities.end();)
 	{
 		QString nameToValidate = QObject::tr("%1/%2").arg(it->basename).arg(it->getEntity()->getName());
 		bool toBeSelected = false;

--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -389,7 +389,7 @@ QString ccCommandLineParser::exportEntity(	CLEntityDesc& entityDesc,
 
 	return (result != CC_FERR_NO_ERROR ? QString("Failed to save result in file '%1'").arg(outputFilename) : QString());
 }
-template<class EntityDesc > bool SelectEntities(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, unsigned firstNr, unsigned lastNr, QRegExp regex,ccCommandLineParser cmd, std::vector<EntityDesc>& selectedEntities, std::vector<EntityDesc>& unselectedEntities,CL_ENTITY_TYPE entityType)
+template<class EntityDesc > bool SelectEntities(ccCommandLineInterface::SelectEntitiesOptions options, ccCommandLineParser cmd, std::vector<EntityDesc>& selectedEntities, std::vector<EntityDesc>& unselectedEntities, CL_ENTITY_TYPE entityType)
 {
 	//early abort if no clouds found
 	if (selectedEntities.empty() && unselectedEntities.empty())
@@ -399,9 +399,9 @@ template<class EntityDesc > bool SelectEntities(bool selectAll, bool reverse, bo
 		return true;
 	}
 
-	if (selectRegex && !regex.isValid())
+	if (options.selectRegex && !options.regex.isValid())
 	{
-		return cmd.error(QObject::tr("Regex string invalid: %1").arg(regex.errorString()));
+		return cmd.error(QObject::tr("Regex string invalid: %1").arg(options.regex.errorString()));
 	}
 
 	//store everthyng in the unselected vector
@@ -423,16 +423,16 @@ template<class EntityDesc > bool SelectEntities(bool selectAll, bool reverse, bo
 	{
 		QString nameToValidate = QObject::tr("%1/%2").arg(it->basename).arg(it->getEntity()->getName());
 		bool toBeSelected = false;
-		if (!reverse)
+		if (!options.reverse)
 		{
 			//first {n}
-			if (selectFirst && index < firstNr)
+			if (options.selectFirst && index < options.firstNr)
 			{
 				toBeSelected = true;
 			}
 
 			//last {n}
-			if (selectLast && index > lastIndex - lastNr)
+			if (options.selectLast && index > lastIndex - options.lastNr)
 			{
 				toBeSelected = true;
 			}
@@ -440,43 +440,43 @@ template<class EntityDesc > bool SelectEntities(bool selectAll, bool reverse, bo
 		else
 		{
 			//not first {n}
-			if (selectFirst && index >= firstNr && !selectLast)
+			if (options.selectFirst && index >= options.firstNr && !options.selectLast)
 			{
 				toBeSelected = true;
 			}
 
 			//not last {n}
-			if (selectLast && index <= lastIndex - lastNr && !selectFirst)
+			if (options.selectLast && index <= lastIndex - options.lastNr && !options.selectFirst)
 			{
 				toBeSelected = true;
 			}
 
 			//not first and not last
-			if (selectFirst && selectLast && index >= firstNr && index <= lastIndex - lastNr)
+			if (options.selectFirst && options.selectLast && index >= options.firstNr && index <= lastIndex - options.lastNr)
 			{
 				toBeSelected = true;
 			}
 		}
 
 		//regex has higher priority than first/last overwrite
-		if (selectRegex)
+		if (options.selectRegex)
 		{
-			if (regex.indexIn(nameToValidate) > -1)
+			if (options.regex.indexIn(nameToValidate) > -1)
 			{
 				//regex matched
-				toBeSelected = !reverse;
+				toBeSelected = !options.reverse;
 			}
 			else
 			{
 				//regex not matched
-				toBeSelected = reverse;
+				toBeSelected = options.reverse;
 			}
 		}
 
 		//selectAll has higher priority than first/last/regex overwrite
-		if (selectAll)
+		if (options.selectAll)
 		{
-			toBeSelected = !reverse;
+			toBeSelected = !options.reverse;
 		}
 
 		if (toBeSelected)
@@ -495,14 +495,14 @@ template<class EntityDesc > bool SelectEntities(bool selectAll, bool reverse, bo
 	return true;
 }
 
-bool ccCommandLineParser::selectClouds(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, unsigned firstNr, unsigned lastNr, QRegExp regex)
+bool ccCommandLineParser::selectClouds(ccCommandLineInterface::SelectEntitiesOptions options)
 {
-	return SelectEntities(selectAll, reverse, selectFirst, selectLast, selectRegex, firstNr, lastNr, regex, *this, m_clouds, m_unselectedClouds, CL_ENTITY_TYPE::CLOUD);
+	return SelectEntities(options, *this, m_clouds, m_unselectedClouds, CL_ENTITY_TYPE::CLOUD);
 }
 
-bool ccCommandLineParser::selectMeshes(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, unsigned firstNr, unsigned lastNr, QRegExp regex)
+bool ccCommandLineParser::selectMeshes(ccCommandLineInterface::SelectEntitiesOptions options)
 {
-	return SelectEntities(selectAll, reverse, selectFirst, selectLast, selectRegex, firstNr, lastNr, regex, *this, m_meshes, m_unselectedMeshes, CL_ENTITY_TYPE::MESH);
+	return SelectEntities(options, *this, m_meshes, m_unselectedMeshes, CL_ENTITY_TYPE::MESH);
 }
 
 void ccCommandLineParser::removeClouds(bool onlyLast/*=false*/)

--- a/qCC/ccCommandLineParser.h
+++ b/qCC/ccCommandLineParser.h
@@ -33,8 +33,8 @@ public:
 							ccCommandLineInterface::ExportOptions options = ExportOption::NoOptions) override;
 	void removeClouds(bool onlyLast = false) override;
 	void removeMeshes(bool onlyLast = false) override;
-	bool selectClouds(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex) override;
-	bool selectMeshes(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex) override;
+	bool selectClouds(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, unsigned firstNr, unsigned lastNr, QRegExp regex) override;
+	bool selectMeshes(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, unsigned firstNr, unsigned lastNr, QRegExp regex) override;
 	QStringList& arguments() override { return m_arguments; }
 	const QStringList& arguments() const override { return m_arguments; }
 	bool registerCommand(Command::Shared command) override;

--- a/qCC/ccCommandLineParser.h
+++ b/qCC/ccCommandLineParser.h
@@ -33,8 +33,8 @@ public:
 							ccCommandLineInterface::ExportOptions options = ExportOption::NoOptions) override;
 	void removeClouds(bool onlyLast = false) override;
 	void removeMeshes(bool onlyLast = false) override;
-	bool selectClouds(bool selectAll, bool not, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex) override;
-	bool selectMeshes(bool selectAll, bool not, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex) override;
+	bool selectClouds(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex) override;
+	bool selectMeshes(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex) override;
 	QStringList& arguments() override { return m_arguments; }
 	const QStringList& arguments() const override { return m_arguments; }
 	bool registerCommand(Command::Shared command) override;

--- a/qCC/ccCommandLineParser.h
+++ b/qCC/ccCommandLineParser.h
@@ -33,8 +33,8 @@ public:
 							ccCommandLineInterface::ExportOptions options = ExportOption::NoOptions) override;
 	void removeClouds(bool onlyLast = false) override;
 	void removeMeshes(bool onlyLast = false) override;
-	bool selectClouds(ccCommandLineInterface::SelectEntitiesOptions options) override;
-	bool selectMeshes(ccCommandLineInterface::SelectEntitiesOptions options) override;
+	bool selectClouds(const SelectEntitiesOptions& options) override;
+	bool selectMeshes(const SelectEntitiesOptions& options) override;
 	QStringList& arguments() override { return m_arguments; }
 	const QStringList& arguments() const override { return m_arguments; }
 	bool registerCommand(Command::Shared command) override;

--- a/qCC/ccCommandLineParser.h
+++ b/qCC/ccCommandLineParser.h
@@ -33,8 +33,8 @@ public:
 							ccCommandLineInterface::ExportOptions options = ExportOption::NoOptions) override;
 	void removeClouds(bool onlyLast = false) override;
 	void removeMeshes(bool onlyLast = false) override;
-	bool selectClouds(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, unsigned firstNr, unsigned lastNr, QRegExp regex) override;
-	bool selectMeshes(bool selectAll, bool reverse, bool selectFirst, bool selectLast, bool selectRegex, unsigned firstNr, unsigned lastNr, QRegExp regex) override;
+	bool selectClouds(ccCommandLineInterface::SelectEntitiesOptions options) override;
+	bool selectMeshes(ccCommandLineInterface::SelectEntitiesOptions options) override;
 	QStringList& arguments() override { return m_arguments; }
 	const QStringList& arguments() const override { return m_arguments; }
 	bool registerCommand(Command::Shared command) override;

--- a/qCC/ccCommandLineParser.h
+++ b/qCC/ccCommandLineParser.h
@@ -33,6 +33,8 @@ public:
 							ccCommandLineInterface::ExportOptions options = ExportOption::NoOptions) override;
 	void removeClouds(bool onlyLast = false) override;
 	void removeMeshes(bool onlyLast = false) override;
+	bool selectClouds(bool selectAll, bool not, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex) override;
+	bool selectMeshes(bool selectAll, bool not, bool selectFirst, bool selectLast, bool selectRegex, int firstNr, int lastNr, QRegExp regex) override;
 	QStringList& arguments() override { return m_arguments; }
 	const QStringList& arguments() const override { return m_arguments; }
 	bool registerCommand(Command::Shared command) override;


### PR DESCRIPTION
see changlog, 

few thoughs about it:
 -is it a viable option to merge the  selectClouds and selectMeshes function in the ccCommandLineParser?
 -added some verbosity to few old commands as well, like clear_clouds, clear_meshes, etc.

here is an example command file
[list_of_commands.txt](https://github.com/CloudCompare/CloudCompare/files/13790043/list_of_commands.txt)

and here is the result of the command file:
[result_of_commands.txt](https://github.com/CloudCompare/CloudCompare/files/13790046/result_of_commands.txt)

it will open up a lot of possibilities to the command line. 
references:
#1922 #1491
https://www.danielgm.net/cc/forum/viewtopic.php?f=9&t=6682&sid=259b20637305467d74d7d18a9cbb6298&p=28625#p28625