### PR TITLE
Add support for comments inside a command file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,9 @@ v2.13.beta (???) - (??/??/2024)
 			* -SS OCTREE NUMBER_OF_POINTS PERCENT {number} to calculate NUMBER_OF_POINTS from PERCENT. PERCENT should be a decimal number between 0 and 100.
 			* -SS OCTREE CELL_SIZE {size} to deduce the octree level from the given cell size.
 			* -SS RANDOM PERCENT {number} to calculate the number of sampled points from PERCENT. PERCENT should be a decimal number between 0 and 100.
+		- Support comments inside COMMAND_FILE files
+			* whole line comments with # my comment here or // here
+			* comment out single arguments '/* my comment here */', must be quoted with either single or double quote, if it contains spaces 
 
 	- New entity picking mechanism (to not rely on the deprecated OpenGL 'names' pushing mechanism)
 		- Should hopefully solve most of the random issues with picking

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -720,7 +720,7 @@ bool CommandLoadCommandFile::process(ccCommandLineInterface& cmd)
 						processedArgs.append(arg);
 					}
 				}
-				if (insideSingleQuoteSection||insideDoubleQuoteSection)
+				if (insideSingleQuoteSection || insideDoubleQuoteSection)
 				{
 					// the single/double quote section was not closed...
 					cmd.warning("Probably malformed command (missing closing quote)");
@@ -730,31 +730,36 @@ bool CommandLoadCommandFile::process(ccCommandLineInterface& cmd)
 			}
 
 			//inject back all the arguments to the cmd.arguments()
-			bool commentWholeLine = false;
+			bool isWholeLineComment = false;
 			while (!processedArgs.isEmpty())
 			{
 				QString processedArg = processedArgs.takeFirst();
 				if (!processedArg.isEmpty())
 				{
-					bool commentArgument = false;
-					QString commentStr = "[COMMENT] ";
-					if (processedArg.startsWith("//") || processedArg.startsWith("#"))
+					bool isComment = isWholeLineComment;
+					if (!isComment)
 					{
-						commentWholeLine = true;
-					}
-					if (processedArg.startsWith("/*") && processedArg.endsWith("*/"))
-					{
-						commentArgument = true;
+						if (processedArg.startsWith("//") || processedArg.startsWith("#"))
+						{
+							isComment = isWholeLineComment = true;
+						}
+						else
+						{
+							isComment = (processedArg.startsWith("/*") && processedArg.endsWith("*/"));
+						}
 					}
 
-					if (!commentArgument && !commentWholeLine)
+					if (!isComment)
 					{
-						//argument is not a comment add it to the arguments
-						commentStr = "";
+						//standard argument
 						cmd.arguments().insert(insertingIndex, processedArg);
 						insertingIndex++;
+						cmd.print(QObject::tr("\t[%1] %2").arg(insertingIndex - 1).arg(processedArg));
 					}
-					cmd.print(QObject::tr("\t%3[%1] %2").arg(insertingIndex - 1).arg(processedArg).arg(commentStr));
+					else
+					{
+						cmd.print(QObject::tr("\t[COMMENT] [%1] %2").arg(insertingIndex - 1).arg(processedArg));
+					}
 				}
 			}
 		}

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -643,7 +643,7 @@ bool CommandLoadCommandFile::process(ccCommandLineInterface& cmd)
 		QTextStream in(&commandFile);
 		while (!in.atEnd())
 		{
-			QString line = in.readLine();
+			QString line = in.readLine().trimmed();
 			QStringList argumentsInLine = line.split(" ");
 			QStringList processedArgs;
 
@@ -730,12 +730,31 @@ bool CommandLoadCommandFile::process(ccCommandLineInterface& cmd)
 			}
 
 			//inject back all the arguments to the cmd.arguments()
-			while (!processedArgs.isEmpty()) {
+			bool commentWholeLine = false;
+			while (!processedArgs.isEmpty())
+			{
 				QString processedArg = processedArgs.takeFirst();
-				if (!processedArg.isEmpty()) {
-					cmd.print(QObject::tr("\t[%1] %2").arg(insertingIndex).arg(processedArg));
-					cmd.arguments().insert(insertingIndex, processedArg);
-					insertingIndex++;
+				if (!processedArg.isEmpty())
+				{
+					bool commentArgument = false;
+					QString commentStr = "[COMMENT] ";
+					if (processedArg.startsWith("//") || processedArg.startsWith("#"))
+					{
+						commentWholeLine = true;
+					}
+					if (processedArg.startsWith("/*") && processedArg.endsWith("*/"))
+					{
+						commentArgument = true;
+					}
+
+					if (!commentArgument && !commentWholeLine)
+					{
+						//argument is not a comment add it to the arguments
+						commentStr = "";
+						cmd.arguments().insert(insertingIndex, processedArg);
+						insertingIndex++;
+					}
+					cmd.print(QObject::tr("\t%3[%1] %2").arg(insertingIndex - 1).arg(processedArg).arg(commentStr));
 				}
 			}
 		}


### PR DESCRIPTION
syntax:
```
# whole line comment
// whole line comment
-SS OCTREE 10 //subsample cloud with octree level 10
 # this will run octree 10 rename_entities is commented out then save 
-SS OCTREE 10 '/* -RENAME_ENTITIES "rename" */' -SAVE_CLOUDS #we can use hashtags here as well
```

#1929