### PR TITLE
Adding command line options to -ICP to skip translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,7 +277,10 @@ v2.13.beta (???) - (??/??/2024)
 			* -SS OCTREE NUMBER_OF_POINTS PERCENT {number} to calculate NUMBER_OF_POINTS from PERCENT. PERCENT should be a decimal number between 0 and 100.
 			* -SS OCTREE CELL_SIZE {size} to deduce the octree level from the given cell size.
 			* -SS RANDOM PERCENT {number} to calculate the number of sampled points from PERCENT. PERCENT should be a decimal number between 0 and 100.
-
+		- New sub-options for -ICP command:
+			* -SKIP_TX to skip translation along X axis
+			* -SKIP_TY to skip translation along Y axis
+			* -SKIP_TZ to skip translation along Z axis
 	- New entity picking mechanism (to not rely on the deprecated OpenGL 'names' pushing mechanism)
 		- Should hopefully solve most of the random issues with picking
 

--- a/libs/CCPluginAPI/include/ccCommandLineInterface.h
+++ b/libs/CCPluginAPI/include/ccCommandLineInterface.h
@@ -1,3 +1,5 @@
+#pragma once
+
 //##########################################################################
 //#                                                                        #
 //#                            CLOUDCOMPARE                                #
@@ -11,12 +13,9 @@
 //#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
 //#  GNU General Public License for more details.                          #
 //#                                                                        #
-//#          COPYRIGHT: CloudCompare project                               #
+//#                   COPYRIGHT: CloudCompare project                      #
 //#                                                                        #
 //##########################################################################
-
-#ifndef CC_COMMAND_LINE_INTERFACE_HEADER
-#define CC_COMMAND_LINE_INTERFACE_HEADER
 
 #include "CCPluginAPI.h"
 
@@ -297,8 +296,11 @@ public: //logging
 
 	//logging
 	virtual void print(const QString& message) const = 0;
+	virtual void printDebug(const QString& message) const = 0;
 	virtual void warning(const QString& message) const = 0;
+	virtual void warningDebug(const QString& message) const = 0;
 	virtual bool error(const QString& message) const = 0; //must always return false!
+	virtual bool errorDebug(const QString& message) const = 0; //must always return false!
 
 public: //access to data
 
@@ -372,5 +374,3 @@ protected: //members
 	//! File loading parameters
 	CLLoadParameters m_loadingParameters;
 };
-
-#endif //CC_COMMAND_LINE_INTERFACE_HEADER

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -6295,27 +6295,28 @@ bool CommandICP::process(ccCommandLineInterface& cmd)
 				QString rotation = cmd.arguments().takeFirst().toUpper();
 				if (rotation == "XYZ")
 				{
-					//keep this to not make breaking changes
+					transformationFilters &= (~CCCoreLib::RegistrationTools::SKIP_ROTATION);
+					cmd.print(QObject::tr("[ICP] Use all rotations"));
 				}
 				else if (rotation == "X")
 				{
 					transformationFilters |= CCCoreLib::RegistrationTools::SKIP_RYZ;
-					cmd.print(QObject::tr("[ICP] Skip RYZ, current filter: %1").arg(transformationFilters));
+					cmd.print(QObject::tr("[ICP] Skip RYZ"));
 				}
 				else if (rotation == "Y")
 				{
 					transformationFilters |= CCCoreLib::RegistrationTools::SKIP_RXZ;
-					cmd.print(QObject::tr("[ICP] Skip RXZ, current filter: %1").arg(transformationFilters));
+					cmd.print(QObject::tr("[ICP] Skip RXZ"));
 				}
 				else if (rotation == "Z")
 				{
 					transformationFilters |= CCCoreLib::RegistrationTools::SKIP_RXY;
-					cmd.print(QObject::tr("[ICP] Skip RXY, current filter: %1").arg(transformationFilters));
+					cmd.print(QObject::tr("[ICP] Skip RXY"));
 				}
 				else if (rotation == "NONE")
 				{
 					transformationFilters |= CCCoreLib::RegistrationTools::SKIP_ROTATION;
-					cmd.print(QObject::tr("[ICP] Skip rotation, current filter: %1").arg(transformationFilters));
+					cmd.print(QObject::tr("[ICP] Skip rotation"));
 				}
 				else
 				{
@@ -6330,21 +6331,21 @@ bool CommandICP::process(ccCommandLineInterface& cmd)
 		else if (ccCommandLineInterface::IsCommand(argument, COMMAND_ICP_SKIP_TX))
 		{
 			transformationFilters |= CCCoreLib::RegistrationTools::SKIP_TX;
-			cmd.print(QObject::tr("[ICP] Skip TX, current filter: %1").arg(transformationFilters));
+			cmd.print(QObject::tr("[ICP] Skip TX"));
 			//local option confirmed, we can move on
 			cmd.arguments().pop_front();
 		}
 		else if (ccCommandLineInterface::IsCommand(argument, COMMAND_ICP_SKIP_TY))
 		{
 			transformationFilters |= CCCoreLib::RegistrationTools::SKIP_TY;
-			cmd.print(QObject::tr("[ICP] Skip TY, current filter: %1").arg(transformationFilters));
+			cmd.print(QObject::tr("[ICP] Skip TY"));
 			//local option confirmed, we can move on
 			cmd.arguments().pop_front();
 		}
 		else if (ccCommandLineInterface::IsCommand(argument, COMMAND_ICP_SKIP_TZ))
 		{
 			transformationFilters |= CCCoreLib::RegistrationTools::SKIP_TZ;
-			cmd.print(QObject::tr("[ICP] Skip TZ, current filter: %1").arg(transformationFilters));
+			cmd.print(QObject::tr("[ICP] Skip TZ"));
 			//local option confirmed, we can move on
 			cmd.arguments().pop_front();
 		}
@@ -6353,6 +6354,8 @@ bool CommandICP::process(ccCommandLineInterface& cmd)
 			break; //as soon as we encounter an unrecognized argument, we break the local loop to go back to the main one!
 		}
 	}
+
+	cmd.printDebug(QObject::tr("[ICP] Transfromation filter: %1").arg(transformationFilters));
 
 	//we'll get the first two entities
 	CLEntityDesc* dataAndModel[2]{ nullptr, nullptr };

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -6293,9 +6293,13 @@ bool CommandICP::process(ccCommandLineInterface& cmd)
 			if (!cmd.arguments().empty())
 			{
 				QString rotation = cmd.arguments().takeFirst().toUpper();
+
+				//invalidate all previous rotations in case -ROT used twice
+				cmd.print(QObject::tr("[ICP] Reset rotation constraints if any. Only one -%1 argument allowed").arg(COMMAND_ICP_ROT));
+				transformationFilters &= (~CCCoreLib::RegistrationTools::SKIP_ROTATION);
+
 				if (rotation == "XYZ")
 				{
-					transformationFilters &= (~CCCoreLib::RegistrationTools::SKIP_ROTATION);
 					cmd.print(QObject::tr("[ICP] Use all rotations"));
 				}
 				else if (rotation == "X")

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -140,6 +140,9 @@ constexpr char COMMAND_ICP_ENABLE_FARTHEST_REMOVAL[]	= "FARTHEST_REMOVAL";
 constexpr char COMMAND_ICP_USE_MODEL_SF_AS_WEIGHT[]		= "MODEL_SF_AS_WEIGHTS";
 constexpr char COMMAND_ICP_USE_DATA_SF_AS_WEIGHT[]		= "DATA_SF_AS_WEIGHTS";
 constexpr char COMMAND_ICP_ROT[]						= "ROT";
+constexpr char COMMAND_ICP_SKIP_TX[]					= "SKIP_TX";
+constexpr char COMMAND_ICP_SKIP_TY[]					= "SKIP_TY";
+constexpr char COMMAND_ICP_SKIP_TZ[]					= "SKIP_TZ";
 constexpr char COMMAND_PLY_EXPORT_FORMAT[]				= "PLY_EXPORT_FMT";
 constexpr char COMMAND_COMPUTE_GRIDDED_NORMALS[]		= "COMPUTE_NORMALS";
 constexpr char COMMAND_INVERT_NORMALS[]					= "INVERT_NORMALS";
@@ -6292,23 +6295,27 @@ bool CommandICP::process(ccCommandLineInterface& cmd)
 				QString rotation = cmd.arguments().takeFirst().toUpper();
 				if (rotation == "XYZ")
 				{
-					transformationFilters = CCCoreLib::RegistrationTools::SKIP_NONE;
+					//keep this to not make breaking changes
 				}
 				else if (rotation == "X")
 				{
-					transformationFilters = CCCoreLib::RegistrationTools::SKIP_RYZ;
+					transformationFilters |= CCCoreLib::RegistrationTools::SKIP_RYZ;
+					cmd.print(QObject::tr("[ICP] Skip RYZ, current filter: %1").arg(transformationFilters));
 				}
 				else if (rotation == "Y")
 				{
-					transformationFilters = CCCoreLib::RegistrationTools::SKIP_RXZ;
+					transformationFilters |= CCCoreLib::RegistrationTools::SKIP_RXZ;
+					cmd.print(QObject::tr("[ICP] Skip RXZ, current filter: %1").arg(transformationFilters));
 				}
 				else if (rotation == "Z")
 				{
-					transformationFilters = CCCoreLib::RegistrationTools::SKIP_RXY;
+					transformationFilters |= CCCoreLib::RegistrationTools::SKIP_RXY;
+					cmd.print(QObject::tr("[ICP] Skip RXY, current filter: %1").arg(transformationFilters));
 				}
 				else if (rotation == "NONE")
 				{
-					transformationFilters = CCCoreLib::RegistrationTools::SKIP_ROTATION;
+					transformationFilters |= CCCoreLib::RegistrationTools::SKIP_ROTATION;
+					cmd.print(QObject::tr("[ICP] Skip rotation, current filter: %1").arg(transformationFilters));
 				}
 				else
 				{
@@ -6319,6 +6326,27 @@ bool CommandICP::process(ccCommandLineInterface& cmd)
 			{
 				return cmd.error(QObject::tr("Missing parameter: rotation filter after \"-%1\" (XYZ/X/Y/Z/NONE)").arg(COMMAND_ICP_ROT));
 			}
+		}
+		else if (ccCommandLineInterface::IsCommand(argument, COMMAND_ICP_SKIP_TX))
+		{
+			transformationFilters |= CCCoreLib::RegistrationTools::SKIP_TX;
+			cmd.print(QObject::tr("[ICP] Skip TX, current filter: %1").arg(transformationFilters));
+			//local option confirmed, we can move on
+			cmd.arguments().pop_front();
+		}
+		else if (ccCommandLineInterface::IsCommand(argument, COMMAND_ICP_SKIP_TY))
+		{
+			transformationFilters |= CCCoreLib::RegistrationTools::SKIP_TY;
+			cmd.print(QObject::tr("[ICP] Skip TY, current filter: %1").arg(transformationFilters));
+			//local option confirmed, we can move on
+			cmd.arguments().pop_front();
+		}
+		else if (ccCommandLineInterface::IsCommand(argument, COMMAND_ICP_SKIP_TZ))
+		{
+			transformationFilters |= CCCoreLib::RegistrationTools::SKIP_TZ;
+			cmd.print(QObject::tr("[ICP] Skip TZ, current filter: %1").arg(transformationFilters));
+			//local option confirmed, we can move on
+			cmd.arguments().pop_front();
 		}
 		else
 		{

--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -41,16 +41,31 @@ void ccCommandLineParser::print(const QString& message) const
 	ccConsole::Print(message);
 }
 
+void ccCommandLineParser::printDebug(const QString& message) const
+{
+	ccConsole::PrintDebug(message);
+}
+
 void ccCommandLineParser::warning(const QString& message) const
 {
 	ccConsole::Warning(message);
-	
+}
+
+void ccCommandLineParser::warningDebug(const QString& message) const
+{
+	ccConsole::WarningDebug(message);
 }
 
 bool ccCommandLineParser::error(const QString& message) const
 {
 	ccConsole::Error(message);
-	
+
+	return false;
+}
+
+bool ccCommandLineParser::errorDebug(const QString& message) const
+{
+	ccConsole::ErrorDebug(message);
 
 	return false;
 }

--- a/qCC/ccCommandLineParser.h
+++ b/qCC/ccCommandLineParser.h
@@ -1,5 +1,21 @@
-#ifndef CC_COMMAND_LINE_PARSER_HEADER
-#define CC_COMMAND_LINE_PARSER_HEADER
+#pragma once
+
+//##########################################################################
+//#                                                                        #
+//#                            CLOUDCOMPARE                                #
+//#                                                                        #
+//#  This program is free software; you can redistribute it and/or modify  #
+//#  it under the terms of the GNU General Public License as published by  #
+//#  the Free Software Foundation; version 2 of the License.               #
+//#                                                                        #
+//#  This program is distributed in the hope that it will be useful,       #
+//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+//#  GNU General Public License for more details.                          #
+//#                                                                        #
+//#                   COPYRIGHT: CloudCompare project                      #
+//#                                                                        #
+//##########################################################################
 
 //interface
 #include "ccCommandLineInterface.h"
@@ -40,8 +56,11 @@ public:
 	bool registerCommand(Command::Shared command) override;
 	QDialog* widgetParent() override { return m_parentWidget; }
 	void print(const QString& message) const override;
+	void printDebug(const QString& message) const override;
 	void warning(const QString& message) const override;
+	void warningDebug(const QString& message) const override;
 	bool error(const QString& message) const override; //must always return false!
+	bool errorDebug(const QString& message) const override; //must always return false!
 	bool saveClouds(QString suffix = QString(), bool allAtOnce = false, const QString* allAtOnceFileName = nullptr) override;
 	bool saveMeshes(QString suffix = QString(), bool allAtOnce = false, const QString* allAtOnceFileName = nullptr) override;
 	bool importFile(QString filename, const GlobalShiftOptions& globalShiftOptions, FileIOFilter::Shared filter = FileIOFilter::Shared(nullptr)) override;
@@ -102,5 +121,3 @@ private: //members
 	//! Widget parent
 	QDialog* m_parentWidget;
 };
-
-#endif


### PR DESCRIPTION
Add suboptions for icp to skip each translation.

-SKIP_TX
-SKIP_TY
-SKIP_TZ

#1898