### PR TITLE
Don't use the omp_set_num_threads command

### DIFF
--- a/libs/CCPluginAPI/include/ccQtHelpers.h
+++ b/libs/CCPluginAPI/include/ccQtHelpers.h
@@ -20,11 +20,6 @@
 #include <QAbstractButton>
 #include <QThread>
 
-#if defined(_OPENMP)
-//OpenMP
-#include <omp.h>
-#endif
-
 class ccQtHelpers
 {
 public:
@@ -64,13 +59,5 @@ public:
 	{
 		return GetMaxThreadCount(QThread::idealThreadCount());
 	}
-
-#if defined(_OPENMP)
-	//! Returns the ideal number of threads/cores with OpenMP
-	static int GetMaxThreadCount_OMP()
-	{
-		return GetMaxThreadCount(omp_get_max_threads());
-	}
-#endif
 
 };

--- a/libs/qCC_db/src/ccClipBox.cpp
+++ b/libs/qCC_db/src/ccClipBox.cpp
@@ -568,8 +568,7 @@ void ccClipBox::flagPointsInside(	ccGenericPointCloud* cloud,
 		ccGLMatrix transMat = m_glTrans.inverse();
 
 #if defined(_OPENMP)
-		omp_set_num_threads(omp_get_max_threads());
-		#pragma omp parallel for
+		#pragma omp parallel for num_threads(omp_get_max_threads())
 #endif
 		for (int i = 0; i < count; ++i)
 		{
@@ -584,8 +583,7 @@ void ccClipBox::flagPointsInside(	ccGenericPointCloud* cloud,
 	else
 	{
 #if defined(_OPENMP)
-		omp_set_num_threads(omp_get_max_threads());
-		#pragma omp parallel for
+		#pragma omp parallel for num_threads(omp_get_max_threads())
 #endif
 		for (int i = 0; i < count; ++i)
 		{

--- a/libs/qCC_db/src/ccGenericMesh.cpp
+++ b/libs/qCC_db/src/ccGenericMesh.cpp
@@ -1082,8 +1082,7 @@ bool ccGenericMesh::trianglePicking(const CCVector2d& clickPos,
 #endif
 
 #if defined(_OPENMP) && !defined(_DEBUG) && !defined(TEST_PICKING)
-	omp_set_num_threads(omp_get_max_threads());
-	#pragma omp parallel for
+	#pragma omp parallel for num_threads(omp_get_max_threads())
 #endif
 	for (int i = 0; i < static_cast<int>(size()); ++i)
 	{

--- a/libs/qCC_db/src/ccGenericPointCloud.cpp
+++ b/libs/qCC_db/src/ccGenericPointCloud.cpp
@@ -420,8 +420,7 @@ bool ccGenericPointCloud::pointPicking(	const CCVector2d& clickPos,
 		tbb::parallel_for( 0, pointCount, [&](int i)
 #else
 #if defined(_OPENMP)
-		omp_set_num_threads(omp_get_max_threads());
-		#pragma omp parallel for
+		#pragma omp parallel for num_threads(omp_get_max_threads())
 #endif
 		for (int i = 0; i < pointCount; ++i)
 #endif

--- a/plugins/core/Standard/qCSF/src/CSF.cpp
+++ b/plugins/core/Standard/qCSF/src/CSF.cpp
@@ -52,6 +52,11 @@
 #include <sstream>
 #include <iostream>
 
+#if defined(_OPENMP)
+//OpenMP
+#include <omp.h>
+#endif
+
 CSF::CSF(wl::PointCloud& cloud, const Parameters& params)
 	: m_pointCloud(cloud)
 	, m_params(params)
@@ -117,7 +122,9 @@ bool CSF::do_filtering(	std::vector<unsigned>& groundIndexes,
 		double squareTimeStep = m_params.time_step * m_params.time_step;
 
 #if defined(_OPENMP)
-        omp_set_num_threads(ccQtHelpers::GetMaxThreadCount_OMP());
+		//save the current max number of threads before changing it
+		int maxThreadCount = omp_get_max_threads();
+        omp_set_num_threads(ccQtHelpers::GetMaxThreadCount(maxThreadCount));
 #endif
 
 		//do the filtering
@@ -161,6 +168,10 @@ bool CSF::do_filtering(	std::vector<unsigned>& groundIndexes,
 
 		if (wasCancelled)
 		{
+#if defined(_OPENMP)
+			//restore the original max number of threads
+			omp_set_num_threads(maxThreadCount);
+#endif
 			return false;
 		}
 
@@ -186,6 +197,11 @@ bool CSF::do_filtering(	std::vector<unsigned>& groundIndexes,
 		{
 			clothMesh = cloth.toMesh();
 		}
+
+#if defined(_OPENMP)
+		//restore the original max number of threads
+		omp_set_num_threads(maxThreadCount);
+#endif
 
 		return result;
 	}

--- a/qCC/ccGraphicalSegmentationTool.cpp
+++ b/qCC/ccGraphicalSegmentationTool.cpp
@@ -967,8 +967,7 @@ void ccGraphicalSegmentationTool::segment(bool keepPointsInside, ScalarType clas
 
 		// we project each point and we check if it falls inside the segmentation polyline
 #if defined(_OPENMP)
-		omp_set_num_threads(omp_get_max_threads());
-#pragma omp parallel for
+#pragma omp parallel for num_threads(omp_get_max_threads())
 #endif
 		for (int i = 0; i < cloudSize; ++i)
 		{


### PR DESCRIPTION
 to avoid changing the max number of threads for the whole application (especially when using less than the maximum number, in which case it will reduce the max number each time).