### PR TITLE
command line SF_OP improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 CloudCompare Version History
 ============================
+v2.14.beta
+----------------------
+- New features:
+	-Command line:
+		* add new option to SF_OP {sf} {operation} {value} -NOT_IN_PLACE, to create new scalar field during the operation
+
+- Improvements:
+	-Command line:
+		* -SF_OP command now supports MIN/DISP_MIN/SAT_MIN/N_SIGMA_MIN/MAX/DISP_MAX/SAT_MAX/N_SIGMA_MAX as value
 
 v2.14.alpha (???) - (??/??/202?)
 ----------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ v2.14.beta
 ----------------------
 - New features:
 	-Command line:
-		* add new option to SF_OP {sf} {operation} {value} -NOT_IN_PLACE, to create new scalar field during the operation
+		* add new option to SF_OP -NOT_IN_PLACE {sf} {operation} {value}, to create new scalar field during the operation.
 
 - Improvements:
 	-Command line:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,5 @@
 CloudCompare Version History
 ============================
-v2.14.beta
-----------------------
-- New features:
-	-Command line:
-		* add new option to SF_OP -NOT_IN_PLACE {sf} {operation} {value}, to create new scalar field during the operation.
-
-- Improvements:
-	-Command line:
-		* -SF_OP command now supports MIN/DISP_MIN/SAT_MIN/N_SIGMA_MIN/MAX/DISP_MAX/SAT_MAX/N_SIGMA_MAX as value
-
 v2.14.alpha (???) - (??/??/202?)
 ----------------------
 
@@ -21,7 +11,7 @@ New Feature:
 		- to improve coloring by applying a color filter
 
 	- New Command line options
-		- New command -FILTER -RGB -SF {-MEAN|-MEDIAN|GAUSSIAN|BILATERAL} -BURNT_COLOR_THRESHOLD {burnt_color_threshold} -BLEND_GRAYSCALE {grayscale_threshold} {grayscale_percent}
+		- New command -FILTER -RGB -SF {-MEAN|-MEDIAN|GAUSSIAN|BILATERAL} -SIGMA {sigma} -SIGMA_SF {sigma_sf} -BURNT_COLOR_THRESHOLD {burnt_color_threshold} -BLEND_GRAYSCALE {grayscale_threshold} {grayscale_percent}
 			- command arguments with a dash can be in any order
 			- -RGB runs the filter on color
 			- -SF runs the filter on the active scalar field
@@ -43,8 +33,19 @@ New Feature:
 				- {grayscale_percent} is an integer between 0 and 100 to decide when to consider colors as grayscale instead of RGB
 				- optional
 				- only used when the filter is applied to RGB colors
+			- -SIGMA {sigma}
+					- optional
+					- nearest neighbours calculated with a radius of 3*sigma, if not set cloud compare will calculate a default value.
+			- -SIGMA_SF {sigma_sf}
+					- optional, only used when bilateral filter applied
+		- New option to SF_OP -NOT_IN_PLACE {sf} {operation} {value}, to create new scalar field during the operation.
 
-v2.13.1 (Kharkiv) - (03/20/2024)
+Improvements:
+	- Command line:
+		- -SF_OP command now supports MIN/DISP_MIN/SAT_MIN/N_SIGMA_MIN/MAX/DISP_MAX/SAT_MAX/N_SIGMA_MAX as value
+		- Rename -CSF command's result clouds to be able to select them later.
+
+		v2.13.1 (Kharkiv) - (03/20/2024)
 ----------------------
 Improvements:
 	- the Facets plugin will now retain the Global Shift information when extracting facets, and the 'Global center' will

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,17 +35,20 @@ New Feature:
 				- only used when the filter is applied to RGB colors
 			- -SIGMA {sigma}
 					- optional
-					- nearest neighbours calculated with a radius of 3*sigma, if not set cloud compare will calculate a default value.
+					- nearest neighbours extracted with a radius of 3*sigma. If not set, CloudCompare will calculate a default value.
 			- -SIGMA_SF {sigma_sf}
 					- optional, only used when bilateral filter applied
-		- New option to SF_OP -NOT_IN_PLACE {sf} {operation} {value}, to create new scalar field during the operation.
+		- New SF_OP suboption: -NOT_IN_PLACE
+			- to create new scalar field during the operation.
 
 Improvements:
 	- Command line:
-		- -SF_OP command now supports MIN/DISP_MIN/SAT_MIN/N_SIGMA_MIN/MAX/DISP_MAX/SAT_MAX/N_SIGMA_MAX as value
-		- Rename -CSF command's result clouds to be able to select them later.
+		- the -SF_OP command now supports MIN/DISP_MIN/SAT_MIN/N_SIGMA_MIN/MAX/DISP_MAX/SAT_MAX/N_SIGMA_MAX as input values
+		- Rename -CSF command's resulting clouds to be able to select them later:
+			- {original cloud name} + '_ground_points'
+			- {original cloud name} + '_offground_points'
 
-		v2.13.1 (Kharkiv) - (03/20/2024)
+v2.13.1 (Kharkiv) - (03/20/2024)
 ----------------------
 Improvements:
 	- the Facets plugin will now retain the Global Shift information when extracting facets, and the 'Global center' will

--- a/plugins/core/Standard/qCSF/include/qCSFCommands.h
+++ b/plugins/core/Standard/qCSF/include/qCSFCommands.h
@@ -202,6 +202,7 @@ struct CommandCSF : public ccCommandLineInterface::Command
 			//store ground subset
 			if (groundCloud)
 			{
+				groundCloud->setName(desc.basename + QString("_ground_points"));
 				//add cloud to the pool of new clouds
 				CLCloudDesc groundDesc(groundCloud, desc.basename + QString("_ground_points"), desc.path, -1);
 				newClouds.push_back(groundDesc);
@@ -219,6 +220,7 @@ struct CommandCSF : public ccCommandLineInterface::Command
 			//store off-ground subset
 			if (offGroundCloud)
 			{
+				offGroundCloud->setName(desc.basename + QString("_offground_points"));
 				CLCloudDesc offgroundDesc(offGroundCloud, desc.basename + QString("_offground_points"), desc.path, -1);
 				newClouds.push_back(offgroundDesc);
 				if (exportOffground)

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -5885,7 +5885,6 @@ CommandSFOperation::CommandSFOperation()
 
 bool CommandSFOperation::process(ccCommandLineInterface& cmd)
 {
-
 	//in place modifier, to keep old commands intact we should keep it in place by default. However it makes the command line inconsistent, because the SF_ARITHMETIC works the other way.
 	bool inPlace = true;
 	if (!cmd.arguments().empty())


### PR DESCRIPTION
 1. -SF_OP command now supports MIN/DISP_MIN/SAT_MIN/N_SIGMA_MIN/MAX/DISP_MAX/SAT_MAX/N_SIGMA_MAX as value
 2. add new option to SF_OP {sf} {operation} {value} -NOT_IN_PLACE, to create new scalar field during the operation

reference:
https://www.cloudcompare.org/forum/viewtopic.php?f=9&t=6784