### PR TITLE
Update LasDetails.cpp

### DIFF
--- a/plugins/core/IO/qLASIO/src/LasDetails.cpp
+++ b/plugins/core/IO/qLASIO/src/LasDetails.cpp
@@ -264,8 +264,8 @@ namespace LasDetails
 		{
 			bool hasGpsTime   = cloud.getScalarFieldIndexByName(LasNames::GpsTime) != -1;
 			int  pointFormat  = 0;
-			int  minorVersion = 2;
-			if (hasWaveform || previousMinorVersion >= 3)
+			int  minorVersion = previousMinorVersion == 3 ? 3 : 2;
+			if (hasWaveform)
 			{
 				minorVersion = 3;
 				pointFormat = 4;

--- a/plugins/core/IO/qLASIO/src/LasDetails.cpp
+++ b/plugins/core/IO/qLASIO/src/LasDetails.cpp
@@ -268,11 +268,8 @@ namespace LasDetails
 			if (hasWaveform || previousMinorVersion >= 3)
 			{
 				minorVersion = 3;
-				if (hasGpsTime)
-				{
-					pointFormat = 4;
-				}
-				else if (hasRGB)
+				pointFormat = 4;
+				if (hasRGB)
 				{
 					pointFormat = 5;
 				}


### PR DESCRIPTION
The smallest valid point format value is 4 for a cloud with waveforms. The dialog may be wrongly initialized with a point format of 0 if this is not taken into account. In command line this could result in missing waveforms when saving.