### PR TITLE
Substantially improve speed of cloud merge operation

### DIFF
--- a/libs/qCC_db/include/ccPointCloud.h
+++ b/libs/qCC_db/include/ccPointCloud.h
@@ -792,9 +792,10 @@ public: //other methods
 		\param cloud cloud to be added
 		\param pointCountBefore the number of points previously contained in this cloud
 		\param ignoreChildren whether to copy input cloud's children or not
+		\param recomputeMinAndMax whether to compute min and max of scalar fields after append or not
 		\return the resulting point cloud
 	**/
-	const ccPointCloud& append(ccPointCloud* cloud, unsigned pointCountBefore, bool ignoreChildren = false);
+	const ccPointCloud& append(ccPointCloud* cloud, unsigned pointCountBefore, bool ignoreChildren = false, bool recomputeMinAndMax = true);
 
 	//! Enhances the RGB colors with the current scalar field (assuming it's intensities)
 	bool enhanceRGBWithIntensitySF(int sfIdx, bool useCustomIntensityRange = false, double minI = 0.0, double maxI = 1.0);

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -907,9 +907,19 @@ const ccPointCloud& ccPointCloud::append(ccPointCloud* addedCloud, unsigned poin
 					if (sameSF->currentSize() == pointCountBefore)
 					{
 						double shift = sf->getGlobalShift() - sameSF->getGlobalShift();
-						for (unsigned i = 0; i < addedPoints; i++)
+						if (shift != 0) //avoid re-casting unless necessary
 						{
-							sameSF->addElement(static_cast<ScalarType>(shift + sf->getValue(i))); //FIXME: we could have accuracy issues here
+							for (unsigned i = 0; i < addedPoints; i++)
+							{
+								sameSF->addElement(static_cast<ScalarType>(shift + sf->getValue(i))); //FIXME: we could have accuracy issues here
+							}
+						}
+						else
+						{
+							for (unsigned i = 0; i < addedPoints; i++)
+							{
+								sameSF->addElement(sf->getValue(i));
+							}
 						}
 					}
 					if (recomputeMinAndMax)

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -602,7 +602,7 @@ const ccPointCloud& ccPointCloud::operator +=(ccPointCloud* addedCloud)
 	return append(addedCloud, size());
 }
 
-const ccPointCloud& ccPointCloud::append(ccPointCloud* addedCloud, unsigned pointCountBefore, bool ignoreChildren/*=false*/)
+const ccPointCloud& ccPointCloud::append(ccPointCloud* addedCloud, unsigned pointCountBefore, bool ignoreChildren/*=false*/, bool recomputeMinAndMax/*=true*/)
 {
 	//Clears the LOD structure (and potentially stop its construction)
 	clearLOD();
@@ -912,7 +912,10 @@ const ccPointCloud& ccPointCloud::append(ccPointCloud* addedCloud, unsigned poin
 							sameSF->addElement(static_cast<ScalarType>(shift + sf->getValue(i))); //FIXME: we could have accuracy issues here
 						}
 					}
-					sameSF->computeMinAndMax();
+					if (recomputeMinAndMax)
+					{
+						sameSF->computeMinAndMax();
+					}
 
 					//flag this SF as 'updated'
 					assert(sfIdx < static_cast<int>(sfCount));
@@ -930,7 +933,10 @@ const ccPointCloud& ccPointCloud::append(ccPointCloud* addedCloud, unsigned poin
 						{
 							newSF->setValue(pointCountBefore + i, sf->getValue(i));
 						}
-						newSF->computeMinAndMax();
+						if (recomputeMinAndMax)
+						{
+							newSF->computeMinAndMax();
+						}
 						//copy display parameters
 						newSF->importParametersFrom(sf);
 

--- a/libs/qCC_db/src/ccScalarField.cpp
+++ b/libs/qCC_db/src/ccScalarField.cpp
@@ -205,7 +205,7 @@ void ccScalarField::computeMinAndMax()
 
 						if (ValidValue(val))
 						{
-							unsigned bin = static_cast<unsigned>(floor(static_cast<double>(val - m_displayRange.min())*step));
+							unsigned bin = static_cast<unsigned>((val - m_displayRange.min())*step);
 							++m_histogram[std::min(bin, numberOfClasses - 1)];
 						}
 					}

--- a/libs/qCC_db/src/ccScalarField.cpp
+++ b/libs/qCC_db/src/ccScalarField.cpp
@@ -151,7 +151,7 @@ void ccScalarField::setLogScale(bool state)
 	if (m_logScale != state)
 	{
 		m_logScale = state;
-		if (m_logScale && m_minVal < 0)
+		if (m_logScale && getMin() < 0)
 		{
 			ccLog::Warning("[ccScalarField] Scalar field contains negative values! Log scale will only consider absolute values...");
 		}
@@ -164,7 +164,7 @@ void ccScalarField::computeMinAndMax()
 {
 	ScalarField::computeMinAndMax();
 
-	m_displayRange.setBounds(m_minVal, m_maxVal);
+	m_displayRange.setBounds(getMin(), getMax());
 
 	//update histogram
 	{
@@ -226,8 +226,8 @@ void ccScalarField::updateSaturationBounds()
 {
 	if (!m_colorScale || m_colorScale->isRelative()) //Relative scale (default)
 	{
-		ScalarType minAbsVal = (m_maxVal < 0 ? std::min(-m_maxVal, -m_minVal) : std::max<ScalarType>(m_minVal, 0));
-		ScalarType maxAbsVal = std::max(std::abs(m_minVal), std::abs(m_maxVal));
+		ScalarType minAbsVal = (getMax() < 0 ? std::min(-getMax(), -getMin()) : std::max<ScalarType>(getMin(), 0));
+		ScalarType maxAbsVal = std::max(std::abs(getMin()), std::abs(getMax()));
 
 		if (m_symmetricalScale)
 		{
@@ -235,7 +235,7 @@ void ccScalarField::updateSaturationBounds()
 		}
 		else
 		{
-			m_saturationRange.setBounds(m_minVal,m_maxVal);
+			m_saturationRange.setBounds(getMin(),getMax());
 		}
 
 		//log scale (we always update it even if m_logScale is not enabled!)

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -3574,6 +3574,13 @@ void MainWindow::doActionMerge()
 		CCCoreLib::ScalarField* ocIndexSF = nullptr;
 		size_t cloudIndex = 0;
 
+		//compute total size of the final cloud
+		unsigned totalSize = 0;
+		for (size_t i = 0; i < clouds.size(); ++i)
+		{
+			totalSize += clouds[i]->size();
+		}
+
 		for (size_t i = 0; i < clouds.size(); ++i)
 		{
 			ccPointCloud* pc = clouds[i];
@@ -3584,6 +3591,13 @@ void MainWindow::doActionMerge()
 				//we still have to temporarily detach the first cloud, as it may undergo
 				//'severe' modifications (octree deletion, etc.) --> see ccPointCloud::operator +=
 				firstCloudContext = removeObjectTemporarilyFromDBTree(firstCloud);
+
+				//reserve the final required number of points
+				if (!firstCloud->reserve(totalSize))
+				{
+					ccConsole::Error(tr("Not enough memory!"));
+					break;
+				}
 
 				if (QMessageBox::question(this, tr("Original cloud index"), tr("Do you want to generate a scalar field with the original cloud index?")) == QMessageBox::Yes)
 				{

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -3609,7 +3609,7 @@ void MainWindow::doActionMerge()
 			{
 				unsigned countBefore = firstCloud->size();
 				unsigned countAdded = pc->size();
-				*firstCloud += pc;
+				firstCloud->append(pc, countBefore, false, false); //append without recalculating SF min/max
 
 				//success?
 				if (firstCloud->size() == countBefore + countAdded)
@@ -3644,9 +3644,17 @@ void MainWindow::doActionMerge()
 			}
 		}
 
+		//compute min and max once after all appends are done
+		if (firstCloud)
+		{
+			for (size_t i = 0; i<firstCloud->getNumberOfScalarFields(); i++)
+			{
+				firstCloud->getScalarField(i)->computeMinAndMax();
+			}
+		}
+
 		if (ocIndexSF)
 		{
-			ocIndexSF->computeMinAndMax();
 			firstCloud->showSF(true);
 		}
 


### PR DESCRIPTION
Improves the speed of merging 25 clouds with 6M points each and 7 scalar fields from over 2 minutes to under 10 seconds, an order of magnitude improvement.

Please see commit messages for details.