### PR TITLE
ccScalarField: remove redundant computeMinAndMax during loading

### DIFF
--- a/libs/qCC_db/src/ccScalarField.cpp
+++ b/libs/qCC_db/src/ccScalarField.cpp
@@ -457,8 +457,6 @@ bool ccScalarField::fromFile(QFile& in, short dataVersion, int flags, LoadedIDMa
 		}
 	}
 
-	computeMinAndMax();
-
 	//displayed values & saturation boundaries (dataVersion>=20)
 	double minDisplayed = 0;
 	if (in.read((char*)&minDisplayed, sizeof(double)) < 0)


### PR DESCRIPTION
Improves speed of loading .bin files. A 7GB file is reduced from 13 to 8 seconds.

I have not exhaustively tested that the subsequent code is okay not having those values but it looks okay after some examination. I encourage you to look closely.