### PR TITLE
Update Continuous Integration

### DIFF
--- a/.ci/conda-macos.yml
+++ b/.ci/conda-macos.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - eigen=3.4.*
   - ninja
-  - pcl=1.14.*
+  #- pcl=1.14.*
   - qt=5.15.*
   - xerces-c=3.2.*
   - zlib=1.2.*

--- a/.ci/conda-macos.yml
+++ b/.ci/conda-macos.yml
@@ -1,0 +1,11 @@
+name: CloudCompareDev
+channels:
+  - conda-forge
+dependencies:
+  - eigen=3.4.*
+  - ninja
+  - pcl=1.14.*
+  - qt=5.15.*
+  - xerces-c=3.2.*
+  - zlib=1.2.*
+  - laszip

--- a/.ci/conda-win.yml
+++ b/.ci/conda-win.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - eigen=3.4.*
-  - ffmpeg=6.1.*
+  - ffmpeg=4.2.*
   - ninja
   - pcl=1.14.*
   - qt=5.15.*

--- a/.ci/conda-win.yml
+++ b/.ci/conda-win.yml
@@ -5,7 +5,7 @@ dependencies:
   - eigen=3.4.*
   - ffmpeg=4.2.*
   - ninja
-  - pcl=1.14.*
+  #- pcl=1.14.*
   - qt=5.15.*
   - xerces-c=3.2.*
   - zlib=1.2.*

--- a/.ci/conda.yml
+++ b/.ci/conda.yml
@@ -2,12 +2,11 @@ name: CloudCompareDev
 channels:
   - conda-forge
 dependencies:
-  - eigen=3.3.*
-  - ffmpeg=4.2.*
+  - eigen=3.4.*
+  - ffmpeg=6.1.*
   - ninja
-  - pcl=1.9.*
-  - pdal=2.1.*
-  - qt=5.12.*
+  - pcl=1.14.*
+  - qt=5.15.*
   - xerces-c=3.2.*
   - zlib=1.2.*
   - laszip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
 
   ubuntu-build:
     name: Ubuntu ${{ matrix.compiler }} SCALAR_DOUBLE=${{ matrix.scalar_double }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
     strategy:
@@ -144,7 +144,7 @@ jobs:
           sudo apt-get update -qq
 
           sudo apt-get install -qy cmake ninja-build
-          libqt5svg5-dev libqt5opengl5-dev qt5-default qttools5-dev qttools5-dev-tools libqt5websockets5-dev
+          libqt5svg5-dev libqt5opengl5-dev qtbase5-dev qttools5-dev qttools5-dev-tools libqt5websockets5-dev
           libtbb-dev
           libavcodec-dev libavformat-dev libavutil-dev libswscale-dev
           libboost-program-options-dev libboost-thread-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,15 +48,11 @@ jobs:
       - name: Install Dependencies
         uses: conda-incubator/setup-miniconda@v3
         with:
-          architecture: arm64
+          architecture: ${{ matrix.config.os == 'macos-latest' && 'arm64' || 'x64' }}
           activate-environment: CloudCompareDev
           auto-activate-base: false
           environment-file: .ci/conda.yml
           miniconda-version: 'latest'
-
-      - name: Install Dependencies (macOS)
-        if: matrix.config.os == 'macos-latest'
-        run: brew install xerces-c
 
       - name: Configure MSVC console (Windows)
         if: matrix.config.os == 'windows-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
             -DPLUGIN_IO_QE57=ON \
             -DPLUGIN_IO_QPHOTOSCAN=ON \
             -DPLUGIN_IO_QLAS=ON \
-            -DPLUGIN_IO_QRDB=ON \
+            -DPLUGIN_IO_QRDB=OFF \
             -DPLUGIN_IO_QRDB_FETCH_DEPENDENCY=ON \
             -DPLUGIN_IO_QRDB_INSTALL_DEPENDENCY=ON \
             -DPLUGIN_STANDARD_QANIMATION=ON \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,26 +44,11 @@ jobs:
         with:
           node-version: '16'
 
-      # Turn off for now since GitHub Actions is broken (will eventually move to brew anyways)
-      # - name: Conda Cache (macOS)
-      #   if:  matrix.config.os == 'macos-latest'
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: /Users/runner/miniconda3/envs/CloudCompareDev
-      #     key: conda-cache-${{ runner.os }}-${{ hashFiles('.ci/conda.yml') }}
-
-      # DGM: caching conda doesn't seem to work properly anymore
-      #- name: Conda Cache (Windows)
-      #  if: matrix.config.os == 'windows-latest'
-      #  uses: actions/cache@v3
-      #  with:
-      #    path: C:\Miniconda3\envs\CloudCompareDev
-      #    key: conda-cache-${{ runner.os }}-${{ hashFiles('.ci/conda.yml') }}
-
       # DGM: without caching, using conda on Windows takes a long time...
       - name: Install Dependencies
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
+          architecture: arm64
           activate-environment: CloudCompareDev
           auto-activate-base: false
           environment-file: .ci/conda.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
           activate-environment: CloudCompareDev
           auto-activate-base: false
           environment-file: .ci/conda.yml
-          miniconda-version: 'latest'
+          mamba-version: "*"
 
       - name: Configure MSVC console (Windows)
         if: matrix.config.os == 'windows-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
             compile_qanimation_with_ffmpeg: "ON",
             compile_qpcl: "OFF",
             compile_qransac: "ON",
+            compile_riegl: "ON",
+            conda_dep_file: ".ci/conda-win.yml"
           }
           - {
             name: "macOS Clang",
@@ -30,6 +32,8 @@ jobs:
             compile_qanimation_with_ffmpeg: "OFF",
             compile_qpcl: "OFF",
             compile_qransac: "ON",
+            compile_riegl: "OFF",
+            conda_dep_file: ".ci/conda-macos.yml"
           }
 
     steps:
@@ -38,12 +42,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup (Windows)
-        if: matrix.config.os == 'windows-latest'
-        uses: actions/setup-node@v3
-        with:
-          node-version: '16'
-
       # DGM: without caching, using conda on Windows takes a long time...
       - name: Install Dependencies
         uses: conda-incubator/setup-miniconda@v3
@@ -51,7 +49,7 @@ jobs:
           architecture: ${{ matrix.config.os == 'macos-latest' && 'arm64' || 'x64' }}
           activate-environment: CloudCompareDev
           auto-activate-base: false
-          environment-file: .ci/conda.yml
+          environment-file: ${{ matrix.config.conda_dep_file }}
           mamba-version: "*"
 
       - name: Configure MSVC console (Windows)
@@ -92,9 +90,9 @@ jobs:
             -DPLUGIN_IO_QE57=ON \
             -DPLUGIN_IO_QPHOTOSCAN=ON \
             -DPLUGIN_IO_QLAS=ON \
-            -DPLUGIN_IO_QRDB=OFF \
-            -DPLUGIN_IO_QRDB_FETCH_DEPENDENCY=ON \
-            -DPLUGIN_IO_QRDB_INSTALL_DEPENDENCY=ON \
+            -DPLUGIN_IO_QRDB=${{ matrix.config.compile_riegl }}  \
+            -DPLUGIN_IO_QRDB_FETCH_DEPENDENCY=${{ matrix.config.compile_riegl }}  \
+            -DPLUGIN_IO_QRDB_INSTALL_DEPENDENCY=${{ matrix.config.compile_riegl }}  \
             -DPLUGIN_STANDARD_QANIMATION=ON \
             -DQANIMATION_WITH_FFMPEG_SUPPORT=${{ matrix.config.compile_qanimation_with_ffmpeg }} \
             -DPLUGIN_STANDARD_QBROOM=ON \


### PR DESCRIPTION
update CI builds following the migration of macos-latest runner to macos-14 image (and thus to apple silicon).
- Migrate build to qt 5.15.x for all system (should generate a lot of warning before we finished and merge [this branch](https://github.com/CloudCompare/CloudCompare/tree/qt_deprecation_warnings))
- Remove `riegl` support build from macOS build (no reign binaries available for Apple Silicon)
- Remove a bunch of dead declarations in the yml file
- Migrate conda dep management to `mamba` (should improve a bit the speed of dependency setup on windows and macOS) 