### PR TITLE
macOS: remove automatic launch of postinsall scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,9 @@ endif()
 # Default debug suffix for libraries.
 set( CMAKE_DEBUG_POSTFIX "d" )
 
-
 # Define target folders
 # (now that ccViewer can have its own plugins, qCC and ccViewer must fall in separate folders!
-if(WIN32 OR APPLE) 
+if(WIN32 OR APPLE)
 	set( CLOUDCOMPARE_DEST_FOLDER CloudCompare )
 	set( CCVIEWER_DEST_FOLDER ccViewer )
 else()
@@ -42,7 +41,7 @@ endif()
 
 if( WIN32 )
     set( INSTALL_DESTINATIONS ${CLOUDCOMPARE_DEST_FOLDER} )
-    
+
     if( ${OPTION_BUILD_CCVIEWER} )
         list( APPEND INSTALL_DESTINATIONS ${CCVIEWER_DEST_FOLDER} )
 	endif()

--- a/postInstall/CMakeLists.txt
+++ b/postInstall/CMakeLists.txt
@@ -1,5 +1,4 @@
 if( APPLE )
     configure_file(libBundleCloudCompare.py.in libBundleCloudCompare.py)
     configure_file(signatureCloudCompare.sh.in signatureCloudCompare.sh @ONLY )
-    install( SCRIPT postInstall.cmake )
 endif()

--- a/postInstall/postInstall.cmake
+++ b/postInstall/postInstall.cmake
@@ -1,7 +1,0 @@
-message( STATUS "post install process ...")
-execute_process( COMMAND pwd )
-message( STATUS "add libraries to bundle ...")
-execute_process( COMMAND python postInstall/libBundleCloudCompare.py )
-message( STATUS "signature ...")
-execute_process( COMMAND bash postInstall/signatureCloudCompare.sh )
-message( STATUS "... Done")


### PR DESCRIPTION
As discussed with @prascle, it's better to avoid to launch these scripts after each compilation, most user won't need this and scripts are environment specific (conda).

Moreover, there is a possibility cmake won't find them anyway (using out of build dir build invocation i.e `cmake --build build_dir`)

Script are still generated at cmake configuration phase, but now it's up to the user to launch them.