### PR TITLE
LAS: assign by default scalar fields to extra LAS dim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,11 +46,18 @@ New Feature:
 		- it can then be restored via the 'Display > Display options' menu entry
 
 Improvements:
+
 	- Command line:
 		- the -SF_OP command now supports MIN/DISP_MIN/SAT_MIN/N_SIGMA_MIN/MAX/DISP_MAX/SAT_MAX/N_SIGMA_MAX as input values
 		- Rename -CSF command's resulting clouds to be able to select them later:
 			- {original cloud name} + '_ground_points'
 			- {original cloud name} + '_offground_points'
+
+	- LAS file saving dialog
+		- CC will now automatically assign scalar fields with non 'LAS-standard' names to Extra fields (VLRs)
+		- if the 'Save remaining scalar fields as Extra fields / VLRs' checkbox is checked (default state),
+			some entries are automatically created in the 3rd tab (Extra fields / VLRs). This is updated automatically
+			if the point format is changed.
 
 Bug fixes:
 	- Editing the Global Shift & Scale information of a polyline would make CC crash

--- a/plugins/core/IO/qLASIO/include/LasDetails.h
+++ b/plugins/core/IO/qLASIO/include/LasDetails.h
@@ -162,7 +162,7 @@ namespace LasDetails
 	/// If the version does not exists or is not supported a nullptr is returned.
 	///
 	/// \param version version string, must be "major.minor" e.g. "1.2"
-	const std::vector<unsigned>* PointFormatsAvailableForVersion(QString version);
+	const std::vector<unsigned>& PointFormatsAvailableForVersion(const QString& version);
 
 	const std::array<const char*, 3>& AvailableVersions();
 

--- a/plugins/core/IO/qLASIO/include/LasExtraScalarFieldCard.h
+++ b/plugins/core/IO/qLASIO/include/LasExtraScalarFieldCard.h
@@ -45,17 +45,17 @@ class LasExtraScalarFieldCard : public QWidget
 	/// Returns `true` on success, `false` on failure.
 	bool fillField(LasExtraScalarField& field, const ccPointCloud& pointCloud) const;
 
-	bool isDefault() const
+	inline bool isDefault() const
 	{
 		return !unlockModificationsButton->isHidden();
 	};
 
 	/// Returns true if this card maps the field with the name
-	bool mapsFieldWithName(const char* sfName);
+	bool mapsFieldWithName(const char* sfName) const;
 
   private:
-	//! Struct to aggregate together the user input related
-	//! to one dimension of an extra scalar field definition.
+	/// Struct to aggregate together the user input related
+	/// to one dimension of an extra scalar field definition.
 	struct ScalarFieldUserInputs
 	{
 		QComboBox*      scalarFieldComboBox{nullptr};

--- a/plugins/core/IO/qLASIO/include/LasExtraScalarFieldCard.h
+++ b/plugins/core/IO/qLASIO/include/LasExtraScalarFieldCard.h
@@ -1,21 +1,21 @@
 #pragma once
 
-//##########################################################################
-//#                                                                        #
-//#                CLOUDCOMPARE PLUGIN: LAS-IO Plugin                      #
-//#                                                                        #
-//#  This program is free software; you can redistribute it and/or modify  #
-//#  it under the terms of the GNU General Public License as published by  #
-//#  the Free Software Foundation; version 2 of the License.               #
-//#                                                                        #
-//#  This program is distributed in the hope that it will be useful,       #
-//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
-//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
-//#  GNU General Public License for more details.                          #
-//#                                                                        #
-//#                   COPYRIGHT: Thomas Montaigu                           #
-//#                                                                        #
-//##########################################################################
+// ##########################################################################
+// #                                                                        #
+// #                CLOUDCOMPARE PLUGIN: LAS-IO Plugin                      #
+// #                                                                        #
+// #  This program is free software; you can redistribute it and/or modify  #
+// #  it under the terms of the GNU General Public License as published by  #
+// #  the Free Software Foundation; version 2 of the License.               #
+// #                                                                        #
+// #  This program is distributed in the hope that it will be useful,       #
+// #  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+// #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+// #  GNU General Public License for more details.                          #
+// #                                                                        #
+// #                   COPYRIGHT: Thomas Montaigu                           #
+// #                                                                        #
+// ##########################################################################
 
 #include "LasExtraScalarField.h"
 #include "ui_extra_scarlar_field_card.h"
@@ -28,13 +28,30 @@ class LasExtraScalarFieldCard : public QWidget
   public:
 	explicit LasExtraScalarFieldCard(QWidget* parent = nullptr);
 
+	/// Fills the card info from the given input field
+	///
+	/// A card filled using this method is considered as being non-default
 	void fillFrom(const LasExtraScalarField& field);
+
+	void fillAsDefault(const char* sfName);
 
 	void reset();
 
 	LasExtraScalarField::DataType dataType() const;
 
+	/// Fills the `field` with the info the card contains
+	///
+	/// This includes linking the scalar field from the pointCloud to to the field.
+	/// Returns `true` on success, `false` on failure.
 	bool fillField(LasExtraScalarField& field, const ccPointCloud& pointCloud) const;
+
+	bool isDefault() const
+	{
+		return !unlockModificationsButton->isHidden();
+	};
+
+	/// Returns true if this card maps the field with the name
+	bool mapsFieldWithName(const char* sfName);
 
   private:
 	//! Struct to aggregate together the user input related
@@ -50,9 +67,12 @@ class LasExtraScalarFieldCard : public QWidget
 	void onRadioButton1Selected(bool);
 	void onRadioButton2Selected(bool);
 	void onRadioButton3Selected(bool);
+	void onUnlockModifications();
 
 	void onToggleAdvancedOptionsClicked();
 
   private:
 	ScalarFieldUserInputs m_scalarFieldsUserInputs[LasExtraScalarField::MAX_DIM_SIZE];
+
+	LasExtraScalarField::DimensionSize dimensionSize() const;
 };

--- a/plugins/core/IO/qLASIO/include/LasSaveDialog.h
+++ b/plugins/core/IO/qLASIO/include/LasSaveDialog.h
@@ -1,21 +1,21 @@
 #pragma once
 
-//##########################################################################
-//#                                                                        #
-//#                CLOUDCOMPARE PLUGIN: LAS-IO Plugin                      #
-//#                                                                        #
-//#  This program is free software; you can redistribute it and/or modify  #
-//#  it under the terms of the GNU General Public License as published by  #
-//#  the Free Software Foundation; version 2 of the License.               #
-//#                                                                        #
-//#  This program is distributed in the hope that it will be useful,       #
-//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
-//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
-//#  GNU General Public License for more details.                          #
-//#                                                                        #
-//#                   COPYRIGHT: Thomas Montaigu                           #
-//#                                                                        #
-//##########################################################################
+// ##########################################################################
+// #                                                                        #
+// #                CLOUDCOMPARE PLUGIN: LAS-IO Plugin                      #
+// #                                                                        #
+// #  This program is free software; you can redistribute it and/or modify  #
+// #  it under the terms of the GNU General Public License as published by  #
+// #  the Free Software Foundation; version 2 of the License.               #
+// #                                                                        #
+// #  This program is distributed in the hope that it will be useful,       #
+// #  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+// #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+// #  GNU General Public License for more details.                          #
+// #                                                                        #
+// #                   COPYRIGHT: Thomas Montaigu                           #
+// #                                                                        #
+// ##########################################################################
 
 #include "LasDetails.h"
 #include "LasExtraScalarField.h"
@@ -74,14 +74,23 @@ class LasSaveDialog : public QDialog
 	std::vector<LasExtraScalarField> extraFieldsToSave() const;
 
   public Q_SLOTS:
-	void handleSelectedVersionChange(const QString&);
-	void handleSelectedPointFormatChange(int index);
-	void handleComboBoxChange(int index);
-	void handleCustomScaleButtontoggled(bool checked);
-	void addExtraScalarFieldCard();
+	void                     handleSelectedVersionChange(const QString&);
+	void                     handleSelectedPointFormatChange(int index);
+	void                     handleComboBoxChange(int index);
+	void                     handleCustomScaleButtontoggled(bool checked);
+	LasExtraScalarFieldCard* addExtraScalarFieldCard();
 
   private:
 	LasExtraScalarFieldCard* createCard() const;
+	/// This will scan the scalar fields from the point cloud
+	/// and create a default scalar field extra card if the field is
+	/// neither selected as a standard field nor as a extra field.
+	void assignLeftOverFieldsAsExtra();
+	void unassignDefaultFields();
+	bool shouldAutomaticallyAssignLeftOverFieldsAsExtra() const
+	{
+		return leftOverFieldsAsExtraCheckBox->isChecked();
+	}
 
   private:
 	ccPointCloud* m_cloud{nullptr};

--- a/plugins/core/IO/qLASIO/include/LasSaveDialog.h
+++ b/plugins/core/IO/qLASIO/include/LasSaveDialog.h
@@ -82,15 +82,12 @@ class LasSaveDialog : public QDialog
 
   private:
 	LasExtraScalarFieldCard* createCard() const;
-	/// This will scan the scalar fields from the point cloud
+	/// This will scan the the point cloud scalar fields
 	/// and create a default scalar field extra card if the field is
-	/// neither selected as a standard field nor as a extra field.
-	void assignLeftOverFieldsAsExtra();
+	/// neither selected as a standard field nor as an extra field.
+	void assignLeftoverScalarFieldsAsExtra();
 	void unassignDefaultFields();
-	bool shouldAutomaticallyAssignLeftOverFieldsAsExtra() const
-	{
-		return leftOverFieldsAsExtraCheckBox->isChecked();
-	}
+	bool shouldAutomaticallyAssignLeftoverSFsAsExtra() const;
 
   private:
 	ccPointCloud* m_cloud{nullptr};

--- a/plugins/core/IO/qLASIO/src/LasDetails.cpp
+++ b/plugins/core/IO/qLASIO/src/LasDetails.cpp
@@ -31,10 +31,10 @@
 #include <cstring>
 #include <stdexcept>
 
-static const std::vector<unsigned>      PointFormatForV1_2 = {0, 1, 2, 3};
-static const std::vector<unsigned>      PointFormatForV1_3 = {0, 1, 2, 3, 4, 5};
-static const std::vector<unsigned>      PointFormatForV1_4 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-static const std::array<const char*, 3> VersionsArray      = {"1.2", "1.3", "1.4"};
+static const std::vector<unsigned>      PointFormatForV1_2{0, 1, 2, 3};
+static const std::vector<unsigned>      PointFormatForV1_3{0, 1, 2, 3, 4, 5};
+static const std::vector<unsigned>      PointFormatForV1_4{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+static const std::array<const char*, 3> VersionsArray{"1.2", "1.3", "1.4"};
 
 namespace LasDetails
 {
@@ -158,26 +158,27 @@ namespace LasDetails
 		                       { return vlr.record_length_after_header + header_size + size; });
 	}
 
-	const std::vector<unsigned>* PointFormatsAvailableForVersion(QString version)
+	const std::vector<unsigned>& PointFormatsAvailableForVersion(const QString& version)
 	{
 		if (version.size() == 3 && version.startsWith("1."))
 		{
 			if (version[2] == '2')
 			{
-				return &PointFormatForV1_2;
+				return PointFormatForV1_2;
 			}
 			if (version[2] == '3')
 			{
-				return &PointFormatForV1_3;
+				return PointFormatForV1_3;
 			}
 			if (version[2] == '4')
 			{
-				return &PointFormatForV1_4;
+				return PointFormatForV1_4;
 			}
 		}
 
 		ccLog::Warning("Unknown LAS version: " + version);
-		return nullptr;
+		static std::vector<unsigned> InvalidPointFormat;
+		return InvalidPointFormat;
 	}
 
 	const std::array<const char*, 3>& AvailableVersions()
@@ -268,7 +269,7 @@ namespace LasDetails
 			if (hasWaveform)
 			{
 				minorVersion = 3;
-				pointFormat = 4;
+				pointFormat  = 4;
 				if (hasRGB)
 				{
 					pointFormat = 5;

--- a/plugins/core/IO/qLASIO/src/LasExtraScalarFieldCard.cpp
+++ b/plugins/core/IO/qLASIO/src/LasExtraScalarFieldCard.cpp
@@ -257,13 +257,12 @@ bool LasExtraScalarFieldCard::fillField(LasExtraScalarField& field, const ccPoin
 
 	for (size_t i = 0; i < field.numElements(); i++)
 	{
-		const std::string sfName =
-		    m_scalarFieldsUserInputs[i].scalarFieldComboBox->currentText().toStdString();
-		int sfIndex = pointCloud.getScalarFieldIndexByName(sfName.c_str());
+		const std::string sfName  = m_scalarFieldsUserInputs[i].scalarFieldComboBox->currentText().toStdString();
+		int               sfIndex = pointCloud.getScalarFieldIndexByName(sfName.c_str());
 
 		if (sfIndex < 0)
 		{
-			ccLog::Warning("Failed to get scalar field named '%s'", sfName.c_str());
+			ccLog::Warning("Failed to retrieve scalar field named '%s'", sfName.c_str());
 			return false;
 		}
 		field.scalarFields[i] = static_cast<ccScalarField*>(pointCloud.getScalarField(sfIndex));
@@ -286,8 +285,10 @@ LasExtraScalarField::DimensionSize LasExtraScalarFieldCard::dimensionSize() cons
 	{
 		return LasExtraScalarField::DimensionSize::Three;
 	}
-
-	throw std::logic_error("None of the radio button of extra field num dimension are picked");
+	else
+	{
+		throw std::logic_error("None of the radio button of extra field num dimension are picked");
+	}
 }
 
 LasExtraScalarField::DataType LasExtraScalarFieldCard::dataType() const
@@ -298,54 +299,47 @@ LasExtraScalarField::DataType LasExtraScalarFieldCard::dataType() const
 	{
 		return LasExtraScalarField::DataType::u8;
 	}
-
-	if (selectedElementType == "uint16")
+	else if (selectedElementType == "uint16")
 	{
 		return LasExtraScalarField::DataType::u16;
 	}
-
-	if (selectedElementType == "uint32")
+	else if (selectedElementType == "uint32")
 	{
 		return LasExtraScalarField::DataType::u32;
 	}
-
-	if (selectedElementType == "uint64")
+	else if (selectedElementType == "uint64")
 	{
 		return LasExtraScalarField::DataType::u64;
 	}
-
-	if (selectedElementType == "int8")
+	else if (selectedElementType == "int8")
 	{
 		return LasExtraScalarField::DataType::i8;
 	}
-
-	if (selectedElementType == "int16")
+	else if (selectedElementType == "int16")
 	{
 		return LasExtraScalarField::DataType::i16;
 	}
-
-	if (selectedElementType == "int32")
+	else if (selectedElementType == "int32")
 	{
 		return LasExtraScalarField::DataType::i32;
 	}
-
-	if (selectedElementType == "int64")
+	else if (selectedElementType == "int64")
 	{
 		return LasExtraScalarField::DataType::i64;
 	}
-
-	if (selectedElementType == "float32")
+	else if (selectedElementType == "float32")
 	{
 		return LasExtraScalarField::DataType::f32;
 	}
-
-	if (selectedElementType == "float64")
+	else if (selectedElementType == "float64")
 	{
 		return LasExtraScalarField::DataType::f64;
 	}
-
-	assert(false);
-	return LasExtraScalarField::DataType::Invalid;
+	else
+	{
+		assert(false);
+		return LasExtraScalarField::DataType::Invalid;
+	}
 }
 
 void LasExtraScalarFieldCard::onNumberOfElementsSelected(unsigned numberOfElements)
@@ -360,7 +354,7 @@ void LasExtraScalarFieldCard::onNumberOfElementsSelected(unsigned numberOfElemen
 	{
 		ScalarFieldUserInputs& userInput = m_scalarFieldsUserInputs[i];
 
-		const bool isPartOfSelected = i <= (numberOfElements - 1);
+		bool isPartOfSelected = (i <= (numberOfElements - 1));
 
 		userInput.scalarFieldComboBox->setVisible(isPartOfSelected);
 		userInput.scaleSpinBox->setEnabled(isPartOfSelected);
@@ -395,7 +389,7 @@ void LasExtraScalarFieldCard::onToggleAdvancedOptionsClicked()
 	}
 }
 
-bool LasExtraScalarFieldCard::mapsFieldWithName(const char* sfName)
+bool LasExtraScalarFieldCard::mapsFieldWithName(const char* sfName) const
 {
 	const auto numDimensions = static_cast<size_t>(dimensionSize());
 

--- a/plugins/core/IO/qLASIO/src/LasSaveDialog.cpp
+++ b/plugins/core/IO/qLASIO/src/LasSaveDialog.cpp
@@ -1,19 +1,19 @@
-//##########################################################################
-//#                                                                        #
-//#                CLOUDCOMPARE PLUGIN: LAS-IO Plugin                      #
-//#                                                                        #
-//#  This program is free software; you can redistribute it and/or modify  #
-//#  it under the terms of the GNU General Public License as published by  #
-//#  the Free Software Foundation; version 2 of the License.               #
-//#                                                                        #
-//#  This program is distributed in the hope that it will be useful,       #
-//#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
-//#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
-//#  GNU General Public License for more details.                          #
-//#                                                                        #
-//#                   COPYRIGHT: Thomas Montaigu                           #
-//#                                                                        #
-//##########################################################################
+// ##########################################################################
+// #                                                                        #
+// #                CLOUDCOMPARE PLUGIN: LAS-IO Plugin                      #
+// #                                                                        #
+// #  This program is free software; you can redistribute it and/or modify  #
+// #  it under the terms of the GNU General Public License as published by  #
+// #  the Free Software Foundation; version 2 of the License.               #
+// #                                                                        #
+// #  This program is distributed in the hope that it will be useful,       #
+// #  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+// #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+// #  GNU General Public License for more details.                          #
+// #                                                                        #
+// #                   COPYRIGHT: Thomas Montaigu                           #
+// #                                                                        #
+// ##########################################################################
 
 #include "LasSaveDialog.h"
 
@@ -139,14 +139,34 @@ LasSaveDialog::LasSaveDialog(ccPointCloud* cloud, QWidget* parent)
 	versionComboBox->setCurrentIndex(0);
 
 	connect(versionComboBox,
-	        (void (QComboBox::*)(const QString&))(&QComboBox::currentIndexChanged),
+	        (void(QComboBox::*)(const QString&))(&QComboBox::currentIndexChanged),
 	        this,
 	        &LasSaveDialog::handleSelectedVersionChange);
 
 	connect(pointFormatComboBox,
-	        (void (QComboBox::*)(int))(&QComboBox::currentIndexChanged),
+	        (void(QComboBox::*)(int))(&QComboBox::currentIndexChanged),
 	        this,
 	        &LasSaveDialog::handleSelectedPointFormatChange);
+
+	connect(pointFormatComboBox,
+	        (void(QComboBox::*)(int))(&QComboBox::currentIndexChanged),
+	        this,
+	        &LasSaveDialog::handleSelectedPointFormatChange);
+
+	connect(leftOverFieldsAsExtraCheckBox,
+	        &QCheckBox::stateChanged,
+	        this,
+	        [this](bool state)
+	        {
+		        if (state)
+		        {
+			        assignLeftOverFieldsAsExtra();
+		        }
+		        else
+		        {
+			        unassignDefaultFields();
+		        }
+	        });
 
 	handleSelectedVersionChange(versionComboBox->currentText()); // will call handleSelectedPointFormatChange
 
@@ -256,6 +276,11 @@ void LasSaveDialog::handleComboBoxChange(int index)
 	else
 	{
 		tabWidget->setTabIcon(1, {});
+	}
+
+	if (shouldAutomaticallyAssignLeftOverFieldsAsExtra())
+	{
+		assignLeftOverFieldsAsExtra();
 	}
 }
 
@@ -371,6 +396,11 @@ void LasSaveDialog::handleSelectedPointFormatChange(int index)
 			waveformCheckBox->hide();
 		}
 	}
+
+	if (shouldAutomaticallyAssignLeftOverFieldsAsExtra())
+	{
+		assignLeftOverFieldsAsExtra();
+	}
 }
 
 void LasSaveDialog::handleCustomScaleButtontoggled(bool checked)
@@ -392,28 +422,18 @@ LasExtraScalarFieldCard* LasSaveDialog::createCard() const
 	return card;
 }
 
-void LasSaveDialog::addExtraScalarFieldCard()
+LasExtraScalarFieldCard* LasSaveDialog::addExtraScalarFieldCard()
 {
-#ifdef CC_CORE_LIB_USES_DOUBLE
-	const char* defaultType = "float64";
-#else
-	const char* defaultType = "float32";
-#endif
-	int defaultTypeIndex = m_extraFieldsDataTypesModel->stringList().indexOf(defaultType);
-	defaultTypeIndex     = std::max(defaultTypeIndex, 0);
-
 	int esfCount = extraScalarFieldsLayout->count();
 
-	// firt, look if a card has already been created, but is currently hidden
+	// first, look if a card has already been created, but is currently hidden
 	for (int i = 0; i < esfCount; ++i)
 	{
+
 		QLayoutItem* item   = extraScalarFieldsLayout->itemAt(i);
 		QWidget*     widget = item->widget();
 		if (widget && widget->isHidden())
 		{
-			// remove and insert it again at the end
-			extraScalarFieldsLayout->removeItem(item);
-			extraScalarFieldsLayout->insertItem(extraScalarFieldsLayout->count(), item);
 			auto* card = qobject_cast<LasExtraScalarFieldCard*>(widget);
 			if (!card)
 			{
@@ -423,13 +443,14 @@ void LasSaveDialog::addExtraScalarFieldCard()
 
 			card->reset();
 			widget->show();
-			return;
+			return card;
 		}
 	}
 
 	// else we'll create a new card
 	auto* card = createCard();
 	extraScalarFieldsLayout->insertWidget(esfCount, card);
+	return card;
 }
 
 void LasSaveDialog::setVersionAndPointFormat(const LasDetails::LasVersion versionAndFmt)
@@ -584,7 +605,7 @@ std::vector<LasScalarField> LasSaveDialog::fieldsToSave() const
 				continue;
 			}
 
-			ccScalarField* sf = static_cast<ccScalarField*>(m_cloud->getScalarField(sfIdx));
+			auto* sf = static_cast<ccScalarField*>(m_cloud->getScalarField(sfIdx));
 
 			const std::string name = item.first->name().toStdString();
 			fields.emplace_back(LasScalarField::IdFromName(name.c_str(), pointFormat), sf);
@@ -635,4 +656,101 @@ std::vector<LasExtraScalarField> LasSaveDialog::extraFieldsToSave() const
 	}
 
 	return extraScalarFields;
+}
+
+void LasSaveDialog::assignLeftOverFieldsAsExtra()
+{
+	unassignDefaultFields();
+
+	// We use lambda for clarity
+	auto isAssignedToStandardField = [this](const char* sfName) -> bool
+	{
+		for (const auto& item : m_scalarFieldMapping)
+		{
+			if (item.second->currentIndex() > 0)
+			{
+				const QString correspondingScalarFieldName = item.second->currentText();
+				if (correspondingScalarFieldName == sfName)
+				{
+					return true;
+				}
+			}
+		}
+		return false;
+	};
+
+	auto isAssignedAsExtraField = [this](const char* sfName)
+	{
+		int esfCount = extraScalarFieldsLayout->count();
+		for (int i = 0; i < esfCount; ++i)
+		{
+			QLayoutItem* item   = extraScalarFieldsLayout->itemAt(i);
+			QWidget*     widget = item->widget();
+			if (!widget || widget->isHidden())
+			{
+				continue;
+			}
+			auto* card = qobject_cast<LasExtraScalarFieldCard*>(widget);
+			if (!card)
+			{
+				continue;
+			}
+
+			if (card->isDefault())
+			{
+				continue;
+			}
+
+			if (card->mapsFieldWithName(sfName))
+			{
+				return true;
+			}
+		}
+		return false;
+	};
+
+	uint sfCount = m_cloud->getNumberOfScalarFields();
+
+	for (uint index = 0; index < sfCount; index++)
+	{
+		auto*       sf              = static_cast<ccScalarField*>(m_cloud->getScalarField(index));
+		const char* sfName          = sf->getName();
+		const bool  alreadyAssigned = isAssignedToStandardField(sfName) || isAssignedAsExtraField(sfName);
+		if (!alreadyAssigned)
+		{
+			LasExtraScalarFieldCard* card = addExtraScalarFieldCard();
+			card->fillAsDefault(sfName);
+		}
+	}
+}
+
+void LasSaveDialog::unassignDefaultFields()
+{
+	unsigned int esfCount = extraScalarFieldsLayout->count();
+	for (unsigned int numIter = 0, i = 0; numIter < esfCount; ++numIter)
+	{
+		QLayoutItem* item   = extraScalarFieldsLayout->itemAt(static_cast<int>(i));
+		QWidget*     widget = item->widget();
+		if (!widget || widget->isHidden())
+		{
+			++i;
+			continue;
+		}
+		auto* card = qobject_cast<LasExtraScalarFieldCard*>(widget);
+		if (!card)
+		{
+			++i;
+			continue;
+		}
+
+		if (card->isDefault())
+		{
+			card->reset();
+			widget->setVisible(false);
+		}
+
+		// Move the item to the back
+		extraScalarFieldsLayout->removeItem(item);
+		extraScalarFieldsLayout->addItem(item);
+	}
 }

--- a/plugins/core/IO/qLASIO/ui/extra_scarlar_field_card.ui
+++ b/plugins/core/IO/qLASIO/ui/extra_scarlar_field_card.ui
@@ -141,6 +141,16 @@
           <number>0</number>
          </property>
          <item>
+          <widget class="QPushButton" name="unlockModificationsButton">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="text">
+            <string>Unlock Modification</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QPushButton" name="advancedOptionsButton">
            <property name="text">
             <string>Advanced Options</string>

--- a/plugins/core/IO/qLASIO/ui/lassavedialog.ui
+++ b/plugins/core/IO/qLASIO/ui/lassavedialog.ui
@@ -21,7 +21,7 @@
      </property>
      <widget class="QWidget" name="basicParamTab">
       <attribute name="title">
-       <string>Basic Params</string>
+       <string>Basic Parameters</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
@@ -33,10 +33,10 @@
           </sizepolicy>
          </property>
          <property name="frameShape">
-          <enum>QFrame::Shape::StyledPanel</enum>
+          <enum>QFrame::StyledPanel</enum>
          </property>
          <property name="frameShadow">
-          <enum>QFrame::Shadow::Raised</enum>
+          <enum>QFrame::Raised</enum>
          </property>
          <layout class="QFormLayout" name="formLayout">
           <item row="0" column="0">
@@ -73,7 +73,7 @@
             <item>
              <widget class="QRadioButton" name="bestScaleRadioButton">
               <property name="text">
-               <string>Op&amp;timal scale</string>
+               <string>Optimal scale</string>
               </property>
              </widget>
             </item>
@@ -87,7 +87,7 @@
             <item>
              <spacer name="horizontalSpacer_10">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -120,7 +120,7 @@ font: italic;</string>
             <item>
              <widget class="QRadioButton" name="originalScaleRadioButton">
               <property name="text">
-               <string>O&amp;riginal scale</string>
+               <string>Original scale</string>
               </property>
               <property name="checkable">
                <bool>true</bool>
@@ -140,7 +140,7 @@ font: italic;</string>
             <item>
              <spacer name="horizontalSpacer_8">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -168,7 +168,7 @@ font: italic;</string>
             <item>
              <widget class="QRadioButton" name="customScaleRadioButton">
               <property name="text">
-               <string>Custo&amp;m scale</string>
+               <string>Custom scale</string>
               </property>
              </widget>
             </item>
@@ -207,7 +207,7 @@ font: italic;</string>
             <item>
              <spacer name="horizontalSpacer_9">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -247,7 +247,7 @@ font: italic;</string>
        <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
+          <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -261,10 +261,10 @@ font: italic;</string>
      </widget>
      <widget class="QWidget" name="scalarFieldsMappingTab">
       <attribute name="title">
-       <string>Scalarfields Mapping</string>
+       <string>Standard LAS fields</string>
       </attribute>
       <attribute name="whatsThis">
-       <string>Select for each LAS dimension, the PointColoud Scalarfield to use</string>
+       <string>Select the point cloud's scalar field to use for each LAS dimension</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_6">
        <item>
@@ -279,43 +279,61 @@ font: italic;</string>
           </sizepolicy>
          </property>
          <property name="frameShape">
-          <enum>QFrame::Shape::StyledPanel</enum>
+          <enum>QFrame::StyledPanel</enum>
          </property>
          <property name="frameShadow">
-          <enum>QFrame::Shadow::Raised</enum>
+          <enum>QFrame::Raised</enum>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_5">
           <item>
            <widget class="QCheckBox" name="rgbCheckBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="text">
              <string>RGB</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="normalsCheckBox">
-            <property name="toolTip">
-             <string>Saves normals as extra scalar field using the names &quot;NormalX&quot;, &quot;NormalY&quot; and &quot;NormalZ&quot;.</string>
-            </property>
-            <property name="text">
-             <string>Normals (As Extra Scalarfield)</string>
-            </property>
-           </widget>
-          </item>
-          <item>
            <widget class="QCheckBox" name="waveformCheckBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="text">
              <string>Waveform</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="leftOverFieldsAsExtraCheckBox">
+           <widget class="QCheckBox" name="normalsCheckBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="toolTip">
-             <string>If checked, all scalar fields of the point cloud that are not assigned to a standard LAS field, will then be assigned as an extra LAS field</string>
+             <string>Saves normals as Extra fields (VLRs) using the names &quot;NormalX&quot;, &quot;NormalY&quot; and &quot;NormalZ&quot;.</string>
             </property>
             <property name="text">
-             <string>Assign other fields as extra scalarFields</string>
+             <string>Normals (as Extra fields / VLRs)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="saveLeftoverSFsAsExtraVLRCheckBox">
+            <property name="toolTip">
+             <string>If checked, all scalar fields that are not assigned to a standard LAS field will be saved as extra fields (VLRs)</string>
+            </property>
+            <property name="text">
+             <string>Save remaining scalar fields as Extra fields / VLRs</string>
             </property>
             <property name="checked">
              <bool>true</bool>
@@ -328,7 +346,7 @@ font: italic;</string>
        <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
+          <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -342,7 +360,7 @@ font: italic;</string>
      </widget>
      <widget class="QWidget" name="extraScalarFieldsTab">
       <attribute name="title">
-       <string>Extra Scalarfields</string>
+       <string>Extra fields (VLRs)</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_7">
        <item>
@@ -355,8 +373,8 @@ font: italic;</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>720</width>
-            <height>283</height>
+            <width>620</width>
+            <height>292</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -366,7 +384,7 @@ font: italic;</string>
            <item>
             <spacer name="verticalSpacer_3">
              <property name="orientation">
-              <enum>Qt::Orientation::Vertical</enum>
+              <enum>Qt::Vertical</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -394,10 +412,10 @@ font: italic;</string>
    <item>
     <widget class="QFrame" name="buttonFrame">
      <property name="frameShape">
-      <enum>QFrame::Shape::StyledPanel</enum>
+      <enum>QFrame::StyledPanel</enum>
      </property>
      <property name="frameShadow">
-      <enum>QFrame::Shadow::Raised</enum>
+      <enum>QFrame::Raised</enum>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <property name="leftMargin">
@@ -415,7 +433,7 @@ font: italic;</string>
       <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
+         <enum>Qt::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -428,10 +446,10 @@ font: italic;</string>
       <item>
        <widget class="QDialogButtonBox" name="buttonBox">
         <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
+         <enum>Qt::Horizontal</enum>
         </property>
         <property name="standardButtons">
-         <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+         <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
         </property>
        </widget>
       </item>

--- a/plugins/core/IO/qLASIO/ui/lassavedialog.ui
+++ b/plugins/core/IO/qLASIO/ui/lassavedialog.ui
@@ -33,10 +33,10 @@
           </sizepolicy>
          </property>
          <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
+          <enum>QFrame::Shape::StyledPanel</enum>
          </property>
          <property name="frameShadow">
-          <enum>QFrame::Raised</enum>
+          <enum>QFrame::Shadow::Raised</enum>
          </property>
          <layout class="QFormLayout" name="formLayout">
           <item row="0" column="0">
@@ -73,7 +73,7 @@
             <item>
              <widget class="QRadioButton" name="bestScaleRadioButton">
               <property name="text">
-               <string>Optimal scale</string>
+               <string>Op&amp;timal scale</string>
               </property>
              </widget>
             </item>
@@ -87,7 +87,7 @@
             <item>
              <spacer name="horizontalSpacer_10">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -120,7 +120,7 @@ font: italic;</string>
             <item>
              <widget class="QRadioButton" name="originalScaleRadioButton">
               <property name="text">
-               <string>Original scale</string>
+               <string>O&amp;riginal scale</string>
               </property>
               <property name="checkable">
                <bool>true</bool>
@@ -140,7 +140,7 @@ font: italic;</string>
             <item>
              <spacer name="horizontalSpacer_8">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -168,7 +168,7 @@ font: italic;</string>
             <item>
              <widget class="QRadioButton" name="customScaleRadioButton">
               <property name="text">
-               <string>Custom scale</string>
+               <string>Custo&amp;m scale</string>
               </property>
              </widget>
             </item>
@@ -207,7 +207,7 @@ font: italic;</string>
             <item>
              <spacer name="horizontalSpacer_9">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -247,7 +247,7 @@ font: italic;</string>
        <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -279,10 +279,10 @@ font: italic;</string>
           </sizepolicy>
          </property>
          <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
+          <enum>QFrame::Shape::StyledPanel</enum>
          </property>
          <property name="frameShadow">
-          <enum>QFrame::Raised</enum>
+          <enum>QFrame::Shadow::Raised</enum>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_5">
           <item>
@@ -309,13 +309,26 @@ font: italic;</string>
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="leftOverFieldsAsExtraCheckBox">
+            <property name="toolTip">
+             <string>If checked, all scalar fields of the point cloud that are not assigned to a standard LAS field, will then be assigned as an extra LAS field</string>
+            </property>
+            <property name="text">
+             <string>Assign other fields as extra scalarFields</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
        <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -342,8 +355,8 @@ font: italic;</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>98</width>
-            <height>28</height>
+            <width>720</width>
+            <height>283</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -353,7 +366,7 @@ font: italic;</string>
            <item>
             <spacer name="verticalSpacer_3">
              <property name="orientation">
-              <enum>Qt::Vertical</enum>
+              <enum>Qt::Orientation::Vertical</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -381,10 +394,10 @@ font: italic;</string>
    <item>
     <widget class="QFrame" name="buttonFrame">
      <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
+      <enum>QFrame::Shape::StyledPanel</enum>
      </property>
      <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
+      <enum>QFrame::Shadow::Raised</enum>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <property name="leftMargin">
@@ -402,7 +415,7 @@ font: italic;</string>
       <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -415,10 +428,10 @@ font: italic;</string>
       <item>
        <widget class="QDialogButtonBox" name="buttonBox">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="standardButtons">
-         <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+         <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Currently when saving a LAS file, scalar fields that are not mapped
to LAS standard field or that are not mapped to LAS extra field
(only possible if the cloud was read from a LAS), are not going to be
saved unless the user manually assigns CC scalar fields to LAS extra
fields, which can be tedious.

These changes makes CloudCompare automatically assigns as LAS extra
dimension any scalar fields that is not already assigned to standard
or extra LAS dimension using default settings (name == sf Name and type
== f32).

The "workflow" is that if the "Assign other fields as extra scalarfields"
checkbox of the 2nd tab is checked (which it is by default),
then the dialog will automatically assign to a extra LAS field with
default settings any CC scalar field that is not already assigned something,
this is done by creating a "card" in the 3rd tab.

Everytime the point format or the standard field mapping is changed, the
automatic assigning is done/re-done. Extra scalar field cards that were
automatically (default) made are "locked" as they may be automatically
removed/added when point format/standard field mapping changes, a user
can unlock the card to allow customizing it, in that case, the card is
no longer considerer a default.

# TODO
- [x] Test this a bit more in real scenarios
- [x] re-assign fields each time a standard field mapping changes ?
- [x] have a check box in the dialog (checked by default) to enable or not this behavior