### PR TITLE
Add "Don't ask again" option to quit confirmation

### DIFF
--- a/libs/CCAppCommon/include/ccOptions.h
+++ b/libs/CCAppCommon/include/ccOptions.h
@@ -32,6 +32,9 @@ public: //parameters
 	//! Use native load/save dialogs
 	bool useNativeDialogs;
 
+	//! Should we ask for confirmation when user clicked to quit the app ?
+	bool confirmQuit;
+
 public: //methods
 
 	//! Default constructor

--- a/libs/CCAppCommon/src/ccDisplayOptionsDlg.cpp
+++ b/libs/CCAppCommon/src/ccDisplayOptionsDlg.cpp
@@ -65,6 +65,7 @@ ccDisplayOptionsDlg::ccDisplayOptionsDlg(QWidget* parent)
 	connect(m_ui->singleClickPickingCheckBox,	   &QCheckBox::toggled, this, [&](bool state) { m_parameters.singleClickPicking = state; });
 	connect(m_ui->autoDisplayNormalsCheckBox,      &QCheckBox::toggled, this, [&](bool state) { m_options.normalsDisplayedByDefault = state; });
 	connect(m_ui->useNativeDialogsCheckBox,        &QCheckBox::toggled, this, [&](bool state) { m_options.useNativeDialogs = state; });
+	connect(m_ui->confirmQuitCheckBox,             &QCheckBox::toggled, this, [&](bool state) { m_options.confirmQuit = state; });
 
 	connect(m_ui->useVBOCheckBox,	&QAbstractButton::clicked,	this, &ccDisplayOptionsDlg::changeVBOUsage);
 
@@ -205,6 +206,7 @@ void ccDisplayOptionsDlg::refresh()
 
 	m_ui->autoDisplayNormalsCheckBox->setChecked(m_options.normalsDisplayedByDefault);
 	m_ui->useNativeDialogsCheckBox->setChecked(m_options.useNativeDialogs);
+	m_ui->confirmQuitCheckBox->setChecked(m_options.confirmQuit);
 
 	switch (m_parameters.pickingCursorShape)
 	{

--- a/libs/CCAppCommon/src/ccOptions.cpp
+++ b/libs/CCAppCommon/src/ccOptions.cpp
@@ -59,6 +59,7 @@ void ccOptions::reset()
 {
 	normalsDisplayedByDefault = false;
 	useNativeDialogs = true;
+	confirmQuit = true;
 }
 
 void ccOptions::fromPersistentSettings()
@@ -68,6 +69,7 @@ void ccOptions::fromPersistentSettings()
 	{
 		normalsDisplayedByDefault = settings.value("normalsDisplayedByDefault", false).toBool();
 		useNativeDialogs = settings.value("useNativeDialogs", true).toBool();
+		confirmQuit = settings.value("confirmQuit", true).toBool();
 	}
 	settings.endGroup();
 }
@@ -79,6 +81,7 @@ void ccOptions::toPersistentSettings() const
 	{
 		settings.setValue("normalsDisplayedByDefault", normalsDisplayedByDefault);
 		settings.setValue("useNativeDialogs", useNativeDialogs);
+		settings.setValue("confirmQuit", confirmQuit);
 	}
 	settings.endGroup();
 }

--- a/libs/CCAppCommon/ui/displayOptionsDlg.ui
+++ b/libs/CCAppCommon/ui/displayOptionsDlg.ui
@@ -837,7 +837,7 @@
          </property>
         </widget>
        </item>
-       <item row="14" column="0">
+       <item row="15" column="0">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -892,6 +892,13 @@
            <string>Pointing hand</string>
           </property>
          </item>
+        </widget>
+       </item>
+       <item row="14" column="0">
+        <widget class="QCheckBox" name="confirmQuitCheckBox">
+         <property name="text">
+          <string>Ask for a confirmation before quitting</string>
+         </property>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
Some users do not like the dialog asking to confirm if it really wanted to quit the app.

This adds a "Yes, don't ask again" option that will quit the app and make CC remember not to show that confirmation dialog and directly exit.

This setting can be toggled in the settings menu (Display->display settings->Other Options).


![dontask](https://github.com/user-attachments/assets/948cd18d-4ced-4028-b2d7-cc173ea36ea2)
![settings](https://github.com/user-attachments/assets/cd0309f4-df0b-4e3a-b558-e890951046a2)


closes #1376 