### PR TITLE
LAS: add option to not decompose classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ Improvements:
 			- {original cloud name} + '_ground_points'
 			- {original cloud name} + '_offground_points'
 
+	- LAS file loading dialog
+		- Option to decompose the classification fields into Classification, Synthetic, Key Point and Withheld sub-fields
 	- LAS file saving dialog
 		- CC will now automatically assign scalar fields with non 'LAS-standard' names to Extra fields (VLRs)
 		- if the 'Save remaining scalar fields as Extra fields / VLRs' checkbox is checked (default state),

--- a/plugins/core/IO/qLASIO/include/LasOpenDialog.h
+++ b/plugins/core/IO/qLASIO/include/LasOpenDialog.h
@@ -77,6 +77,10 @@ class LasOpenDialog : public QDialog
 	/// rgb from the file as 8-bit components.
 	bool shouldForce8bitColors() const;
 
+	/// Returns whether the user wants to decompose the classification field
+	/// according to what the LAS standard says.
+	bool shouldDecomposeClassification() const;
+
 	/// Returns quiet_NaN if the time shift value should be
 	/// automatically found.
 	///
@@ -120,6 +124,9 @@ class LasOpenDialog : public QDialog
 	void onBrowseTilingOutputDir();
 
 	void onCurrentTabChanged(int index);
+
+	/// Hides or un-hides the checkboxes that corresponds to the flag fields
+	void onDecomposeClassificationToggled(bool state);
 
   private:
 	bool m_shouldSkipDialog{false};

--- a/plugins/core/IO/qLASIO/include/LasScalarFieldLoader.h
+++ b/plugins/core/IO/qLASIO/include/LasScalarFieldLoader.h
@@ -67,7 +67,8 @@ class LasScalarFieldLoader
 	/// the classification, synthetic flag, key_point flag, withheld flag.
 	///
 	/// Only applies to point format <= 5 (ie field Classification, not ExtendedClassification)
-	inline void setDecomposeClassification(bool state) {
+	inline void setDecomposeClassification(bool state)
+	{
 		m_decomposeClassification = state;
 	}
 

--- a/plugins/core/IO/qLASIO/include/LasScalarFieldLoader.h
+++ b/plugins/core/IO/qLASIO/include/LasScalarFieldLoader.h
@@ -63,6 +63,14 @@ class LasScalarFieldLoader
 		m_force8bitRgbMode = state;
 	}
 
+	/// Sets whether the classification field should be decomposed into
+	/// the classification, synthetic flag, key_point flag, withheld flag.
+	///
+	/// Only applies to point format <= 5 (ie field Classification, not ExtendedClassification)
+	inline void setDecomposeClassification(bool state) {
+		m_decomposeClassification = state;
+	}
+
 	/// If nan, this value will be ignored and the time shift
 	/// will be taken using the first value encountered.
 	inline void setManualTimeShift(double timeShift)
@@ -116,6 +124,7 @@ class LasScalarFieldLoader
 
   private:
 	bool                              m_force8bitRgbMode{false};
+	bool                              m_decomposeClassification{true};
 	bool                              m_ignoreFieldsWithDefaultValues{true};
 	double                            m_manualTimeShiftValue{std::numeric_limits<double>::quiet_NaN()};
 	unsigned char                     m_colorCompShift{0};

--- a/plugins/core/IO/qLASIO/include/LasScalarFieldSaver.h
+++ b/plugins/core/IO/qLASIO/include/LasScalarFieldSaver.h
@@ -42,10 +42,12 @@ class LasScalarFieldSaver
 		// a field with name that is one of the decomposed flags.
 		// However check by looking at the max value may be better to handle
 		// clouds not coming from LAS at all.
-		for (const LasScalarField& field: m_standardFields) {
+		for (const LasScalarField& field : m_standardFields)
+		{
 			if (strcmp(field.name(), LasNames::Classification) == 0
-				&& field.sf
-				&& field.sf->getMax() >= 32) {
+			    && field.sf
+			    && field.sf->getMax() >= 32)
+			{
 				m_classificationWasDecomposed = false;
 			}
 		}
@@ -89,7 +91,7 @@ class LasScalarFieldSaver
 	std::vector<LasScalarField>      m_standardFields;
 	std::vector<LasExtraScalarField> m_extraFields;
 	/// Whether the classification flags from point format <= 5 were
-	/// decomposed into individual scalar field (synthetic, keypoint, withheld)
-	/// are if their values was kept packed into the classification field.
-	bool                             m_classificationWasDecomposed{false};
+	/// decomposed into individual scalar fields (synthetic, keypoint, withheld)
+	/// or if their values were kept packed into the classification field.
+	bool m_classificationWasDecomposed{false};
 };

--- a/plugins/core/IO/qLASIO/include/LasScalarFieldSaver.h
+++ b/plugins/core/IO/qLASIO/include/LasScalarFieldSaver.h
@@ -38,6 +38,17 @@ class LasScalarFieldSaver
 	inline void setStandarFields(std::vector<LasScalarField>&& standardFields)
 	{
 		m_standardFields = standardFields;
+		// Another way to check this could have been to check for the existence of
+		// a field with name that is one of the decomposed flags.
+		// However check by looking at the max value may be better to handle
+		// clouds not coming from LAS at all.
+		for (const LasScalarField& field: m_standardFields) {
+			if (strcmp(field.name(), LasNames::Classification) == 0
+				&& field.sf
+				&& field.sf->getMax() >= 32) {
+				m_classificationWasDecomposed = false;
+			}
+		}
 	}
 
 	inline void setExtraFields(std::vector<LasExtraScalarField>&& extraFields)
@@ -77,4 +88,8 @@ class LasScalarFieldSaver
   private:
 	std::vector<LasScalarField>      m_standardFields;
 	std::vector<LasExtraScalarField> m_extraFields;
+	/// Whether the classification flags from point format <= 5 were
+	/// decomposed into individual scalar field (synthetic, keypoint, withheld)
+	/// are if their values was kept packed into the classification field.
+	bool                             m_classificationWasDecomposed{false};
 };

--- a/plugins/core/IO/qLASIO/src/LasIOFilter.cpp
+++ b/plugins/core/IO/qLASIO/src/LasIOFilter.cpp
@@ -253,6 +253,7 @@ CC_FILE_ERROR LasIOFilter::loadFile(const QString&  fileName,
 	loader.setIgnoreFieldsWithDefaultValues(m_openDialog.shouldIgnoreFieldsWithDefaultValues());
 	loader.setForce8bitRgbMode(m_openDialog.shouldForce8bitColors());
 	loader.setManualTimeShift(m_openDialog.timeShiftValue());
+	loader.setDecomposeClassification(m_openDialog.shouldDecomposeClassification());
 	std::unique_ptr<LasWaveformLoader> waveformLoader{nullptr};
 	if (LasDetails::HasWaveform(laszipHeader->point_data_format))
 	{

--- a/plugins/core/IO/qLASIO/src/LasOpenDialog.cpp
+++ b/plugins/core/IO/qLASIO/src/LasOpenDialog.cpp
@@ -272,7 +272,8 @@ bool LasOpenDialog::shouldForce8bitColors() const
 	return force8bitColorsCheckBox->isChecked();
 }
 
-bool LasOpenDialog::shouldDecomposeClassification() const {
+bool LasOpenDialog::shouldDecomposeClassification() const
+{
 	return decomposeClassificationCheckBox->isChecked();
 }
 
@@ -410,14 +411,15 @@ void LasOpenDialog::onCurrentTabChanged(int index)
 	}
 }
 
-void LasOpenDialog::onDecomposeClassificationToggled(bool checked) {
-	static constexpr std::array<const char *, 3>flagNames = {
-			LasNames::SyntheticFlag, LasNames::KeypointFlag, LasNames::WithheldFlag};
+void LasOpenDialog::onDecomposeClassificationToggled(bool checked)
+{
+	static constexpr std::array<const char*, 3> flagNames{LasNames::SyntheticFlag, LasNames::KeypointFlag, LasNames::WithheldFlag};
 
-	for (const char *flagName: flagNames) {
+	for (const char* flagName : flagNames)
+	{
 		for (int i = 0; i < availableScalarFields->count(); ++i)
 		{
-			QListWidgetItem *item = availableScalarFields->item(i);
+			QListWidgetItem* item = availableScalarFields->item(i);
 			if (item->text() == flagName)
 			{
 				item->setHidden(!checked);

--- a/plugins/core/IO/qLASIO/src/LasScalarFieldLoader.cpp
+++ b/plugins/core/IO/qLASIO/src/LasScalarFieldLoader.cpp
@@ -56,8 +56,16 @@ CC_FILE_ERROR LasScalarFieldLoader::handleScalarFields(ccPointCloud&       point
 			error = handleScalarField(lasScalarField, pointCloud, currentPoint.edge_of_flight_line);
 			break;
 		case LasScalarField::Classification:
-			error = handleScalarField(lasScalarField, pointCloud, currentPoint.classification);
+		{
+			laszip_U8 classification = currentPoint.classification;
+			if (!m_decomposeClassification) {
+				classification |= (currentPoint.synthetic_flag << 5);
+				classification |= (currentPoint.keypoint_flag << 6);
+				classification |= (currentPoint.withheld_flag << 7);
+			}
+			error = handleScalarField(lasScalarField, pointCloud, classification);
 			break;
+		}
 		case LasScalarField::SyntheticFlag:
 			error = handleScalarField(lasScalarField, pointCloud, currentPoint.synthetic_flag);
 			break;

--- a/plugins/core/IO/qLASIO/src/LasScalarFieldLoader.cpp
+++ b/plugins/core/IO/qLASIO/src/LasScalarFieldLoader.cpp
@@ -58,7 +58,8 @@ CC_FILE_ERROR LasScalarFieldLoader::handleScalarFields(ccPointCloud&       point
 		case LasScalarField::Classification:
 		{
 			laszip_U8 classification = currentPoint.classification;
-			if (!m_decomposeClassification) {
+			if (!m_decomposeClassification)
+			{
 				classification |= (currentPoint.synthetic_flag << 5);
 				classification |= (currentPoint.keypoint_flag << 6);
 				classification |= (currentPoint.withheld_flag << 7);

--- a/plugins/core/IO/qLASIO/src/LasScalarFieldSaver.cpp
+++ b/plugins/core/IO/qLASIO/src/LasScalarFieldSaver.cpp
@@ -70,7 +70,15 @@ void LasScalarFieldSaver::handleScalarFields(size_t pointIndex, laszip_point& po
 		case LasScalarField::Classification:
 			if (field.sf)
 			{
-				point.classification = static_cast<laszip_U8>(value);
+				// Before entering the switch, the value is 'clamped',
+				// for the following to work we need the non-clamped value
+				value = field.sf->getValue(pointIndex);
+				point.classification = static_cast<laszip_U8>(value) & 31;
+				if (!m_classificationWasDecomposed) {
+					point.synthetic_flag = (static_cast<laszip_U8>(value) >> 5) & 1;
+					point.keypoint_flag = (static_cast<laszip_U8>(value) >> 6) & 1;
+					point.withheld_flag = (static_cast<laszip_U8>(value) >> 7) & 1;
+				}
 			}
 			break;
 		case LasScalarField::SyntheticFlag:

--- a/plugins/core/IO/qLASIO/src/LasScalarFieldSaver.cpp
+++ b/plugins/core/IO/qLASIO/src/LasScalarFieldSaver.cpp
@@ -72,12 +72,13 @@ void LasScalarFieldSaver::handleScalarFields(size_t pointIndex, laszip_point& po
 			{
 				// Before entering the switch, the value is 'clamped',
 				// for the following to work we need the non-clamped value
-				value = field.sf->getValue(pointIndex);
-				point.classification = static_cast<laszip_U8>(value) & 31;
-				if (!m_classificationWasDecomposed) {
-					point.synthetic_flag = (static_cast<laszip_U8>(value) >> 5) & 1;
-					point.keypoint_flag = (static_cast<laszip_U8>(value) >> 6) & 1;
-					point.withheld_flag = (static_cast<laszip_U8>(value) >> 7) & 1;
+				laszip_U8 valueU8    = static_cast<laszip_U8>(field.sf->getValue(pointIndex));
+				point.classification = valueU8 & 31;
+				if (!m_classificationWasDecomposed)
+				{
+					point.synthetic_flag = (valueU8 >> 5) & 1;
+					point.keypoint_flag  = (valueU8 >> 6) & 1;
+					point.withheld_flag  = (valueU8 >> 7) & 1;
 				}
 			}
 			break;

--- a/plugins/core/IO/qLASIO/ui/lasopendialog.ui
+++ b/plugins/core/IO/qLASIO/ui/lasopendialog.ui
@@ -257,6 +257,19 @@
                   </widget>
                  </item>
                  <item>
+                  <widget class="QCheckBox" name="decomposeClassificationCheckBox">
+                   <property name="toolTip">
+                    <string>If checked, the classification field will be decomposed into Classification, Synthetic, Key Point and Withheld</string>
+                   </property>
+                   <property name="text">
+                    <string>Decompose Classification</string>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
                   <widget class="QCheckBox" name="force8bitColorsCheckBox">
                    <property name="text">
                     <string>Force 8-bit colors</string>


### PR DESCRIPTION
This adds (back) the option not to decompose the classification field into "classification", "synthethic flag", "key point flag", "withheld flag".

This only is only shown for point format that it can be applied to (fmt <= 5).