### PR TITLE
Add dark theme using QDarkStyleSheet

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,6 @@
 	path = plugins/core/Standard/q3DMASC
 	url = https://github.com/dgirardeau/q3DMASC.git
 	branch = master
+[submodule "libs/CCAppCommon/QDarkStyleSheet"]
+	path = libs/CCAppCommon/QDarkStyleSheet
+	url = https://github.com/ColinDuquesnoy/QDarkStyleSheet

--- a/libs/CCAppCommon/CMakeLists.txt
+++ b/libs/CCAppCommon/CMakeLists.txt
@@ -18,6 +18,12 @@ set_target_properties( ${PROJECT_NAME} PROPERTIES
 	CXX_VISIBILITY_PRESET hidden
 )
 
+target_sources(${PROJECT_NAME}
+		PRIVATE
+		${CMAKE_CURRENT_LIST_DIR}/QDarkStyleSheet/qdarkstyle/dark/darkstyle.qrc
+		${CMAKE_CURRENT_LIST_DIR}/QDarkStyleSheet/qdarkstyle/light/lightstyle.qrc
+)
+
 if( OPTION_SUPPORT_GAMEPADS )
 	find_package( Qt5
 		COMPONENTS

--- a/libs/CCAppCommon/src/ccApplicationBase.cpp
+++ b/libs/CCAppCommon/src/ccApplicationBase.cpp
@@ -273,15 +273,51 @@ void ccApplicationBase::setupPaths()
 
 bool ccApplicationBase::setAppStyle(QString styleKey)
 {
-	QStyle* style = QStyleFactory::create(styleKey);
-	if (!style)
+	const auto loadStyleSheet = [this](const QString& resourcePath)
 	{
-		ccLog::Warning("Invalid style key or style couldn't be created: " + styleKey);
-		return false;
-	}
+		QFile f(resourcePath);
+		if (!f.exists())
+		{
+			f.close();
+			return false;
+		}
+		else
+		{
+			f.open(QFile::ReadOnly | QFile::Text);
+			QTextStream ts(&f);
+			setStyleSheet(ts.readAll());
+			f.close();
+			return true;
+		}
+	};
 
-	ccLog::Print("Applying application style: " + styleKey);
-	setStyle(style);
+	if (styleKey == "QDarkStyleSheet::Dark")
+	{
+		if (!loadStyleSheet(":qdarkstyle/dark/darkstyle.qss"))
+		{
+			return false;
+		}
+	}
+	else if (styleKey == "QDarkStyleSheet::Light")
+	{
+		if (!loadStyleSheet(":qdarkstyle/light/lightstyle.qss"))
+		{
+			return false;
+		}
+	}
+	else
+	{
+		QStyle* style = QStyleFactory::create(styleKey);
+		if (!style)
+		{
+			ccLog::Warning("Invalid style key or style couldn't be created: " + styleKey);
+			return false;
+		}
+
+		setStyleSheet({});
+		ccLog::Print("Applying application style: " + styleKey);
+		setStyle(style);
+	}
 
 	// remember the style in persistent settings
 	QSettings settings;

--- a/libs/CCAppCommon/src/ccDisplayOptionsDlg.cpp
+++ b/libs/CCAppCommon/src/ccDisplayOptionsDlg.cpp
@@ -22,6 +22,7 @@
 
 //local
 #include "ccQtHelpers.h"
+#include "ccPersistentSettings.h"
 
 #include <ccLog.h>
 
@@ -30,6 +31,7 @@
 #include <QStyleFactory>
 
 #include <cassert>
+#include <QSettings>
 
 //Default 'min cloud size' for LoD  when VBOs are activated
 constexpr double s_defaultMaxVBOCloudSizeM = 50.0;
@@ -91,26 +93,34 @@ ccDisplayOptionsDlg::ccDisplayOptionsDlg(QWidget* parent)
 
 	// fill the application style combo-box
 	{
-		// store the default style (= the active one when the dialog is first shown)
-		QStyle* defaultStyle = ccApp->style();
-		QString defaultAppStyle;
-		if (defaultStyle)
+		// Store the default style (= the active one when the dialog is first shown)
+		// Which is necessarily the key currently stored in persistent settings
+		// since this is saved each time the current setting is selected,
+		// and since it's the first time the user opens the settings for this session,
+		// then, the style was not changed.
+		QSettings settings;
+		settings.beginGroup(ccPS::AppStyle());
+		const QString defaultStyleName = settings.value("style").toString();
+		settings.endGroup();
+
+				// fill the combo-box
+		QStringList appStyles = QStyleFactory::keys();
+		for (const auto & style : appStyles)
 		{
-			defaultAppStyle = defaultStyle->objectName();
+				m_ui->appStyleComboBox->addItem(style);
 		}
 
-		// fill the combo-box
-		QStringList appStyles = QStyleFactory::keys();
-		for (int i = 0; i < appStyles.size(); ++i)
-		{
-			const QString& style = appStyles[i];
-			m_ui->appStyleComboBox->addItem(style);
+		m_ui->appStyleComboBox->addItem(QStringLiteral("QDarkStyleSheet::Light"));
+		m_ui->appStyleComboBox->addItem(QStringLiteral("QDarkStyleSheet::Dark"));
 
-			if (style.compare(defaultAppStyle, Qt::CaseInsensitive) == 0)
+		for (int i = 0; i < m_ui->appStyleComboBox->count(); ++i)
+		{
+			if (m_ui->appStyleComboBox->itemText(i).compare(defaultStyleName, Qt::CaseInsensitive) == 0)
 			{
 				m_defaultAppStyleIndex = i;
 			}
 		}
+
 		m_ui->appStyleComboBox->setCurrentIndex(m_defaultAppStyleIndex);
 	}
 


### PR DESCRIPTION
This adds to CC a Dark (and also a light) theme
using the QDarkStyleSheet (https://github.com/ColinDuquesnoy/QDarkStyleSheet)

This dark theme is not perfect but a bit better than not having not dark theme at all for platforms that do not have one by default like Windows.