### PR TITLE
Remove mamba reference (conda 23.10+ should use the mamba resolver)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,6 @@ jobs:
           activate-environment: CloudCompareDev
           auto-activate-base: false
           environment-file: ${{ matrix.config.conda_dep_file }}
-          mamba-version: "*"
 
       - name: Configure MSVC console (Windows)
         if: matrix.config.os == 'windows-latest'


### PR DESCRIPTION
Fixes the CI build that wrongly force to use mamba to speed up the process. Performance should be on par with mamba.