### PR TITLE
Add qVoxFall to the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,7 @@ jobs:
             -DPLUGIN_STANDARD_QRANSAC_SD=ON \
             -DPLUGIN_STANDARD_QPCL=ON \
             -DPLUGIN_STANDARD_QCLOUDLAYERS=ON \
+            -DPLUGIN_STANDARD_QVOXFALL=ON \
             .
 
       - name: Build
@@ -200,6 +201,7 @@ jobs:
           -DPLUGIN_STANDARD_QRANSAC_SD=ON
           -DPLUGIN_STANDARD_QPCL=ON
           -DPLUGIN_STANDARD_QCLOUDLAYERS=ON
+          -DPLUGIN_STANDARD_QVOXFALL=ON
           -DBUILD_TESTING=ON
 
       - name: Build


### PR DESCRIPTION
- Update qVoxFall to point to the latest commit (it makes qVoxFall cross platform and leaks less memory :D)
- add qVoxFall to the CI for all supported platforms.