### PR TITLE
correct bug in command line call for the setting of the computation mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ Bug fixes:
 	- When specifying some scalar fields by name or by index as weights to the ICP command line, those would be ignored
 	- E57/PCD: when saving a cloud after having applied a 'reflection' transformation (e.g. inverting a single axis), the saved
 		sensor pose was truncated due to the internal representation of these formats (as a quaternion)
+	- M3C2: 
+		- force the vertical mode in CLI call when NormalMode=3 is requested (needed in case of multiple calls in the same command line)
 
 v2.13.2 (Kharkiv) - (06/30/2024)
 ----------------------

--- a/plugins/core/Standard/qM3C2/include/qM3C2Dialog.h
+++ b/plugins/core/Standard/qM3C2/include/qM3C2Dialog.h
@@ -72,6 +72,9 @@ public:
 	//! Returns selected export option
 	ExportOptions getExportOption() const;
 
+	//! Returns the computation mode read in the parameter file (usefull in command line calls)
+	qM3C2Normals::ComputationMode getRequestedComputationMode() const {return m_requestedComputationMode;}
+
 	//! Returns whether the original cloud should be kept instead of creating a new output one
 	/** Only valid if the export option is PROJECT_ON_CORE_POINTS.
 	**/
@@ -126,6 +129,9 @@ protected: //members
 	ccPointCloud* m_cloud1;
 	ccPointCloud* m_cloud2;
 	ccPointCloud* m_corePointsCloud;
+
+	//! Computation mode requested in a parameter file during a command line call
+	qM3C2Normals::ComputationMode m_requestedComputationMode = qM3C2Normals::DEFAULT_MODE;
 };
 
 #endif //Q_M3C2_DIALOG_HEADER

--- a/plugins/core/Standard/qM3C2/src/qM3C2Dialog.cpp
+++ b/plugins/core/Standard/qM3C2/src/qM3C2Dialog.cpp
@@ -377,8 +377,8 @@ qM3C2Normals::ComputationMode qM3C2Dialog::getNormalsComputationMode() const
 	{
 		if (getRequestedComputationMode() == qM3C2Normals::VERT_MODE)
 		{
-			return qM3C2Normals::VERT_MODE;
 			ccLog::Print("[M3C2] force vertical mode as requested in the parameter file");
+			return qM3C2Normals::VERT_MODE;
 		}
 	}
 

--- a/plugins/core/Standard/qM3C2/src/qM3C2Dialog.cpp
+++ b/plugins/core/Standard/qM3C2/src/qM3C2Dialog.cpp
@@ -279,7 +279,7 @@ void qM3C2Dialog::updateNormalComboBox()
 	{
 		normalSourceComboBox->setCurrentIndex(lastIndex); //default mode
 	}
-	
+
 	if (m_cloud1 && m_cloud1->hasNormals())
 	{
 		normalSourceComboBox->addItem("Use cloud #1 normals", QVariant(qM3C2Normals::USE_CLOUD1_NORMALS));
@@ -290,7 +290,7 @@ void qM3C2Dialog::updateNormalComboBox()
 			previouslySelectedItem = qM3C2Normals::USE_CLOUD1_NORMALS;
 		}
 	}
-	
+
 	if (cpUseOtherCloudRadioButton->isChecked())
 	{
 		//return the cloud currently selected in the combox box
@@ -372,6 +372,16 @@ void qM3C2Dialog::setCloud2Visibility(bool state)
 
 qM3C2Normals::ComputationMode qM3C2Dialog::getNormalsComputationMode() const
 {
+	// force vertical mode if needed in command line mode
+	if (!m_app)
+	{
+		if (getRequestedComputationMode() == qM3C2Normals::VERT_MODE)
+		{
+			return qM3C2Normals::VERT_MODE;
+			ccLog::Print("[M3C2] force vertical mode as requested in the parameter file");
+		}
+	}
+
 	//special case
 	if (normalSourceComboBox->currentIndex() >= 0)
 	{
@@ -649,6 +659,10 @@ bool qM3C2Dialog::loadParamsFromFile(QString filename)
 	}
 
 	loadParamsFrom(fileSettings);
+
+	// load the requested normal mode from the parameter file (used in command line calls)
+	int normalMode = fileSettings.value("NormalMode", static_cast<int>(qM3C2Normals::DEFAULT_MODE)).toInt();
+	m_requestedComputationMode = static_cast<qM3C2Normals::ComputationMode>(normalMode);
 
 	return true;
 }


### PR DESCRIPTION
When calling M3C2 multiple times in the same command line call, depending on the configuration (cloud1 with normals), the second call may fail if the vertical mode is requested. In case the vertical mode is requested, force it.