### PR TITLE
qLASIO : Initial support of COPC format (File Reading)

### DIFF
--- a/plugins/core/IO/qLASIO/include/CMakeLists.txt
+++ b/plugins/core/IO/qLASIO/include/CMakeLists.txt
@@ -17,6 +17,8 @@ target_sources(${PROJECT_NAME}
         ${CMAKE_CURRENT_LIST_DIR}/LasVlr.h
         ${CMAKE_CURRENT_LIST_DIR}/LasSaver.h
         ${CMAKE_CURRENT_LIST_DIR}/LasWaveformSaver.h
+        ${CMAKE_CURRENT_LIST_DIR}/CopcVlrs.h
+        ${CMAKE_CURRENT_LIST_DIR}/CopcLoader.h
         )
 
 target_include_directories(${PROJECT_NAME}

--- a/plugins/core/IO/qLASIO/include/CopcLoader.h
+++ b/plugins/core/IO/qLASIO/include/CopcLoader.h
@@ -222,8 +222,8 @@ namespace copc
 		CCVector3d     m_globalShift;
 		UnscaledExtent m_extent;
 
-		bool m_hasClippingConstraint;
-		bool m_hasMaxLevelConstraint;
+		bool m_hasClippingConstraint{false};
+		bool m_hasMaxLevelConstraint{false};
 
 		int32_t        m_maxLevelConstraint{0};
 		UnscaledExtent m_ClippingConstraint;

--- a/plugins/core/IO/qLASIO/include/CopcLoader.h
+++ b/plugins/core/IO/qLASIO/include/CopcLoader.h
@@ -21,7 +21,6 @@
 #include "CopcVlrs.h"
 #include "LasDetails.h"
 
-// CC
 // Qt
 #include <QFile>
 
@@ -43,8 +42,6 @@ using namespace LasDetails;
 
 namespace copc
 {
-	using MyBox = CCCoreLib::BoundingBoxTpl<double>;
-
 	class CopcLoader
 	{
 	  public: // methods

--- a/plugins/core/IO/qLASIO/include/CopcLoader.h
+++ b/plugins/core/IO/qLASIO/include/CopcLoader.h
@@ -1,0 +1,235 @@
+#pragma once
+
+// ##########################################################################
+// #                                                                        #
+// #                CLOUDCOMPARE PLUGIN: LAS-IO Plugin                      #
+// #                            COPCLoader                                  #
+// #                                                                        #
+// #  This program is free software; you can redistribute it and/or modify  #
+// #  it under the terms of the GNU General Public License as published by  #
+// #  the Free Software Foundation; version 2 of the License.               #
+// #                                                                        #
+// #  This program is distributed in the hope that it will be useful,       #
+// #  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+// #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+// #  GNU General Public License for more details.                          #
+// #                                                                        #
+// #                   COPYRIGHT: Hobu, Inc.                           	    #
+// #                                                                        #
+// ##########################################################################
+
+#include "CopcVlrs.h"
+#include "LasDetails.h"
+
+// CC
+// TODO LOD
+//#include "ccPointCloudLOD.h"
+
+// Qt
+#include <QFile>
+
+// Laszip
+#include <laszip/laszip_api.h>
+
+// System
+#include <cstdint>
+#include <functional>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+// CCCoreLib
+#include <CCGeom.h>
+#include <ccLog.h>
+
+using namespace LasDetails;
+
+namespace copc
+{
+	using MyBox = CCCoreLib::BoundingBoxTpl<double>;
+
+	class CopcLoader
+	{
+	  public: // methods
+		/// Constructor
+		///
+		/// because the constructor could fail, the user should use isValid() check before
+		/// using the instance.
+		explicit CopcLoader(const laszip_header* laszipHeader, const QString& fileName);
+
+		~CopcLoader() = default;
+
+		/// We do not want copy constructor and assigment for now.
+		CopcLoader(CopcLoader const&)            = delete;
+		CopcLoader& operator=(CopcLoader const&) = delete;
+
+		/// Enable and set the max level constraint
+		void setMaxLevelConstraint(uint32_t maxLevelConstraint)
+		{
+			m_hasMaxLevelConstraint = true;
+			m_maxLevelConstraint    = maxLevelConstraint;
+		}
+
+		/// Release the max level constraint and set the max level to the max level of the octree
+		void releaseMaxLevelConstraint()
+		{
+			m_hasMaxLevelConstraint = false;
+			m_maxLevelConstraint    = m_maxLevel;
+		}
+
+		/// Enable and set the clipping box constraint
+		void setClippingBoxConstraint(const LasDetails::UnscaledExtent& extent)
+		{
+			m_hasClippingConstraint = true;
+			m_ClippingConstraint    = extent;
+		}
+
+		/// Release the clipping Constraint and reset the clipping box to the root extent
+		void releaseClippingBoxConstraint()
+		{
+			m_hasClippingConstraint = false;
+			m_ClippingConstraint    = m_extent;
+		}
+
+		/// Returns an array containing the number of point at each level
+		/// (sequantially and from the root to the deepest depth)
+		const std::vector<uint64_t>& levelPointCounts() const
+		{
+			return m_levelPointCounts;
+		}
+
+		/// Returns the current full (non clipped) extent
+		const LasDetails::UnscaledExtent& extent() const
+		{
+			return m_extent;
+		}
+
+		/// Returns the current clippingExtent
+		const LasDetails::UnscaledExtent& clippingExtent() const
+		{
+			return m_ClippingConstraint;
+		}
+
+		/// Returns the Maximal number of Level (i.e; depth)
+		/// of the current COPC octree.
+		const int32_t maxLevel() const
+		{
+			return m_maxLevel;
+		}
+
+		/// Returns the validity of the viewer.
+		///
+		/// this is set by the constructor.
+		/// User of this class have the responsibility to check this getter
+		/// before any usage of the instance of the CopcLoader.
+		bool isValid() const
+		{
+			return m_isValid;
+		}
+
+		/// Set global shift. This is used by
+		void setGlobalShift(const CCVector3d& globalShift)
+		{
+			m_globalShift = globalShift;
+		}
+
+		/// Get the ChunkIntervals of this COPCfile
+		///
+		/// The entire ChunkInterval vector/set is sorted by pointOffset to minimize seeking.
+		/// It is a vector of references because file reading could have side effect on ChunkIntervals.
+		/// Moreover an estimatedPointCount is returned in order to resize the CC point cloud.
+		/// estimatedPointCount is only an estimation if a Clipping constraint is set, because points in intersected node
+		/// can only be filtered during file reading. if no clipping constraint is set, the estimatedPointCount variable represent the true number of points.
+		void getChunkIntervalsSet(std::vector<std::reference_wrapper<ChunkInterval>>& sortedChunkIntervalSet, uint64_t& estimatedPointCount);
+
+		/// Recurse COPC octree and create a CC LOD matching this Hierachy
+		// TODO LOD
+		//std::vector<ccGenericPointCloudLOD::Level> createLOD();
+
+	  public: // static methods
+		/// Determive if the file has the potential to contains COPC structure
+		static bool IsPutativeCOPCFile(const laszip_header* laszipHeader)
+		{
+
+			return laszipHeader->version_minor >= COPC_LAS_VERSION_MINOR
+			       && laszipHeader->point_data_format > COPC_LAS_DATA_FORMAT_GT
+			       && laszipHeader->point_data_format < COPC_LAS_DATA_FORMAT_LT
+			       && laszipHeader->number_of_variable_length_records > 0
+			       && IsCOPCVlr(laszipHeader->vlrs[0]);
+		}
+
+		/// Check if a given VLR is a COPC one
+		///
+		/// Notes: COPC VLR has to be at id 0 of the vlr array.
+		static bool IsCOPCVlr(const laszip_vlr_struct& vlr)
+		{
+			if (strcmp(COPC_USER_ID, vlr.user_id) == 0 && vlr.record_id == COPC_RECORD_ID)
+			{
+				return true;
+			}
+			return false;
+		}
+
+	  private: // methods
+		/// Generate the chunk table hierarchy from COPC entries
+		///
+		/// Entries are supposed to be contiguous.
+		/// They are sorted and then parsed sequentially to retrieve the first point
+		/// for each entry.
+		///	This is because LAZLib (in its public API) can only seek within a file by point but NOT by byte.
+		/// we rely on the same trick than LASLib and use a kind of proxy class (here ChunkInterval)
+		/// to transform COPC entries into a datastructure than can match the "limitations" of the LASZip API.
+		/// After creation ChunkIntervals are inserted into an octree, i.e a std::unordered_map using voxelKey
+		/// as key.
+		void generateChunktableIntervalsHierarchy(std::vector<Entry>& entries);
+
+		/// Check if a given VoxelKey pass constraints/filter tests and return its status
+		ChunkInterval::eFilterStatus checkConstraints(const VoxelKey& voxelkey);
+
+		/// Reset the satus of the chunkIntervals
+		void resetIntervalsStatus();
+
+		/// Recursively propage failure fag to COPC nodes
+		void propagateFailureFlag(const VoxelKey& voxelkey);
+
+		/// Recursively Flag ChunkIntervals (i.e check constraints of each VoxelKey)
+		uint64_t flagIntervalNodes(const VoxelKey& voxelkey);
+
+		/// Recurse the COPC tree and emplace visited VoxelKeys into
+		void recurse(const VoxelKey& voxelkey, std::unordered_set<VoxelKey>& visitedNodes);
+
+		/// Traverse the COPC octree and if all nodes are reachables.
+		bool isTraversable();
+
+		/// Consistancy check: check if the root node exists
+		bool hasRoot()
+		{
+			return m_chunkIntervalsHierarchy.count(VoxelKey::Root());
+		}
+
+	  private: // static members
+		/// static members used to check if a file is a COPC
+		static const uint8_t         COPC_LAS_VERSION_MINOR{4};
+		static const uint8_t         COPC_LAS_DATA_FORMAT_GT{5};
+		static const uint8_t         COPC_LAS_DATA_FORMAT_LT{9};
+		static const uint8_t         COPC_RECORD_ID{1};
+		static constexpr const char* COPC_USER_ID = "copc";
+
+	  private: // members
+		bool           m_isValid{false};
+		int32_t        m_maxLevel{0};
+		uint64_t       m_numPoints{0};
+		CCVector3d     m_globalShift;
+		UnscaledExtent m_extent;
+
+		bool m_hasClippingConstraint;
+		bool m_hasMaxLevelConstraint;
+
+		int32_t        m_maxLevelConstraint{0};
+		UnscaledExtent m_ClippingConstraint;
+
+		std::vector<uint64_t>                       m_levelPointCounts;
+		std::unordered_map<VoxelKey, ChunkInterval> m_chunkIntervalsHierarchy;
+		Info                                        m_copcInfo;
+	};
+} // namespace copc

--- a/plugins/core/IO/qLASIO/include/CopcVlrs.h
+++ b/plugins/core/IO/qLASIO/include/CopcVlrs.h
@@ -37,7 +37,6 @@
 /// this is based on COPC v1 specs. See https://copc.io for documentation
 namespace copc
 {
-
 	struct Info
 	{
 		/// Extract extent
@@ -263,8 +262,8 @@ namespace std
 		{
 			std::hash<uint64_t> h;
 
-			uint64_t k1 = ((uint64_t)key.level << 32) | key.x;
-			uint64_t k2 = ((uint64_t)key.y << 32) | key.z;
+			uint64_t k1 = (static_cast<uint64_t>(key.level) << 32) | key.x;
+			uint64_t k2 = (static_cast<uint64_t>(key.y) << 32) | key.z;
 			return h(k1) ^ (h(k2) << 1);
 		}
 	};

--- a/plugins/core/IO/qLASIO/include/CopcVlrs.h
+++ b/plugins/core/IO/qLASIO/include/CopcVlrs.h
@@ -92,7 +92,6 @@ namespace copc
 		uint64_t root_hier_offset{0};
 		uint64_t root_hier_size{0};
 
-		/// TODO
 		double gpstime_minimum{0.0};
 		double gpstime_maximum{0.0};
 

--- a/plugins/core/IO/qLASIO/include/CopcVlrs.h
+++ b/plugins/core/IO/qLASIO/include/CopcVlrs.h
@@ -1,0 +1,271 @@
+#pragma once
+
+// ##########################################################################
+// #                                                                        #
+// #                CLOUDCOMPARE PLUGIN: LAS-IO Plugin                      #
+// #                            COPCLoader                                  #
+// #                                                                        #
+// #  This program is free software; you can redistribute it and/or modify  #
+// #  it under the terms of the GNU General Public License as published by  #
+// #  the Free Software Foundation; version 2 of the License.               #
+// #                                                                        #
+// #  This program is distributed in the hope that it will be useful,       #
+// #  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+// #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+// #  GNU General Public License for more details.                          #
+// #                                                                        #
+// #                   COPYRIGHT: Hobu, Inc.                           	    #
+// #                                                                        #
+// ##########################################################################
+
+// qLASIO
+#include "LasDetails.h"
+
+// CCCoreLib
+#include <CCGeom.h>
+
+// Qt
+#include <QDataStream>
+
+// System
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+/// COPC structs as defined in the specs
+/// We kept COPC naming convention (snake case)
+/// this is based on COPC v1 specs. See https://copc.io for documentation
+namespace copc
+{
+
+	struct Info
+	{
+		/// Extract extent
+		///
+		/// return true if extent is valid false otherwise
+		/// Note that COPC extent is cubic, it's the extent of the
+		/// COPC octree, not the BB of the points.
+		bool extractExtent(LasDetails::UnscaledExtent& extent) const
+		{
+			extent.clear();
+			CCVector3d center(center_x, center_y, center_z);
+			CCVector3d halfsizeVec(halfsize, halfsize, halfsize);
+			extent.add(center + halfsizeVec);
+			extent.add(center - halfsizeVec);
+			// it should be valid ;) but we test its norm too
+			// maybe we could also test it's a cube
+			return extent.isValid() && extent.getDiagNormd() > 0;
+		}
+
+		/// Overload the stream extraction operation to read an Info object from a QDataStream.
+		friend QDataStream& operator>>(QDataStream& stream, Info& copc_info)
+		{
+			// use quint64 for linux compat (macOS and Win are fine)
+			quint64 root_hier_offset_, root_hier_size_, reserved_;
+			stream.setByteOrder(QDataStream::ByteOrder::LittleEndian);
+			stream >> copc_info.center_x >> copc_info.center_y >> copc_info.center_z;
+			stream >> copc_info.halfsize >> copc_info.spacing;
+			stream >> root_hier_offset_ >> root_hier_size_;
+			copc_info.root_hier_offset = root_hier_offset_;
+			copc_info.root_hier_size   = root_hier_size_;
+			stream >> copc_info.gpstime_minimum >> copc_info.gpstime_minimum;
+			// Flush reserved
+			std::for_each(std::begin(copc_info.reserved), std::end(copc_info.reserved), [&stream, &reserved_](auto& reserved)
+			              { stream >> reserved_; });
+			return stream;
+		};
+
+		static constexpr size_t SIZE = 160;
+
+		/// Geometric parameters (root cell extent)
+		double center_x{0.0};
+		double center_y{0.0};
+		double center_z{0.0};
+		double halfsize{0.0};
+		/// minimum distance between points at root (0) level.
+		/// it is supposed to be halved at each level
+		double spacing{0.0};
+
+		/// Byte offeset in the LAS file
+		/// the root node is not necessary the node comming at first
+		/// in the COPC EVRL, so it's not the start of the COPC
+		/// EVRL Reccord.
+		uint64_t root_hier_offset{0};
+		uint64_t root_hier_size{0};
+
+		/// TODO
+		double gpstime_minimum{0.0};
+		double gpstime_maximum{0.0};
+
+		/// Should be all set to 0
+		uint64_t reserved[11] = {0};
+	};
+
+	struct VoxelKey
+	{
+		/// Create an invalid Key
+		static VoxelKey Invalid()
+		{
+			return {-1, 0, 0, 0};
+		}
+
+		/// Same as default constructor but used by convenience for its semantic meaning
+		static VoxelKey Root()
+		{
+			return {0, 0, 0, 0};
+		}
+
+		/// Check if a key is valid
+		bool isValid() const
+		{
+			// branching factor in one dim is 2 so
+			// -> num cell is actually 2^level
+			// -> max id in one dimention is actually 2^level - 1
+			const int32_t numCellInOneDim = std::pow(2, level);
+			return level >= 0 && x >= 0 && y >= 0 && z >= 0 && z < numCellInOneDim && y < numCellInOneDim && x < numCellInOneDim;
+		}
+
+		/// Construct the voxel Extent (aligned BB) from a given root extent
+		bool extractExtent(const LasDetails::UnscaledExtent& rootExtent, LasDetails::UnscaledExtent& voxelExtent) const
+		{
+			if (!rootExtent.isValid())
+			{
+				return false;
+			}
+			// root is supposed to be a cube, cell width could be computed using only one dim
+			const int32_t numCellAtLevel = std::pow(2, level);
+			const double  cellSize       = (rootExtent.maxCorner().x - rootExtent.minCorner().x) / numCellAtLevel;
+
+			// Like in PDAL, we clamp the voxelExtent to rootExtent extrem points coordinates in case
+			// the voxelExtent is an extrem one too. it avoid as much as possible for rounding errors.
+			const CCVector3d minCorner(
+			    (x == 0 ? rootExtent.minCorner().x : rootExtent.minCorner().x + (cellSize * x)),
+			    (y == 0 ? rootExtent.minCorner().y : rootExtent.minCorner().y + (cellSize * y)),
+			    (z == 0 ? rootExtent.minCorner().z : rootExtent.minCorner().z + (cellSize * z)));
+
+			const int32_t    maxIdAtLevel = numCellAtLevel - 1;
+			const CCVector3d maxCorner(
+			    (x == maxIdAtLevel ? rootExtent.maxCorner().x : minCorner.x + cellSize),
+			    (y == maxIdAtLevel ? rootExtent.maxCorner().y : minCorner.y + cellSize),
+			    (z == maxIdAtLevel ? rootExtent.maxCorner().z : minCorner.z + cellSize));
+			voxelExtent = LasDetails::UnscaledExtent(minCorner, maxCorner, true);
+			return true;
+		}
+
+		/// Generate the 8 putative children for this key
+		std::array<VoxelKey, 8> childrenKeys() const
+		{
+			std::array<VoxelKey, 8> children{};
+			for (int32_t i = 0; i < 8; i++)
+			{
+				// Bitwise operation are taken from PDAL
+				// see https://github.com/PDAL/PDAL/blob/0c8e84521c040aa8a03ca848d32fb30e75a6e1ec/io/private/copc/Key.hpp#L105-L111
+				children[i].level = level + 1;
+				children[i].x     = (x << 1) | (i & 0x1);
+				children[i].y     = (y << 1) | ((i >> 1) & 0x1);
+				children[i].z     = (z << 1) | ((i >> 2) & 0x1);
+			}
+			return children;
+		}
+
+		/// return parent key of this node
+		VoxelKey parentKey() const
+		{
+			if (!isValid() || level == 0)
+			{
+				return VoxelKey::Invalid();
+			}
+			return {level - 1, x >> 1, y >> 1, z >> 1};
+		}
+
+		/// overloaded equality operator
+		bool operator==(const VoxelKey& other) const
+		{
+			return other.level == level && other.x == x && other.y == y && other.z == z;
+		};
+
+		/// Check if a given key is a valid parent of this key
+		bool isParent(const VoxelKey& other) const
+		{
+			if (!other.isValid())
+				return false;
+			return other.parentKey() == *this;
+		}
+
+		friend QDataStream& operator>>(QDataStream& stream, VoxelKey& key)
+		{
+			stream.setByteOrder(QDataStream::ByteOrder::LittleEndian);
+			stream >> key.level >> key.x >> key.y >> key.z;
+			return stream;
+		};
+
+		static constexpr size_t SIZE = 16;
+		// octree depth
+		int32_t level{0};
+		int32_t x{0};
+		int32_t y{0};
+		int32_t z{0};
+	};
+
+	struct Entry
+	{
+		/// Check if the Entry is actually a hierarchy page
+		bool isHierarchyPage() const
+		{
+			return point_count < 0;
+		}
+
+		/// Overload the stream extraction opentation to read an Info object from a QDataStream.
+		friend QDataStream& operator>>(QDataStream& stream, Entry& entry)
+		{
+			stream.setByteOrder(QDataStream::ByteOrder::LittleEndian);
+			quint64 offset_;
+			stream >> entry.key >> offset_ >> entry.byte_size >> entry.point_count;
+			entry.offset = offset_;
+			return stream;
+		};
+
+		static constexpr size_t SIZE = VoxelKey::SIZE + 16;
+		VoxelKey                key;
+		/// Absolute offset to the data chunk if the pointCount > 0.
+		/// Absolute offset to a child hierarchy page if the pointCount is -1.
+		/// 0 if the pointCount is 0.
+		uint64_t offset{0};
+		int32_t  byte_size{0};
+		/// If > 0, represents the number of points in the data chunk.
+		/// If -1, indicates the information for this octree node is found in another hierarchy page.
+		/// If 0, no point data exists for this key, though may exist for child entries.
+		int32_t point_count{0};
+	};
+
+	struct Page
+	{
+		Page(const uint64_t offset_, const size_t num_entries_)
+		    : offset(offset_)
+		    , num_entries(num_entries_)
+		{
+		}
+		~Page() = default;
+
+		uint64_t offset{0};
+		size_t   num_entries{0};
+	};
+} // namespace copc
+
+namespace std
+{
+	// Hash function taken from PDAL.
+	// see https://github.com/PDAL/PDAL/blob/0c8e84521c040aa8a03ca848d32fb30e75a6e1ec/io/private/copc/Entry.hpp#L79-L89
+	template <>
+	struct hash<copc::VoxelKey>
+	{
+		std::size_t operator()(copc::VoxelKey const& key) const noexcept
+		{
+			std::hash<uint64_t> h;
+
+			uint64_t k1 = ((uint64_t)key.level << 32) | key.x;
+			uint64_t k2 = ((uint64_t)key.y << 32) | key.z;
+			return h(k1) ^ (h(k2) << 1);
+		}
+	};
+} // namespace std

--- a/plugins/core/IO/qLASIO/include/LasDetails.h
+++ b/plugins/core/IO/qLASIO/include/LasDetails.h
@@ -26,19 +26,18 @@
 
 // System
 #include <array>
-#include <cmath>
+#include <cstdint>
 #include <limits>
-#include <string>
+
 #include <vector>
 
-// LASzip
-#include <laszip/laszip_api.h>
 
 class ccPointCloud;
 class ccScalarField;
 
 class QDataStream;
 
+struct laszip_header;
 struct laszip_vlr;
 typedef laszip_vlr laszip_vlr_struct;
 
@@ -125,19 +124,7 @@ namespace LasDetails
 	/// the "true" number of points in a las file.
 	/// the field to query in the laszip_header in order to have the number of point
 	/// is format dependant.
-	static laszip_U64 TrueNumberOfPoints(const laszip_header* laszipHeader)
-	{
-		laszip_U64 pointCount;
-		if (laszipHeader->version_minor == 4)
-		{
-			pointCount = laszipHeader->extended_number_of_point_records;
-		}
-		else
-		{
-			pointCount = laszipHeader->number_of_point_records;
-		}
-		return pointCount;
-	}
+	uint64_t TrueNumberOfPoints(const laszip_header* laszipHeader);
 
 	// The position of the overlap flag in the classification flags
 	// (valid for fmt >= 6)

--- a/plugins/core/IO/qLASIO/include/LasDetails.h
+++ b/plugins/core/IO/qLASIO/include/LasDetails.h
@@ -17,7 +17,8 @@
 //#                                                                        #
 //##########################################################################
 
-// CC
+// CCCorelib
+#include <BoundingBox.h>
 #include <CCTypes.h>
 
 // Qt
@@ -30,12 +31,14 @@
 #include <string>
 #include <vector>
 
+// LASzip
+#include <laszip/laszip_api.h>
+
 class ccPointCloud;
 class ccScalarField;
 
 class QDataStream;
 
-struct laszip_header;
 struct laszip_vlr;
 typedef laszip_vlr laszip_vlr_struct;
 
@@ -72,6 +75,70 @@ namespace LasNames
 
 namespace LasDetails
 {
+	/// Unscaled Extent for LAS or COPC
+	///
+	/// This is an alias for a double-precision bounding box (BB) that is meant to represent:
+	/// - The unscaled extent of a LAS file (as defined in the header), or
+	/// - The unscaled bounding box of a COPC file (derived from copc::Info -> center/halfsize variables).
+	///
+	/// Note: The COPC extent is cubic, corresponding to the COPC octree shape,
+	/// rather than the bounding box of the actual points.
+	using UnscaledExtent = CCCoreLib::BoundingBoxTpl<double>;
+
+	/// LAZ Chunk but with point offset in file.
+	///
+	/// This is primarily used for COPC reading.
+	/// Since the LASZip API does not allow chunk byte seeking, we use the point offset for seeking.
+	/// This data structure can also encode the offset in the current CC point cloud,
+	/// which is useful for the LOD data structure construction.
+	/// Additionally, it includes a status field that indicates whether it should be loaded (PASS),
+	/// checked during loading (INTERSECT_BB), or pruned (FAIL).
+	struct ChunkInterval
+	{
+		enum class eFilterStatus
+		{
+			PASS         = 0,
+			INTERSECT_BB = 1,
+			FAIL         = 2,
+		};
+
+		ChunkInterval() = default;
+		ChunkInterval(uint64_t _pointOffsetInFile, uint64_t _pointCount)
+		    : pointOffsetInFile(_pointOffsetInFile)
+		    , pointCount(_pointCount){};
+
+		/// point offset in the LAZ file
+		uint64_t pointOffsetInFile{0};
+		/// point offset in the CC cloud (used for LOD construction)
+		uint64_t pointOffsetInCCCloud{0};
+		/// point count in the chunk
+		uint64_t pointCount{0};
+		/// Number of points that failed the filter pass (optional)
+		/// total point for this chunk in the ccPointCloud
+		/// should be pointCount - filteredPointCount
+		uint64_t filteredPointCount{0};
+		/// encode the status of the chunk
+		/// basically chunks with FAIL status should not be loaded.
+		eFilterStatus status{eFilterStatus::PASS};
+	};
+
+	/// the "true" number of points in a las file.
+	/// the field to query in the laszip_header in order to have the number of point
+	/// is format dependant.
+	static laszip_U64 TrueNumberOfPoints(const laszip_header* laszipHeader)
+	{
+		laszip_U64 pointCount;
+		if (laszipHeader->version_minor == 4)
+		{
+			pointCount = laszipHeader->extended_number_of_point_records;
+		}
+		else
+		{
+			pointCount = laszipHeader->number_of_point_records;
+		}
+		return pointCount;
+	}
+
 	// The position of the overlap flag in the classification flags
 	// (valid for fmt >= 6)
 	constexpr unsigned OVERLAP_FLAG_BIT_POS  = 3;
@@ -98,6 +165,8 @@ namespace LasDetails
 		static EvlrHeader Waveform();
 
 		bool isWaveFormDataPackets() const;
+
+		bool isCOPCEntry() const;
 
 		friend QDataStream& operator>>(QDataStream& stream, EvlrHeader& hdr);
 		friend QDataStream& operator<<(QDataStream& stream, const EvlrHeader& hdr);

--- a/plugins/core/IO/qLASIO/include/LasOpenDialog.h
+++ b/plugins/core/IO/qLASIO/include/LasOpenDialog.h
@@ -66,6 +66,12 @@ class LasOpenDialog : public QDialog
 	void filterOutNotChecked(std::vector<LasScalarField>&      scalarFields,
 	                         std::vector<LasExtraScalarField>& extraScalarFields);
 
+	/// handle COPC tab visibility
+	void displayCopcTab(bool visibilityState);
+
+	/// set informations to fill the copc tab
+	void setCopcInformations(const std::vector<uint64_t>& level_point_count, const LasDetails::UnscaledExtent& copcBB);
+
 	/// Returns the array of extra scalar fields to be used as normals
 	std::array<LasExtraScalarField, 3> getExtraFieldsToBeLoadedAsNormals(const std::vector<LasExtraScalarField>& extraScalarFields) const;
 
@@ -92,9 +98,14 @@ class LasOpenDialog : public QDialog
 	/// Only valid when the action is Tiling
 	LasTilingOptions tilingOptions() const;
 
+	/// Returns the current extent defined in the COPC tab
+	LasDetails::UnscaledExtent copcExtent() const;
+
 	void resetShouldSkipDialog();
 
 	bool shouldSkipDialog() const;
+
+	bool hasUsableExtent() const;
 
   private:
 	bool isChecked(const LasScalarField& lasScalarField) const;
@@ -114,9 +125,12 @@ class LasOpenDialog : public QDialog
 
 	void decomposeClassificationFields(bool decompose, bool autoUpdateCheckSate);
 
+	void checkExtentConsistency(double);
+
 	/// Hides or un-hides the checkboxes that corresponds to the flag fields
 	void onDecomposeClassificationToggled(bool state);
 
   private:
 	bool m_shouldSkipDialog{false};
+	bool m_validExtent{false};
 };

--- a/plugins/core/IO/qLASIO/include/LasOpenDialog.h
+++ b/plugins/core/IO/qLASIO/include/LasOpenDialog.h
@@ -98,6 +98,12 @@ class LasOpenDialog : public QDialog
 	/// Only valid when the action is Tiling
 	LasTilingOptions tilingOptions() const;
 
+	/// Return the status of the extent defined in the COPC tab
+	bool hasUsableExtent() const;
+
+	/// Returns COPC max level :)
+	uint32_t copcMaxLevel() const;
+
 	/// Returns the current extent defined in the COPC tab
 	LasDetails::UnscaledExtent copcExtent() const;
 
@@ -105,7 +111,6 @@ class LasOpenDialog : public QDialog
 
 	bool shouldSkipDialog() const;
 
-	bool hasUsableExtent() const;
 
   private:
 	bool isChecked(const LasScalarField& lasScalarField) const;

--- a/plugins/core/IO/qLASIO/src/CMakeLists.txt
+++ b/plugins/core/IO/qLASIO/src/CMakeLists.txt
@@ -2,6 +2,7 @@
 target_sources(${PROJECT_NAME}
         PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/LasPlugin.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/CopcLoader.cpp
         ${CMAKE_CURRENT_LIST_DIR}/LasIOFilter.cpp
         ${CMAKE_CURRENT_LIST_DIR}/LasOpenDialog.cpp
         ${CMAKE_CURRENT_LIST_DIR}/LasSaveDialog.cpp

--- a/plugins/core/IO/qLASIO/src/CopcLoader.cpp
+++ b/plugins/core/IO/qLASIO/src/CopcLoader.cpp
@@ -19,6 +19,11 @@
 #include "CopcLoader.h"
 #include "CopcVlrs.h"
 
+// CCCoreLib
+#include <CCGeom.h>
+#include <ParallelSort.h>
+#include <ccLog.h>
+
 // System
 #include <algorithm>
 #include <queue>
@@ -196,7 +201,7 @@ namespace copc
 	void CopcLoader::generateChunktableIntervalsHierarchy(std::vector<Entry>& entries)
 	{
 		// Sort entries by offset to be able to get the first point of each chunk.
-		std::sort(std::begin(entries), std::end(entries), [](const Entry& a, const Entry& b)
+		ParallelSort(std::begin(entries), std::end(entries), [](const Entry& a, const Entry& b)
 		             { return a.offset < b.offset; });
 		uint64_t starting_point = 0;
 		m_chunkIntervalsHierarchy.reserve(entries.size());
@@ -351,7 +356,7 @@ namespace copc
 		               { return std::ref(kv.second); });
 
 		// sort them by starting point to optimize seeking;
-		std::sort(std::begin(sortedChunkIntervalSet), std::end(sortedChunkIntervalSet), [](const ChunkInterval& a, const ChunkInterval& b)
+		ParallelSort(std::begin(sortedChunkIntervalSet), std::end(sortedChunkIntervalSet), [](const ChunkInterval& a, const ChunkInterval& b)
 		             { return a.pointOffsetInFile < b.pointOffsetInFile; });
 	}
 

--- a/plugins/core/IO/qLASIO/src/CopcLoader.cpp
+++ b/plugins/core/IO/qLASIO/src/CopcLoader.cpp
@@ -16,14 +16,8 @@
 // #                                                                        #
 // ##########################################################################
 
-// QLASIO
 #include "CopcLoader.h"
-
 #include "CopcVlrs.h"
-
-// CCCoreLib
-#include <CCGeom.h>
-#include <ccLog.h>
 
 // System
 #include <algorithm>

--- a/plugins/core/IO/qLASIO/src/CopcLoader.cpp
+++ b/plugins/core/IO/qLASIO/src/CopcLoader.cpp
@@ -23,7 +23,6 @@
 
 // CCCoreLib
 #include <CCGeom.h>
-#include <ParallelSort.h>
 #include <ccLog.h>
 
 // System
@@ -184,7 +183,7 @@ namespace copc
 	void CopcLoader::generateChunktableIntervalsHierarchy(std::vector<Entry>& entries)
 	{
 		// Sort entries by offset to be able to get the first point of each chunk.
-		ParallelSort(std::begin(entries), std::end(entries), [](const Entry& a, const Entry& b)
+		std::sort(std::begin(entries), std::end(entries), [](const Entry& a, const Entry& b)
 		             { return a.offset < b.offset; });
 		uint64_t starting_point = 0;
 		m_chunkIntervalsHierarchy.reserve(entries.size());
@@ -339,7 +338,7 @@ namespace copc
 		               { return std::ref(kv.second); });
 
 		// sort them by starting point to optimize seeking;
-		ParallelSort(std::begin(sortedChunkIntervalSet), std::end(sortedChunkIntervalSet), [](const ChunkInterval& a, const ChunkInterval& b)
+		std::sort(std::begin(sortedChunkIntervalSet), std::end(sortedChunkIntervalSet), [](const ChunkInterval& a, const ChunkInterval& b)
 		             { return a.pointOffsetInFile < b.pointOffsetInFile; });
 	}
 

--- a/plugins/core/IO/qLASIO/src/CopcLoader.cpp
+++ b/plugins/core/IO/qLASIO/src/CopcLoader.cpp
@@ -1,0 +1,399 @@
+// ##########################################################################
+// #                                                                        #
+// #                CLOUDCOMPARE PLUGIN: LAS-IO Plugin                      #
+// #                            COPCLoader                                  #
+// #                                                                        #
+// #  This program is free software; you can redistribute it and/or modify  #
+// #  it under the terms of the GNU General Public License as published by  #
+// #  the Free Software Foundation; version 2 of the License.               #
+// #                                                                        #
+// #  This program is distributed in the hope that it will be useful,       #
+// #  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+// #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+// #  GNU General Public License for more details.                          #
+// #                                                                        #
+// #                   COPYRIGHT: Hobu, Inc.                           	    #
+// #                                                                        #
+// ##########################################################################
+
+// QLASIO
+#include "CopcLoader.h"
+
+#include "CopcVlrs.h"
+
+// CCCoreLib
+#include <CCGeom.h>
+#include <ccLog.h>
+
+// System
+#include <algorithm>
+#include <queue>
+
+namespace copc
+{
+	CopcLoader::CopcLoader(const laszip_header* laszipHeader, const QString& fileName)
+	{
+		{
+			// parse the info vlr
+			const laszip_vlr copcInfoVlr = laszipHeader->vlrs[0];
+			if (copcInfoVlr.record_length_after_header != Info::SIZE)
+			{
+				ccLog::Warning("[LAS] laszip error: invalid Copc Info");
+				return;
+			}
+
+			// extract the COPC infos
+			QDataStream copcInfoData(QByteArray::fromRawData(reinterpret_cast<const char*>(copcInfoVlr.data), Info::SIZE));
+			copcInfoData >> m_copcInfo;
+
+			if (!m_copcInfo.extractExtent(m_extent))
+			{
+				ccLog::Warning("[LAS] laszip error: invalid Copc extent");
+				return;
+			}
+			m_ClippingConstraint = m_extent;
+
+			QFile copcFile;
+			copcFile.setFileName(fileName);
+
+			if (!copcFile.open(QFile::ReadOnly))
+			{
+				ccLog::Warning("[LAS] laszip error: Unable to open the LAS file to parse COPC pages");
+				return;
+			}
+
+			// Note: the root page is not the first entry of COPC EVRL data reccord,
+			// This means we cannot obtain the EVLR header by seeking straight to `root_hier_offset` minus the EVLR header size (60).
+			// To check é&the existence of the COPC EVLR hierarchy, we'll have to iterate thought all
+			// EVLRs starting from laszip_header::start_of_first_extended_variable_length_record.
+			// We do not check the existence of the EVLR header. we seek direclty to the root_hier_offset
+			// and validate each seeking operation by checking for EOF.
+			QDataStream        copcDataSource(&copcFile);
+			std::queue<Page>   pageQueue;
+			std::vector<Entry> entries;
+			// Enque the root page
+			pageQueue.emplace(m_copcInfo.root_hier_offset, m_copcInfo.root_hier_size / Entry::SIZE);
+
+			size_t numPages = 0;
+			while (!pageQueue.empty())
+			{
+				const Page& page = pageQueue.front();
+				++numPages;
+
+				copcFile.seek(page.offset);
+				if (copcDataSource.status() == QDataStream::Status::ReadPastEnd)
+				{
+					ccLog::Warning("[LAS] Failed to read the the COPC pages (unexpected EOF");
+					return;
+				}
+				entries.reserve(entries.size() + page.num_entries);
+				QDataStream entryDataStream(&copcFile);
+				for (size_t entry_id = 0; entry_id < page.num_entries; ++entry_id)
+				{
+					Entry entry;
+					copcDataSource >> entry;
+
+					// Check the key validity and early return if it fails
+					if (!entry.key.isValid())
+					{
+						ccLog::Warning("[LAS] Failed to read the the COPC pages (invalid entry)");
+						return;
+					}
+
+					m_maxLevel = std::max(m_maxLevel, entry.key.level);
+					if (copcDataSource.status() == QDataStream::Status::ReadPastEnd)
+					{
+						ccLog::Warning("[LAS] Failed to read the the COPC pages (unexpected EOF");
+						return;
+					}
+					if (entry.isHierarchyPage())
+					{
+						pageQueue.emplace(entry.offset, entry.byte_size / Entry::SIZE);
+					}
+					else
+					{
+						m_numPoints += entry.point_count;
+						entries.push_back(std::move(entry));
+					}
+				}
+				pageQueue.pop();
+			}
+
+			ccLog::Print("[LAS] COPC file with %u pages / %lu entries / %llu points", numPages, entries.size(), m_numPoints);
+
+			// init our octree structure
+			generateChunktableIntervalsHierarchy(entries);
+
+			// Consistency check: Check the number of points in the COPC data structure
+			// is equal to the number of points in the laszip header
+			if (LasDetails::TrueNumberOfPoints(laszipHeader) != m_numPoints)
+			{
+				ccLog::Warning("[LAS] Failed to read the the COPC file (number of points in COPC structure does not match the one in LAZ header)");
+				return;
+			}
+
+			// Consistency check: Does the octree have a root node?
+			if (!hasRoot())
+			{
+				ccLog::Warning("[LAS] COPC file Missing root node");
+				return;
+			}
+
+			// No this is considered as a valid file
+			m_isValid = true;
+
+			// Fill m_levelPointCounts vector (used by UI to provide feedback)
+			m_levelPointCounts.resize(m_maxLevel + 1);
+			for (const auto& entry : entries)
+			{
+				m_levelPointCounts[entry.key.level] += entry.point_count;
+			}
+
+			// Consistency check: is the octree traversable
+			// if not, only issue a warning we will simply not handle the non-traversable part.
+			if (!isTraversable())
+			{
+				ccLog::Warning("[LAS] COPC file contains unreachable nodes");
+			}
+		}
+	}
+
+	void CopcLoader::generateChunktableIntervalsHierarchy(std::vector<Entry>& entries)
+	{
+		// Sort entries by offset to be able to get the first point of each chunk.
+		std::sort(std::begin(entries), std::end(entries), [](const Entry& a, const Entry& b)
+		          { return a.offset < b.offset; });
+		uint64_t starting_point = 0;
+		m_chunkIntervalsHierarchy.reserve(entries.size());
+		std::for_each(std::cbegin(entries), std::cend(entries), [&starting_point, this](const Entry& entry)
+		              {
+			m_chunkIntervalsHierarchy.emplace(std::make_pair(entry.key, ChunkInterval(starting_point, static_cast<uint64_t>(entry.point_count))));
+			starting_point += entry.point_count; });
+	}
+
+	ChunkInterval::eFilterStatus CopcLoader::checkConstraints(const VoxelKey& voxelkey)
+	{
+		// Level constraint takes precendence over BB constraint
+		if (m_hasMaxLevelConstraint && voxelkey.level > m_maxLevelConstraint)
+		{
+			return ChunkInterval::eFilterStatus::FAIL;
+		}
+		if (m_hasClippingConstraint)
+		{
+			LasDetails::UnscaledExtent voxelExtent;
+			bool                       valid = voxelkey.extractExtent(m_extent, voxelExtent);
+
+			// this would always pass:
+			// m_exent has been checked for consistency in the constructor
+			assert(valid);
+
+			// references for convenience
+			const auto aMin = m_ClippingConstraint.minCorner();
+			const auto aMax = m_ClippingConstraint.maxCorner();
+			const auto bMin = voxelExtent.minCorner();
+			const auto bMax = voxelExtent.maxCorner();
+
+			// works because all extents are supposed to be axis aligned
+			// test for inclusion
+			if (aMax.x >= bMax.x
+			    && aMax.y >= bMax.y
+			    && aMax.z >= bMax.z
+			    && aMin.x <= bMin.x
+			    && aMin.y <= bMin.y
+			    && aMin.z <= bMin.z)
+			{
+				return ChunkInterval::eFilterStatus::PASS;
+			}
+			// test for intersection
+			else if (aMax.x >= bMin.x
+			         && aMax.y >= bMin.y
+			         && aMax.z >= bMin.z
+			         && aMin.x <= bMax.x
+			         && aMin.y <= bMax.y
+			         && aMin.z <= bMax.z)
+			{
+				return ChunkInterval::eFilterStatus::INTERSECT_BB;
+			}
+			else
+			{
+				return ChunkInterval::eFilterStatus::FAIL;
+			}
+		}
+		return ChunkInterval::eFilterStatus::PASS;
+	}
+
+	void CopcLoader::resetIntervalsStatus()
+	{
+		std::for_each(std::begin(m_chunkIntervalsHierarchy), std::end(m_chunkIntervalsHierarchy), [](auto& kv)
+		              {
+				kv.second.status = ChunkInterval::eFilterStatus::PASS;
+				kv.second.filteredPointCount = 0; });
+	}
+
+/* TODO: create LOD
+	std::vector<ccGenericPointCloudLOD::Level> CopcLoader::createLOD()
+	{
+		size_t                                     maxNumLayers = (m_hasMaxLevelConstraint ? m_maxLevelConstraint : m_maxLevel) + 1;
+		std::vector<ccGenericPointCloudLOD::Level> lodLevels(maxNumLayers);
+
+		// keep track of the VoxelKey by insterting them in the same order than CC LOD Nodes.
+		std::vector<std::vector<VoxelKey>> lodKeys(maxNumLayers);
+		lodLevels[0].data.emplace_back(0);
+		lodKeys[0].push_back(VoxelKey::Root());
+
+		// First we populate the root level with the root node.
+		// root existence in copc hierarchy is tested in the constructor
+		// so the indexing operator should not fail.
+		const auto& rootInterval = m_chunkIntervalsHierarchy[VoxelKey::Root()];
+
+		// Create the rootNode
+		auto& rootNode          = lodLevels[0].data.back();
+		rootNode.pointCount     = rootInterval.pointCount - rootInterval.filteredPointCount;
+		rootNode.firstCodeIndex = rootInterval.pointOffsetInCCCloud;
+
+		// Compute the enclosing sphere for the root node,
+		// sphere could be computed "exactly" by retrieving each point of the root copc entry.
+		// we simply use the enclosing sphere of the node/voxel but we should try to left the possibility to compute it
+		// elsewhere
+		// the sphere center is a float in the LOD struct, so we do not use PointCoordinateType
+		// but we shift the center and force it to floating.
+		// We do no take into account Clipping.
+		CCVector3f rootSphereCenter(static_cast<float>(m_copcInfo.center_x + m_globalShift.x),
+		                            static_cast<float>(m_copcInfo.center_y + m_globalShift.y),
+		                            static_cast<float>(m_copcInfo.center_z + m_globalShift.z));
+
+		// init the sphere for the rootNode
+		rootNode.radius = static_cast<float>(m_extent.getDiagNorm()) / 2.f; // same as halfsize * sqrt(3.0)
+		rootNode.center = rootSphereCenter;
+
+		for (size_t levelIndex = 0; levelIndex < maxNumLayers - 1; ++levelIndex)
+		{
+			auto&  currLevel      = lodLevels[levelIndex];
+			size_t nextLevelIndex = levelIndex + 1;
+
+			// test the 8 children for each node of current layer and insert them in the next layer
+			for (size_t nodeIndex = 0; nodeIndex < currLevel.data.size(); ++nodeIndex)
+			{
+				auto&       parentNode = currLevel.data[nodeIndex];
+				const auto& parentKey  = lodKeys[levelIndex][nodeIndex];
+				for (const auto& childKey : parentKey.childrenKeys())
+				{
+					const auto& maybeChild = m_chunkIntervalsHierarchy.find(childKey);
+					if (maybeChild != std::end(m_chunkIntervalsHierarchy))
+					{
+						const auto& childInterval = maybeChild->second;
+						if (maybeChild->second.status != ChunkInterval::eFilterStatus::FAIL)
+						{
+							lodKeys[nextLevelIndex].push_back(childKey);
+							lodLevels[nextLevelIndex].data.emplace_back(nextLevelIndex);
+							auto& newNode          = lodLevels[nextLevelIndex].data.back();
+							newNode.firstCodeIndex = childInterval.pointOffsetInCCCloud;
+							newNode.pointCount     = childInterval.pointCount - childInterval.filteredPointCount;
+
+							LasDetails::UnscaledExtent voxelExtent;
+							childKey.extractExtent(m_extent, voxelExtent);
+							newNode.radius                                   = static_cast<float>(voxelExtent.getDiagNorm()) / 2.f;
+							const CCVector3d centerd                         = voxelExtent.getCenter();
+							newNode.center                                   = CCVector3f(static_cast<float>(centerd.x + m_globalShift.x),
+                                                        static_cast<float>(centerd.y + m_globalShift.y),
+                                                        static_cast<float>(centerd.z + m_globalShift.z));
+							parentNode.childIndexes[parentNode.childCount++] = lodKeys[nextLevelIndex].size() - 1;
+						}
+					}
+				}
+			}
+		}
+		return lodLevels;
+	}*/
+
+	void CopcLoader::propagateFailureFlag(const VoxelKey& voxelkey)
+	{
+		if (voxelkey.level > m_maxLevel)
+		{
+			return;
+		}
+		auto maybeNode = m_chunkIntervalsHierarchy.find(voxelkey);
+		if (maybeNode != std::end(m_chunkIntervalsHierarchy))
+		{
+			maybeNode->second.status = ChunkInterval::eFilterStatus::FAIL;
+			for (const auto& childKey : voxelkey.childrenKeys())
+			{
+				propagateFailureFlag(childKey);
+			}
+		}
+	}
+
+	void CopcLoader::recurse(const VoxelKey& voxelkey, std::unordered_set<VoxelKey, std::hash<VoxelKey>>& visitedNodes)
+	{
+		if (voxelkey.level <= m_maxLevel && m_chunkIntervalsHierarchy.count(voxelkey))
+		{
+			visitedNodes.insert(voxelkey);
+			for (const auto& childKey : voxelkey.childrenKeys())
+			{
+				recurse(childKey, visitedNodes);
+			}
+		}
+	}
+
+	bool CopcLoader::isTraversable()
+	{
+		std::unordered_set<VoxelKey> visitedNodes;
+		recurse(VoxelKey::Root(), visitedNodes);
+		return visitedNodes.size() == m_chunkIntervalsHierarchy.size();
+	}
+
+	uint64_t CopcLoader::flagIntervalNodes(const VoxelKey& voxelkey)
+	{
+		uint64_t pointCount = 0;
+		auto     maybeNode  = m_chunkIntervalsHierarchy.find(voxelkey);
+		if (maybeNode != std::end(m_chunkIntervalsHierarchy))
+		{
+			auto& node  = maybeNode->second;
+			node.status = checkConstraints(voxelkey);
+			if (node.status == ChunkInterval::eFilterStatus::FAIL && voxelkey.level < m_maxLevel)
+			{
+				propagateFailureFlag(voxelkey);
+			}
+			else
+			{
+				pointCount = node.pointCount;
+				if (voxelkey.level < m_maxLevel)
+				{
+					const auto childrenKeys = voxelkey.childrenKeys();
+					for (const auto& childKey : childrenKeys)
+					{
+						pointCount += flagIntervalNodes(childKey);
+					}
+				}
+				// node with 0 point at a a given level are allowed but here
+				// the entire traversal at this node does not provides any point,
+				// so it's a "failure".
+				if (pointCount == 0)
+				{
+					node.status = ChunkInterval::eFilterStatus::FAIL;
+				}
+			}
+		}
+		return pointCount;
+	}
+
+	void CopcLoader::getChunkIntervalsSet(std::vector<std::reference_wrapper<ChunkInterval>>& sortedChunkIntervalSet, uint64_t& estimatedPointCount)
+	{
+		resetIntervalsStatus();
+		estimatedPointCount = 0;
+		sortedChunkIntervalSet.clear();
+		sortedChunkIntervalSet.reserve(m_chunkIntervalsHierarchy.size());
+
+		// start by the root and flag all the hierachy according to constraints;
+		estimatedPointCount = flagIntervalNodes(VoxelKey::Root());
+
+		// fill sortedChunkIntervalSet with m_chunkIntervalsHierarchy values
+		std::transform(std::begin(m_chunkIntervalsHierarchy), std::end(m_chunkIntervalsHierarchy), std::back_inserter(sortedChunkIntervalSet), [](auto& kv)
+		               { return std::ref(kv.second); });
+
+		// sort them by starting point to optimize seeking;
+		std::sort(std::begin(sortedChunkIntervalSet), std::end(sortedChunkIntervalSet), [](const ChunkInterval& a, const ChunkInterval& b)
+		          { return a.pointOffsetInFile < b.pointOffsetInFile; });
+	}
+
+} // namespace copc

--- a/plugins/core/IO/qLASIO/src/CopcLoader.cpp
+++ b/plugins/core/IO/qLASIO/src/CopcLoader.cpp
@@ -62,12 +62,12 @@ namespace copc
 				return;
 			}
 
-			// Note: the root page is not the first entry of COPC EVRL data reccord,
+			// Note: the root page is generally not the first entry of COPC EVRL data reccord,
 			// This means we cannot obtain the EVLR header by seeking straight to `root_hier_offset` minus the EVLR header size (60).
-			// To check é&the existence of the COPC EVLR hierarchy, we'll have to iterate thought all
-			// EVLRs starting from laszip_header::start_of_first_extended_variable_length_record.
-			// We do not check the existence of the EVLR header. we seek direclty to the root_hier_offset
-			// and validate each seeking operation by checking for EOF.
+			// To check the existence of the COPC EVLR hierarchy, we'll have to iterate thought all
+			// EVLRs starting from laszip_header::start_of_first_extended_variable_length_record...
+			// Here we do not check the existence of the EVLR header. we seek directly to the root_hier_offset
+			// and validate each seeking operation by checking for EOF which should be robust enough.
 			QDataStream        copcDataSource(&copcFile);
 			std::queue<Page>   pageQueue;
 			std::vector<Entry> entries;
@@ -119,7 +119,7 @@ namespace copc
 				pageQueue.pop();
 			}
 
-			ccLog::Print("[LAS] COPC file with %u pages / %lu entries / %llu points", numPages, entries.size(), m_numPoints);
+			ccLog::Print("[LAS] COPC file with %zu pages / %zu entries / %llu points", numPages, entries.size(), m_numPoints);
 
 			// init our octree structure
 			generateChunktableIntervalsHierarchy(entries);
@@ -150,7 +150,7 @@ namespace copc
 			}
 
 			// Consistency check: is the octree traversable
-			// if not, only issue a warning we will simply not handle the non-traversable part.
+			// Otherwise, we only issue a warning. We will simply not handle the non-traversable part.
 			if (!isTraversable())
 			{
 				ccLog::Warning("[LAS] COPC file contains unreachable nodes");
@@ -236,7 +236,7 @@ namespace copc
 		size_t                                     maxNumLayers = (m_hasMaxLevelConstraint ? m_maxLevelConstraint : m_maxLevel) + 1;
 		std::vector<ccGenericPointCloudLOD::Level> lodLevels(maxNumLayers);
 
-		// keep track of the VoxelKey by insterting them in the same order than CC LOD Nodes.
+		// keep track of the VoxelKey by inserting them in the same order than CC LOD Nodes.
 		std::vector<std::vector<VoxelKey>> lodKeys(maxNumLayers);
 		lodLevels[0].data.emplace_back(0);
 		lodKeys[0].push_back(VoxelKey::Root());

--- a/plugins/core/IO/qLASIO/src/LasDetails.cpp
+++ b/plugins/core/IO/qLASIO/src/LasDetails.cpp
@@ -57,6 +57,20 @@ namespace LasDetails
 		return self;
 	}
 
+	uint64_t TrueNumberOfPoints(const laszip_header* laszipHeader)
+	{
+		laszip_U64 pointCount;
+		if (laszipHeader->version_minor == 4)
+		{
+			pointCount = laszipHeader->extended_number_of_point_records;
+		}
+		else
+		{
+			pointCount = laszipHeader->number_of_point_records;
+		}
+		return pointCount;
+	}
+
 	QDataStream& operator>>(QDataStream& stream, EvlrHeader& hdr)
 	{
 		stream.setByteOrder(QDataStream::ByteOrder::LittleEndian);

--- a/plugins/core/IO/qLASIO/src/LasDetails.cpp
+++ b/plugins/core/IO/qLASIO/src/LasDetails.cpp
@@ -29,7 +29,6 @@
 #include <QDataStream>
 // System
 #include <cstring>
-#include <stdexcept>
 
 static const std::vector<unsigned>      PointFormatForV1_2{0, 1, 2, 3};
 static const std::vector<unsigned>      PointFormatForV1_3{0, 1, 2, 3, 4, 5};
@@ -41,6 +40,11 @@ namespace LasDetails
 	bool EvlrHeader::isWaveFormDataPackets() const
 	{
 		return recordID == 65'535 && strncmp(userID, "LASF_Spec", EvlrHeader::USER_ID_SIZE) == 0;
+	}
+
+	bool EvlrHeader::isCOPCEntry() const
+	{
+		return recordID == 1'000 && strncmp(userID, "copc", EvlrHeader::USER_ID_SIZE) == 0;
 	}
 
 	EvlrHeader EvlrHeader::Waveform()

--- a/plugins/core/IO/qLASIO/src/LasIOFilter.cpp
+++ b/plugins/core/IO/qLASIO/src/LasIOFilter.cpp
@@ -587,17 +587,6 @@ CC_FILE_ERROR LasIOFilter::loadFile(const QString&  fileName,
 
 	LasMetadata::SaveMetadataInto(*laszipHeader, *pointCloud, availableExtraScalarFields);
 
-	// TODO LOD
-	/*
-	if (copcLoader && m_openDialog.copcLoDCheckbox->isChecked())
-	{
-		const auto            lodLevels = copcLoader->createLOD();
-		std::vector<unsigned> indices(pointCloud->size(), 0);
-		// TODO RJ remove indices in this init call as this is no longer used
-		// TODO shrink lod to prune void cells
-		pointCloud->initLOD(lodLevels, indices);
-	}*/
-
 	container.addChild(pointCloud.release());
 
 	if (error == CC_FERR_THIRD_PARTY_LIB_FAILURE)

--- a/plugins/core/IO/qLASIO/src/LasIOFilter.cpp
+++ b/plugins/core/IO/qLASIO/src/LasIOFilter.cpp
@@ -47,6 +47,7 @@
 // System
 #include <memory>
 #include <utility>
+
 static CCVector3d GetGlobalShift(FileIOFilter::LoadParameters& parameters,
                                  bool&                         preserveCoordinateShift,
                                  const CCVector3d&             lasOffset,
@@ -88,7 +89,7 @@ static CCVector3d GetGlobalShift(FileIOFilter::LoadParameters& parameters,
 
 LasIOFilter::LasIOFilter()
     : FileIOFilter({"LAS IO Filter",
-                    3.0f, /// priority (same as the old PDAL-based plugin)
+                    3.0f, // priority (same as the old PDAL-based plugin)
                     QStringList{"las", "laz"},
                     "las",
                     QStringList{"LAS file (*.las *.laz *.copc.laz)"},
@@ -225,7 +226,7 @@ CC_FILE_ERROR LasIOFilter::loadFile(const QString&  fileName,
 	// Update chunksToReads according to the COPCLoader if needed
 	if (copcLoader)
 	{
-		const uint32_t copcUserDefinedMaxLevel = m_openDialog.copcDepthComboBox->currentData().toUInt();
+		const uint32_t copcUserDefinedMaxLevel = m_openDialog.copcMaxLevel();
 		if (copcUserDefinedMaxLevel < copcLoader->maxLevel())
 		{
 			copcLoader->setMaxLevelConstraint(copcUserDefinedMaxLevel);
@@ -233,8 +234,6 @@ CC_FILE_ERROR LasIOFilter::loadFile(const QString&  fileName,
 
 		if (m_openDialog.hasUsableExtent())
 		{
-			// BoundingBox do not have copy/move constructors;
-			// we create a temp
 			const auto clippingExtent = m_openDialog.copcExtent();
 			if (clippingExtent.isValid())
 			{

--- a/plugins/core/IO/qLASIO/src/LasOpenDialog.cpp
+++ b/plugins/core/IO/qLASIO/src/LasOpenDialog.cpp
@@ -276,6 +276,11 @@ LasDetails::UnscaledExtent LasOpenDialog::copcExtent() const
 	return extent;
 }
 
+uint32_t LasOpenDialog::copcMaxLevel() const
+{
+	return copcDepthComboBox->currentData().toUInt();
+}
+
 bool LasOpenDialog::hasUsableExtent() const
 {
 	return copcExtentGroupBox->isChecked() && m_validExtent;

--- a/plugins/core/IO/qLASIO/src/LasOpenDialog.cpp
+++ b/plugins/core/IO/qLASIO/src/LasOpenDialog.cpp
@@ -23,7 +23,11 @@
 #include <QSettings>
 #include <QStringListModel>
 
-constexpr int TILLING_TAB_INDEX = 1;
+// System
+#include <algorithm>
+
+constexpr int TILING_TAB_INDEX = 1;
+constexpr int COPC_TAB_INDEX = 2;
 
 static QListWidgetItem* CreateItem(const char* name, bool checked = true)
 {
@@ -83,19 +87,25 @@ LasOpenDialog::LasOpenDialog(QWidget* parent)
 	connect(unselectAllESFToolButton, &QPushButton::clicked, this, [&]
 	        { doSelectAllESF(false); });
 	connect(xNormalComboBox,
-	        (void (QComboBox::*)(const QString&))(&QComboBox::currentIndexChanged),
+	        (void(QComboBox::*)(const QString&))(&QComboBox::currentIndexChanged),
 	        this,
 	        &LasOpenDialog::onNormalComboBoxChanged);
 	connect(yNormalComboBox,
-	        (void (QComboBox::*)(const QString&))(&QComboBox::currentIndexChanged),
+	        (void(QComboBox::*)(const QString&))(&QComboBox::currentIndexChanged),
 	        this,
 	        &LasOpenDialog::onNormalComboBoxChanged);
 	connect(zNormalComboBox,
-	        (void (QComboBox::*)(const QString&))(&QComboBox::currentIndexChanged),
+	        (void(QComboBox::*)(const QString&))(&QComboBox::currentIndexChanged),
 	        this,
 	        &LasOpenDialog::onNormalComboBoxChanged);
 	connect(decomposeClassificationCheckBox, &QCheckBox::toggled, this, &LasOpenDialog::onDecomposeClassificationToggled);
 
+	{}
+	const auto extentSpinBoxes = copcExtentGroupBox->findChildren<QDoubleSpinBox *>();
+	for(auto extentSpinBox : extentSpinBoxes)
+	{
+		connect(extentSpinBox, (void(QDoubleSpinBox::*)(double))(&QDoubleSpinBox::valueChanged),  this, &LasOpenDialog::checkExtentConsistency);
+	}
 	// reload the last tiling output path
 	{
 		QSettings settings;
@@ -229,6 +239,56 @@ void LasOpenDialog::setAvailableScalarFields(const std::vector<LasScalarField>& 
 	}
 }
 
+void LasOpenDialog::displayCopcTab(bool visibilityState)
+{
+	actionTab->setTabVisible(COPC_TAB_INDEX, visibilityState);
+}
+
+void LasOpenDialog::setCopcInformations(const std::vector<uint64_t>& pointCountPerLevel, const LasDetails::UnscaledExtent& copcBB)
+{
+	// reset previous combo box
+	copcDepthComboBox->clear();
+	uint64_t cumulative_point_count = 0;
+	for (size_t level_id = 0; level_id < pointCountPerLevel.size(); ++level_id)
+	{
+		cumulative_point_count += pointCountPerLevel[level_id];
+		auto label = QString("level %1 (%2 points)").arg(QString::number(level_id), QString::number(cumulative_point_count));
+		copcDepthComboBox->insertItem(0, label, QVariant(static_cast<uint32_t>(level_id)));
+	}
+	copcDepthComboBox->setCurrentIndex(0);
+
+	// set extent
+	copcExtentSpinMinX->setValue(copcBB.minCorner().x);
+	copcExtentSpinMinY->setValue(copcBB.minCorner().y);
+	copcExtentSpinMinZ->setValue(copcBB.minCorner().z);
+	copcExtentSpinMaxX->setValue(copcBB.maxCorner().x);
+	copcExtentSpinMaxY->setValue(copcBB.maxCorner().y);
+	copcExtentSpinMaxZ->setValue(copcBB.maxCorner().z);
+}
+
+LasDetails::UnscaledExtent LasOpenDialog::copcExtent() const
+{
+	LasDetails::UnscaledExtent extent;
+	CCVector3d minCorner(copcExtentSpinMinX->value(), copcExtentSpinMinY->value(), copcExtentSpinMinZ->value());
+	CCVector3d maxCorner(copcExtentSpinMaxX->value(), copcExtentSpinMaxY->value(), copcExtentSpinMaxZ->value());
+	extent.add(minCorner);
+	extent.add(maxCorner);
+	return extent;
+}
+
+bool LasOpenDialog::hasUsableExtent() const
+{
+	return copcExtentGroupBox->isChecked() && m_validExtent;
+}
+
+void LasOpenDialog::checkExtentConsistency(double value)
+{
+	m_validExtent = copcExtentSpinMaxX->value() - copcExtentSpinMinX->value() > 0 &&
+	copcExtentSpinMaxY->value() - copcExtentSpinMinY->value() > 0 &&
+	copcExtentSpinMaxZ->value() - copcExtentSpinMinZ->value() > 0;
+	copcLabelWarningExtent->setVisible(!m_validExtent);
+}
+
 void LasOpenDialog::filterOutNotChecked(std::vector<LasScalarField>&      scalarFields,
                                         std::vector<LasExtraScalarField>& extraScalarFields)
 {
@@ -331,7 +391,7 @@ void LasOpenDialog::onNormalComboBoxChanged(const QString& name)
 
 LasOpenDialog::Action LasOpenDialog::action() const
 {
-	if (actionTab->currentIndex() == TILLING_TAB_INDEX)
+	if (actionTab->currentIndex() == TILING_TAB_INDEX)
 	{
 		return Action::Tile;
 	}
@@ -397,7 +457,7 @@ void LasOpenDialog::onCurrentTabChanged(int index)
 	const static QString APPLY_TEXT     = QStringLiteral("Apply");
 	const static QString APPLY_ALL_TEXT = QStringLiteral("Apply All");
 
-	if (index == TILLING_TAB_INDEX)
+	if (index == TILING_TAB_INDEX)
 	{
 		applyButton->setText(TILE_TEXT);
 		applyAllButton->setText(TILE_ALL_TEXT);

--- a/plugins/core/IO/qLASIO/src/LasVlr.cpp
+++ b/plugins/core/IO/qLASIO/src/LasVlr.cpp
@@ -17,6 +17,7 @@
 
 #include "LasVlr.h"
 
+#include "CopcLoader.h"
 #include "LasMetadata.h"
 
 // Qt
@@ -25,13 +26,13 @@
 #include <ccPointCloud.h>
 // System
 #include <algorithm>
-#include <cstring>
 
 LasVlr::LasVlr(const laszip_header& header)
 {
 	const auto vlrShouldBeCopied = [](const laszip_vlr_struct& vlr)
 	{
-		return !LasDetails::IsLaszipVlr(vlr) && !LasDetails::IsExtraBytesVlr(vlr);
+		// Currently, we avoid copying back the COPC VLR (due to potential modifications to the file)
+		return !LasDetails::IsLaszipVlr(vlr) && !LasDetails::IsExtraBytesVlr(vlr) && !copc::CopcLoader::IsCOPCVlr(vlr);
 	};
 
 	ptrdiff_t numVlrs = std::count_if(header.vlrs, header.vlrs + header.number_of_variable_length_records, vlrShouldBeCopied);

--- a/plugins/core/IO/qLASIO/ui/lasopendialog.ui
+++ b/plugins/core/IO/qLASIO/ui/lasopendialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>650</height>
+    <width>633</width>
+    <height>739</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -506,6 +506,240 @@ It will be saved as multiple tiles on the disk.</string>
           </item>
           <item>
            <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="copcTab">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <attribute name="title">
+          <string>COPC</string>
+         </attribute>
+         <layout class="QVBoxLayout" name="verticalLayout_10">
+          <item>
+           <widget class="QGroupBox" name="copcMaxDepthGroupBox">
+            <layout class="QHBoxLayout" name="copcTabHorizontalLayout">
+             <property name="sizeConstraint">
+              <enum>QLayout::SetDefaultConstraint</enum>
+             </property>
+             <item>
+              <widget class="QLabel" name="copcDepthLabel">
+               <property name="text">
+                <string>Maximum depth</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="copcDepthComboBox"/>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="copcExtentGroupBox">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="title">
+             <string>Limit extent</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_3">
+             <item row="2" column="2">
+              <widget class="QDoubleSpinBox" name="copcExtentSpinMinY">
+               <property name="decimals">
+                <number>6</number>
+               </property>
+               <property name="minimum">
+                <double>-1000000000.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>1000000000.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="4">
+              <widget class="QLabel" name="copcExtentLabelZ">
+               <property name="text">
+                <string>Z</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="copcExtentLabelMin">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Min</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="2">
+              <widget class="QLabel" name="copcExtentLabelY">
+               <property name="text">
+                <string>Y</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="2">
+              <widget class="QDoubleSpinBox" name="copcExtentSpinMaxY">
+               <property name="decimals">
+                <number>6</number>
+               </property>
+               <property name="minimum">
+                <double>-1000000000.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>1000000000.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="1">
+              <widget class="QDoubleSpinBox" name="copcExtentSpinMaxX">
+               <property name="decimals">
+                <number>6</number>
+               </property>
+               <property name="minimum">
+                <double>-1000000000.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>1000000000.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="0">
+              <widget class="QLabel" name="copcExtentLabelMax">
+               <property name="text">
+                <string>Max</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QDoubleSpinBox" name="copcExtentSpinMinX">
+               <property name="decimals">
+                <number>6</number>
+               </property>
+               <property name="minimum">
+                <double>-1000000000.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>1000000000.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="4">
+              <widget class="QDoubleSpinBox" name="copcExtentSpinMinZ">
+               <property name="decimals">
+                <number>6</number>
+               </property>
+               <property name="minimum">
+                <double>-1000000000.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>1000000000.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QLabel" name="copcExtentLabelX">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>X</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="4">
+              <widget class="QDoubleSpinBox" name="copcExtentSpinMaxZ">
+               <property name="decimals">
+                <number>6</number>
+               </property>
+               <property name="minimum">
+                <double>-1000000000.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>1000000000.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="copcLabelExtent">
+               <property name="text">
+                <string>Extent</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="4">
+              <widget class="QLabel" name="copcLabelWarningExtent">
+               <property name="styleSheet">
+                <string notr="true">color: red;</string>
+               </property>
+               <property name="text">
+                <string>Invalid extent!</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="Line" name="line">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="copcLoDCheckbox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>Map COPC hierarchy into LoD data structure</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_2">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>


### PR DESCRIPTION
This work was funded thanks to [Hobu Inc](https://github.com/hobuinc).

This is a first PR of a series to add support of [COPC](https://copc.io) file format in CloudCompare.

This PR cover only the reader part, the LOD/rendering part will come hopefully shortly after. For now, for end user, only very basic filtering operation on COPC data structure (level and spatial) filtering are available in a dedicated tab of the LAS windows. (LOD filling code is available and commented in the PR.)

The decision was made to minimize the impact on the CC Codebase, ensuring a fast adoption of COPC in CC. Therefore, we rely on LASZip's point-seeking capability (instead of a more natural "byte seeking"), similar to the approach used in the LAStools implementation.

As a result, this implementation face two limitations. First, LASZip accepts int64 for seeking but it internally narrows it to an uint32, thus we are limited to file of approx. 4,2B points. Addressing this would require a fix upstream or to vendor our own LASZip version with a fix. This is unfortunately a known issue of [LASZip](https://github.com/LASzip/LASzip/issues/76). Second, due to the use of kind global state in LASZip, it lacks parallel processing capabilities, preventing us from leveraging parallel chunk processing. 

Laz-perf would have been an ideal candidate to replace LASZip in qLASIO, but it would have introduced additional complexity in maintenance, both on the CC side (requiring another change of the LAS/LAZ library and the IO plugin) and within laz-perf itself, as it lacks support for FWF (point formats 4, 5, 9, and 10), which some CC users requires. 

In the current state of CC these limitations have no impact. Point clouds data structure in CC is also limited to unsigned int and CC point cloud internal representation is by now 100% _In core_, so it does not allows to handle very big point clouds.

[Copc samples.](https://copc.io/#example-data)