### PR TITLE
LoD improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ New features:
 				- required
 				- only one should be set (However, if multiple are passed, only the first one will be used)
 			- -BURNT_COLOR_THRESHOLD {burnt_color_threshold}
-				- discards points for calculations if their R,G,B values are out of the [brunt_color_threshold;255-burnt_color_threshold] range.
+				- discards points for calculations if their R,G,B values are out of the [burnt_color_threshold;255-burnt_color_threshold] range.
 				- {burnt_color_threshold} is an integer between 0 and 255
 				- default value is 0, so all points are used
 				- optional
@@ -181,6 +181,7 @@ Bug fixes:
 		and renaming a class would prevent from using it...)
 	- segmenting a cloud with polylines depending on it but not directly present below the cloud entity in the DB tree could lead
 		to a crash (warning: now, the polylines will be emptied to prevent a crash)
+	- VBOs are now properly released when using the LoD rendering
 
 v2.13.2 (Kharkiv) - (06/30/2024)
 ----------------------

--- a/libs/qCC_db/include/ccPointCloud.h
+++ b/libs/qCC_db/include/ccPointCloud.h
@@ -949,11 +949,13 @@ public: //Level of Detail (LOD)
 	//! Clears the LOD structure
 	void clearLOD();
 
-	//! Return if the cloud has a valuable LOD
+	//! Returns if the cloud has a valuable LOD
 	bool hasUsableLOD() const;
 
+	//! Getter for the m_useLODRendering member
 	bool useLODRendering() const;
 
+	//! Mutates the m_useLODRendering member (setter)
 	void setLODRendering(bool);
 
 protected: //Level of Detail (LOD)
@@ -961,6 +963,8 @@ protected: //Level of Detail (LOD)
 	//! L.O.D. structure
 	ccPointCloudLOD* m_lod;
 
+	//! Boolean flag indicating whether this specific cloud should
+	//! be rendered using the LOD mechanism. (see its usage in DrawMeOnly)
 	bool m_useLODRendering;
 
 protected: //waveform (e.g. from airborne scanners)
@@ -974,7 +978,7 @@ protected: //waveform (e.g. from airborne scanners)
 	//! Waveforms raw data storage
 	SharedFWFDataContainer m_fwfData;
 
-protected: //normals drawing
+protected: //Normals drawing
 	bool m_normalsDrawnAsLines;
 
 	struct NormalLineParameters

--- a/libs/qCC_db/include/ccPointCloud.h
+++ b/libs/qCC_db/include/ccPointCloud.h
@@ -949,10 +949,19 @@ public: //Level of Detail (LOD)
 	//! Clears the LOD structure
 	void clearLOD();
 
+	//! Return if the cloud has a valuable LOD
+	bool hasUsableLOD() const;
+
+	bool useLODRendering() const;
+
+	void setLODRendering(bool);
+
 protected: //Level of Detail (LOD)
 
 	//! L.O.D. structure
 	ccPointCloudLOD* m_lod;
+
+	bool m_useLODRendering;
 
 protected: //waveform (e.g. from airborne scanners)
 
@@ -965,6 +974,7 @@ protected: //waveform (e.g. from airborne scanners)
 	//! Waveforms raw data storage
 	SharedFWFDataContainer m_fwfData;
 
+protected: //normals drawing
 	bool m_normalsDrawnAsLines;
 
 	struct NormalLineParameters

--- a/libs/qCC_db/src/ccExtru.cpp
+++ b/libs/qCC_db/src/ccExtru.cpp
@@ -24,9 +24,6 @@
 //CCCoreLib
 #include <Delaunay2dMesh.h>
 
-//system
-#include <string.h>
-
 ccExtru::ccExtru(const std::vector<CCVector2>& profile,
 				 PointCoordinateType height,
 				 const ccGLMatrix* transMat /*= 0*/,

--- a/libs/qCC_db/src/ccMaterial.cpp
+++ b/libs/qCC_db/src/ccMaterial.cpp
@@ -19,8 +19,8 @@
 #include "ccIncludeGL.h"
 
 //Local
-#include "../include/ccMaterial.h"
-#include "../include/ccMaterialDB.h"
+#include "ccMaterial.h"
+#include "ccMaterialDB.h"
 
 //Qt
 #include <QUuid>

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -807,11 +807,11 @@ const ccPointCloud& ccPointCloud::append(ccPointCloud* addedCloud, unsigned poin
 				{
 					size_t newKeyCount = addedCloud->m_fwfDescriptors.size();
 					assert(newKeyCount < 256); //IDs should range from 1 to 255
-					
+
 					if (!m_fwfDescriptors.empty())
 					{
 						assert(m_fwfDescriptors.size() < 256); //IDs should range from 1 to 255
-						
+
 						//we'll have to find free descriptor IDs (not used in the destination cloud) before merging
 						std::queue<uint8_t> freeDescriptorIDs;
 						for (uint8_t k = 0; k < 255; ++k)
@@ -2083,7 +2083,7 @@ static bool ComputeCellGaussianFilter(	const CCCoreLib::DgmOctree::octreeCell& c
 			return false;
 		}
 	}
-	
+
 	return true;
 }
 
@@ -2887,7 +2887,7 @@ template <class QOpenGLFunctions> void glLODChunkNormalPointer(	NormsIndexesTabl
 }
 
 template <class QOpenGLFunctions> void glLODChunkColorPointer(	RGBAColorsTableType* colors,
-																QOpenGLFunctions* glFunc, 
+																QOpenGLFunctions* glFunc,
 																const LODIndexSet& indexMap,
 																unsigned startIndex,
 																unsigned stopIndex)
@@ -2965,10 +2965,10 @@ struct DisplayDesc : LODLevelDesc
 		endIndex = startIndex + count;
 		return *this;
 	}
-	
+
 	//! Last index (excluded)
 	unsigned endIndex;
-	
+
 	//! Decimation step (for non-octree based LoD)
 	unsigned decimStep;
 
@@ -3048,6 +3048,10 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 					else
 					{
 						assert(m_lod);
+						//Reset the VBO manager if needed:
+						// We do not want to use the LoD and
+						// to have the cloud loaded in the VBOs simultaneously.
+						releaseVBOs();
 
 						unsigned char maxLevel = m_lod->maxLevel();
 						bool underConstruction = m_lod->isUnderConstruction();
@@ -3213,7 +3217,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 								const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
 								//we force display of points hidden because of their scalar field value
 								//to be sure that the user doesn't miss them (during manual segmentation for instance)
-								ccGL::Color(glFunc, col ? *col : ccColor::lightGreyRGB); //Make sure all points are visible. No alpha used on purpose 
+								ccGL::Color(glFunc, col ? *col : ccColor::lightGreyRGB); //Make sure all points are visible. No alpha used on purpose
 							}
 							else if (glParams.showColors)
 							{
@@ -3674,7 +3678,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 		}
 
 		glFunc->glPopAttrib(); //GL_LIGHTING_BIT | GL_COLOR_BUFFER_BIT | GL_TRANSFORM_BIT | GL_POINT_BIT --> will switch the light off
-		
+
 		if (m_normalsDrawnAsLines)
 		{
 			drawNormalsAsLines(context);
@@ -5499,7 +5503,7 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 		{
 			m_vboManager.updateFlags |= vboSet::UPDATE_COLORS;
 		}
-		
+
 		if (	glParams.showSF
 		&& (		!m_vboManager.hasColors
 				||	!m_vboManager.colorIsSF
@@ -5590,7 +5594,7 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 			//allocate memory for current VBO
 			int vboSizeBytes = m_vboManager.vbos[chunkIndex]->init(chunkSize, m_vboManager.hasColors, m_vboManager.hasNormals, &reallocated);
 
-			QOpenGLFunctions_2_1* glFunc = context.glFunctions<QOpenGLFunctions_2_1>(); 
+			QOpenGLFunctions_2_1* glFunc = context.glFunctions<QOpenGLFunctions_2_1>();
 			if (glFunc)
 			{
 				CatchGLErrors(glFunc->glGetError(), "ccPointCloud::vbo.init");
@@ -5762,7 +5766,7 @@ int ccPointCloud::VBO::init(int count, bool withColors, bool withNormals, bool* 
 			//no message as it will probably happen on a lot on (old) graphic cards
 			return -1;
 		}
-		
+
 		setUsagePattern(QGLBuffer::DynamicDraw);	//"StaticDraw: The data will be set once and used many times for drawing operations."
 													//"DynamicDraw: The data will be modified repeatedly and used many times for drawing operations.
 	}
@@ -5794,7 +5798,7 @@ int ccPointCloud::VBO::init(int count, bool withColors, bool withNormals, bool* 
 	}
 
 	release();
-	
+
 	return totalSizeBytes;
 }
 
@@ -6023,7 +6027,7 @@ bool ccPointCloud::computeNormalsWithGrids(	double minTriangleAngle_deg/*=1.0*/,
 						{
 							continue;
 						}
-						
+
 						PointCoordinateType cosC = -uBC.dot(uCA);
 						if (cosC > minAngleCos)
 						{
@@ -6237,7 +6241,7 @@ bool ccPointCloud::computeNormalsWithOctree(CCCoreLib::LOCAL_MODEL_TYPES model,
 		ccLog::Warning(QString("[computeNormals] Failed to compute normals on cloud '%1'").arg(getName()));
 		return false;
 	}
-	
+
 	ccLog::Print("[ComputeCloudNormals] Timing: %3.2f s.", eTimer.elapsed() / 1000.0);
 
 	if (!hasNormals())
@@ -6287,7 +6291,7 @@ void ccPointCloud::showNormalsAsLines(bool state)
 {
 	if (!hasNormals())
 		return;
-	
+
 	m_normalsDrawnAsLines = state;
 
 	if (state == false)
@@ -6411,7 +6415,7 @@ unsigned char ccPointCloud::testVisibility(const CCVector3& P) const
 {
 	if (m_visibilityCheckEnabled)
 	{
-		//if we have associated sensors, we can use them to check the visibility of other points 
+		//if we have associated sensors, we can use them to check the visibility of other points
 		unsigned char bestVisibility = 255;
 		for (size_t i = 0; i < m_children.size(); ++i)
 		{
@@ -6460,7 +6464,7 @@ void ccPointCloud::clearFWFData()
 bool ccPointCloud::computeFWFAmplitude(double& minVal, double& maxVal, ccProgressDialog* pDlg/*=nullptr*/) const
 {
 	minVal = maxVal = 0;
-	
+
 	if (size() != m_fwfWaveforms.size())
 	{
 		return false;
@@ -6582,7 +6586,7 @@ ccMesh* ccPointCloud::triangulateGrid(const Grid& grid, double minTriangleAngle_
 
 	PointCoordinateType minAngleCos = static_cast<PointCoordinateType>(cos( CCCoreLib::DegreesToRadians( minTriangleAngle_deg ) ));
 	//double minTriangleAngle_rad = CCCoreLib::DegreesToRadians(minTriangleAngle_deg);
-	
+
 	for (int j = 0; j < static_cast<int>(grid.h) - 1; ++j)
 	{
 		for (int i = 0; i < static_cast<int>(grid.w) - 1; ++i)
@@ -6646,7 +6650,7 @@ ccMesh* ccPointCloud::triangulateGrid(const Grid& grid, double minTriangleAngle_
 				}
 				break;
 			}
-			
+
 			default:
 				continue;
 			}
@@ -6740,7 +6744,7 @@ bool ccPointCloud::setCoordFromSF(bool importDims[3], CCCoreLib::ScalarField* sf
 	}
 
 	invalidateBoundingBox();
-	
+
 	return true;
 }
 

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -28,13 +28,11 @@
 //local
 #include "ccChunk.h"
 #include "ccColorRampShader.h"
-#include "ccColorScalesManager.h"
 #include "ccFastMarchingForNormsDirection.h"
 #include "ccFrustum.h"
 #include "ccGBLSensor.h"
 #include "ccGenericGLDisplay.h"
 #include "ccGenericMesh.h"
-#include "ccImage.h"
 #include "ccKdTree.h"
 #include "ccMaterial.h"
 #include "ccMesh.h"
@@ -150,6 +148,7 @@ ccPointCloud::ccPointCloud(QString name/*=QString()*/, unsigned uniqueID/*=ccUni
 	, m_visibilityCheckEnabled(false)
 	, m_lod(nullptr)
 	, m_fwfData(nullptr)
+	, m_useLODRendering(true)
 	, m_normalsDrawnAsLines(false)
 {
 	setName(name); //sadly we cannot use the ccGenericPointCloud constructor argument
@@ -3029,6 +3028,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 		if (!entityPickingMode)
 		{
 			if (	context.decimateCloudOnMove
+				&&	m_useLODRendering
 				&&	toDisplay.count > context.minLODPointCount
 				&&	MACRO_LODActivated(context)
 				)
@@ -6453,6 +6453,25 @@ void ccPointCloud::clearLOD()
 	{
 		m_lod->clear();
 	}
+}
+
+bool ccPointCloud::hasUsableLOD() const
+{
+	if(m_lod && m_lod->isInitialized())
+	{
+		return true;
+	}
+	return false;
+}
+
+bool ccPointCloud::useLODRendering() const
+{
+	return m_useLODRendering;
+}
+
+void ccPointCloud::setLODRendering(bool value)
+{
+	m_useLODRendering = value;
 }
 
 void ccPointCloud::clearFWFData()

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -6457,7 +6457,7 @@ void ccPointCloud::clearLOD()
 
 bool ccPointCloud::hasUsableLOD() const
 {
-	if(m_lod && m_lod->isInitialized())
+	if (m_lod && m_lod->isInitialized())
 	{
 		return true;
 	}

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -6457,11 +6457,7 @@ void ccPointCloud::clearLOD()
 
 bool ccPointCloud::hasUsableLOD() const
 {
-	if (m_lod && m_lod->isInitialized())
-	{
-		return true;
-	}
-	return false;
+	return m_lod && m_lod->isInitialized();
 }
 
 bool ccPointCloud::useLODRendering() const

--- a/libs/qCC_glWindow/include/ccGLWindowInterface.h
+++ b/libs/qCC_glWindow/include/ccGLWindowInterface.h
@@ -90,7 +90,7 @@ public:
 
 		//options / modifiers
 		INTERACT_TRANSFORM_ENTITIES = 64,
-		
+
 		//signals
 		INTERACT_SIG_RB_CLICKED      =  128, //right button clicked
 		INTERACT_SIG_LB_CLICKED      =  256, //left button clicked
@@ -294,7 +294,7 @@ public:
 		automatically disable this mode.
 	**/
 	void setBubbleViewMode(bool state);
-	
+
 	//! Returns whether bubble-view mode is enabled or no
 	inline bool bubbleViewModeEnabled() const { return m_bubbleViewModeEnabled; }
 
@@ -326,7 +326,7 @@ public:
 		(see setPerspectiveState).
 	**/
 	const ccGLMatrixd& getBaseViewMat() { return m_viewportParams.viewMat; }
-	
+
 	//! Sets the base view matrix
 	/** Warning: 'base view' marix is either:
 		- the rotation around the object in object-centered mode
@@ -381,7 +381,7 @@ public:
 		\param silent whether this function can log and/or display messages on the screen
 	**/
 	void setPointSize(float size, bool silent = false);
-	
+
 	//! Minimum line width
 	static constexpr float MIN_LINE_WIDTH_F = 1.0f;
 	//! Maximum line width
@@ -547,7 +547,7 @@ public: //LOD
 	//! Enables or disables LOD on this display
 	/** \return success
 	**/
-	bool setLODEnabled(bool state, bool autoDisable = false);
+	bool setLODEnabled(bool state);
 
 public: //fullscreen
 
@@ -600,7 +600,7 @@ public: //stereo mode
 
 	//! Returns whether the stereo display mode is enabled or not
 	inline bool stereoModeIsEnabled() const { return m_stereoModeEnabled; }
-	
+
 	//! Returns the current stereo mode parameters
 	inline const StereoParams& getStereoParams() const { return m_stereoParams; }
 
@@ -635,7 +635,7 @@ public: // other methods
 	/** The request will be executed if not in auto refresh mode already
 	**/
 	virtual void requestUpdate() = 0;
-	
+
 	//! Returns the signal emitter (const version)
 	const ccGLWindowSignalEmitter* signalEmitter() const { return m_signalEmitter; }
 	//! Returns the signal emitter
@@ -881,8 +881,8 @@ protected: //other methods
 		\param[out] metrics [optional] output other metrics (Znear and Zfar, etc.)
 		\param[out] eyeOffset [optional] eye offset (for stereo display)
 	**/
-	ccGLMatrixd computeProjectionMatrix(	bool withGLfeatures, 
-											ProjectionMetrics* metrics = nullptr, 
+	ccGLMatrixd computeProjectionMatrix(	bool withGLfeatures,
+											ProjectionMetrics* metrics = nullptr,
 											double* eyeOffset = nullptr) const;
 	void updateModelViewMatrix();
 	void updateProjectionMatrix();
@@ -943,7 +943,7 @@ protected: //other methods
 								const CCVector3* nearestPoint = nullptr,
 								const CCVector3d* nearestPointBC = nullptr, //barycentric coordinates
 								const std::unordered_set<int>* selectedIDs = nullptr);
-	
+
 	//! Updates currently active items list (m_activeItems)
 	/** The items must be currently displayed in this context
 		AND at least one of them must be under the mouse cursor.
@@ -1072,8 +1072,6 @@ protected: //members
 
 	//! Whether L.O.D. (level of detail) is enabled or not
 	bool m_LODEnabled;
-	//! Whether L.O.D. should be automatically disabled at the end of the rendering cycle
-	bool m_LODAutoDisable;
 	//! Whether the display should be refreshed on next call to 'refresh'
 	bool m_shouldBeRefreshed;
 	//! Whether the mouse (cursor) has moved after being pressed or not
@@ -1115,7 +1113,7 @@ protected: //members
 			, position(LOWER_LEFT_MESSAGE)
 			, type(CUSTOM_MESSAGE)
 		{}
-		
+
 		//! Message
 		QString message;
 		//! Message end time (sec)
@@ -1138,7 +1136,7 @@ protected: //members
 	float m_sunLightPos[4];
 	//! Whether sun light is enabled or not
 	bool m_sunLightEnabled;
-	
+
 	//! Custom light position
 	/** Relative to object.
 	**/
@@ -1164,7 +1162,7 @@ protected: //members
 		Role role;
 		QRect area;
 	};
-	
+
 	//! Currently displayed clickable items
 	std::vector<ClickableItem> m_clickableItems;
 
@@ -1220,7 +1218,7 @@ protected: //members
 	//! Rectangular picking polyline
 	ccPolyline* m_rectPickingPoly;
 
-	//! Overridden display parameter 
+	//! Overridden display parameter
 	ccGui::ParamStruct m_overriddenDisplayParameters;
 
 	//! Whether display parameters are overidden for this window
@@ -1274,7 +1272,7 @@ protected: //members
 
 	//! Wether exclusive full screen is enabled or not
 	bool m_exclusiveFullscreen;
-	
+
 	//! Former geometry (for exclusive full-screen display)
 	QByteArray m_formerGeometry;
 

--- a/libs/qCC_glWindow/src/ccGLWindowInterface.cpp
+++ b/libs/qCC_glWindow/src/ccGLWindowInterface.cpp
@@ -214,7 +214,6 @@ ccGLWindowInterface::ccGLWindowInterface(QObject* parent/*=nullptr*/, bool silen
 	, m_validModelviewMatrix(false)
 	, m_validProjectionMatrix(false)
 	, m_LODEnabled(true)
-	, m_LODAutoDisable(false)
 	, m_shouldBeRefreshed(false)
 	, m_mouseMoved(false)
 	, m_mouseButtonPressed(false)
@@ -813,7 +812,7 @@ void ccGLWindowInterface::onResizeGL(int w, int h)
 		logGLError("ccGLWindowInterface::onResizeGL");
 	}
 
-	setLODEnabled(true, true);
+	setLODEnabled(true);
 	m_currentLODState.level = 0;
 	if (m_hotZone)
 	{
@@ -922,7 +921,7 @@ void ccGLWindowInterface::setDisplayParameters(const ccGui::ParamStruct &params,
 	}
 }
 
-bool ccGLWindowInterface::setLODEnabled(bool state, bool autoDisable/*=false*/)
+bool ccGLWindowInterface::setLODEnabled(bool state)
 {
 	if (state && (!m_fbo || (m_stereoModeEnabled && !m_stereoParams.isAnaglyph() && !m_fbo2)))
 	{
@@ -931,7 +930,6 @@ bool ccGLWindowInterface::setLODEnabled(bool state, bool autoDisable/*=false*/)
 	}
 
 	m_LODEnabled = state;
-	m_LODAutoDisable = autoDisable;
 	return true;
 }
 
@@ -1356,7 +1354,7 @@ void ccGLWindowInterface::setPivotPoint(const CCVector3d& P,
 			//in orthographic mode, make sure the level of 'zoom' is maintained by repositioning the camera
 			newCameraPos.z = m_viewportParams.getFocalDistance() + P.z;
 		}
-		
+
 		setCameraPos(newCameraPos); //will also update the pixel size
 	}
 
@@ -1415,7 +1413,7 @@ void ccGLWindowInterface::computeColorRampAreaLimits(int& yStart, int& yStop) co
 	{
 		yStart += 2 * defaultMargin; //we still add a margin
 	}
-	
+
 	//bottom: only the trihedron
 	yStop = glHeight() - defaultMargin;
 	if (trihedronIsDisplayed())
@@ -1586,7 +1584,7 @@ ccGLMatrixd ccGLWindowInterface::computeProjectionMatrix(bool withGLfeatures, Pr
 
 			//on input 'eyeOffset' should be -1 (left) or +1 (right)
 			*eyeOffset *= eyeSeperation;
-			
+
 			frustumAsymmetry = (*eyeOffset) * zNear / convergence;
 
 			//if (*eyeOffset < 0.0)
@@ -1850,7 +1848,7 @@ void ccGLWindowInterface::setPickingMode(PICKING_MODE mode/*=DEFAULT_PICKING*/, 
 		m_defaultCursorShape = displayParams.pickingCursorShape;
 	}
 	break;
-	
+
 	default:
 		break;
 	}
@@ -1993,48 +1991,48 @@ bool ccGLWindowInterface::processClickableItems(int x, int y)
 		//nothing to do
 	}
 	break;
-	
+
 	case ClickableItem::INCREASE_POINT_SIZE:
 	{
 		setPointSize(m_viewportParams.defaultPointSize + 1.0f);
 		redraw();
 	}
 	return true;
-	
+
 	case ClickableItem::DECREASE_POINT_SIZE:
 	{
 		setPointSize(m_viewportParams.defaultPointSize - 1.0f);
 		redraw();
 	}
 	return true;
-	
+
 	case ClickableItem::INCREASE_LINE_WIDTH:
 	{
 		setLineWidth(m_viewportParams.defaultLineWidth + 1.0f);
 		redraw();
 	}
 	return true;
-	
+
 	case ClickableItem::DECREASE_LINE_WIDTH:
 	{
 		setLineWidth(m_viewportParams.defaultLineWidth - 1.0f);
 		redraw();
 	}
 	return true;
-	
+
 	case ClickableItem::LEAVE_BUBBLE_VIEW_MODE:
 	{
 		setBubbleViewMode(false);
 		redraw();
 	}
 	return true;
-	
+
 	case ClickableItem::LEAVE_FULLSCREEN_MODE:
 	{
 		toggleExclusiveFullScreen(false);
 	}
 	return true;
-	
+
 	default:
 	{
 		//unhandled item?!
@@ -2078,7 +2076,7 @@ void ccGLWindowInterface::onWheelEvent(float wheelDelta_deg)
 		moveCamera(v);
 	}
 
-	setLODEnabled(true, true);
+	setLODEnabled(true);
 	m_currentLODState.level = 0;
 
 	redraw();
@@ -2706,12 +2704,12 @@ void ccGLWindowInterface::displayNewMessage(const QString& message,
 void ccGLWindowInterface::setPointSize(float size, bool silent/*=false*/)
 {
 	float newSize = std::max(std::min(size, MAX_POINT_SIZE_F), MIN_POINT_SIZE_F);
-	
+
 	if (m_viewportParams.defaultPointSize != newSize)
 	{
 		m_viewportParams.defaultPointSize = newSize;
 		deprecate3DLayer();
-	
+
 		if (!silent)
 		{
 			displayNewMessage(	QString("New default point size: %1").arg(newSize),
@@ -2743,7 +2741,7 @@ void ccGLWindowInterface::setLineWidth(float width, bool silent/*=false*/)
 			ccLog::Warning(QString("Line width is too big: %1/%2").arg(width).arg(MAX_LINE_WIDTH_F));
 	}
 	float newWidth = std::max(std::min(width, MAX_LINE_WIDTH_F), MIN_LINE_WIDTH_F);
-	
+
 	if (m_viewportParams.defaultLineWidth != newWidth)
 	{
 		m_viewportParams.defaultLineWidth = newWidth;
@@ -3097,7 +3095,7 @@ void ccGLWindowInterface::setBubbleViewFov(float fov_deg)
 	{
 		return;
 	}
-	
+
 	if (fov_deg != m_bubbleViewFov_deg)
 	{
 		m_bubbleViewFov_deg = fov_deg;
@@ -3494,7 +3492,7 @@ void ccGLWindowInterface::displayText(	QString text,
 			x2 -= rect.width() / 2;
 		else if (align & ALIGN_HRIGHT)
 			x2 -= rect.width();
-		
+
 		if (align & ALIGN_VMIDDLE)
 			y2 -= textHeight / 2;
 		else if (align & ALIGN_VBOTTOM)
@@ -3534,7 +3532,7 @@ void ccGLWindowInterface::displayText(	QString text,
 			glFunc->glPopMatrix();
 			glFunc->glMatrixMode(GL_MODELVIEW);
 			glFunc->glPopMatrix();
-			
+
 			glFunc->glPopAttrib(); //GL_COLOR_BUFFER_BIT
 		}
 	}
@@ -3620,12 +3618,12 @@ ccGLWindowInterface::StereoParams::StereoParams()
 {}
 
 void ccGLWindowInterface::renderText(int x, int y, const QString & str, uint16_t uniqueID/*=0*/, const QFont & font/*=QFont()*/)
-{   
+{
 	if (m_activeFbo)
 	{
 		m_activeFbo->start();
 	}
-   
+
 	ccQOpenGLFunctions* glFunc = functions();
 	assert(glFunc);
 
@@ -3711,12 +3709,12 @@ void ccGLWindowInterface::renderText(int x, int y, const QString & str, uint16_t
 		glFunc->glGetFloatv(GL_CURRENT_COLOR, glColor);
 		QColor color;
 		color.setRgbF( glColor[0], glColor[1], glColor[2], glColor[3] );
-		
+
 		painter.setPen( color );
 		painter.setFont( font );
 		painter.drawText(imageRect, Qt::AlignLeft, str );
 	}
-	
+
 	//and then we convert this QImage to a texture!
 	{
 		glFunc->glPushAttrib(GL_COLOR_BUFFER_BIT | GL_TEXTURE_BIT | GL_DEPTH_BUFFER_BIT | GL_ENABLE_BIT);
@@ -3776,7 +3774,7 @@ void ccGLWindowInterface::renderText(int x, int y, const QString & str, uint16_t
 		glFunc->glPopMatrix();
 		glFunc->glMatrixMode(GL_MODELVIEW);
 		glFunc->glPopMatrix();
-		
+
 		glFunc->glPopAttrib(); //GL_COLOR_BUFFER_BIT | GL_TEXTURE_BIT | GL_DEPTH_BUFFER_BIT | GL_ENABLE_BIT
 	}
 }
@@ -3787,7 +3785,7 @@ void ccGLWindowInterface::renderText(double x, double y, double z, const QString
 
 	ccQOpenGLFunctions* glFunc = functions();
 	assert(glFunc);
-	
+
 	//get the actual viewport / matrices
 	ccGLCameraParameters camera;
 	glFunc->glGetIntegerv(GL_VIEWPORT, camera.viewport);
@@ -3848,7 +3846,7 @@ void ccGLWindowInterface::toggleAutoRefresh(bool state, int period_ms/*=0*/)
 		//nothing to do
 		return;
 	}
-	
+
 	m_autoRefresh = state;
 	if (m_autoRefresh)
 	{
@@ -4090,7 +4088,7 @@ bool ccGLWindowInterface::getClick3DPos(int x, int y, CCVector3d& P3D, bool useP
 	{
 		return false;
 	}
-	
+
 	CCVector3d P2D(x, y, glDepth);
 
 	ccGLCameraParameters camera;
@@ -4700,11 +4698,6 @@ void ccGLWindowInterface::doPaintGL()
 	{
 		//we have reached the final level
 		stopLODCycle();
-
-		if (m_LODAutoDisable)
-		{
-			setLODEnabled(false);
-		}
 	}
 
 	if (isFrameRateTestInProgress())
@@ -6097,7 +6090,7 @@ bool ccGLWindowInterface::initFBO(int w, int h)
 		ccLog::Warning("[FBO] Initialization failed!");
 		m_alwaysUseFBO = false;
 		removeFBOSafe(m_fbo2);
-		setLODEnabled(false, false);
+		setLODEnabled(false);
 		return false;
 	}
 
@@ -6116,7 +6109,7 @@ bool ccGLWindowInterface::initFBO(int w, int h)
 			ccLog::Warning("[FBO] Failed to initialize secondary FBO!");
 			m_alwaysUseFBO = false;
 			removeFBOSafe(m_fbo);
-			setLODEnabled(false, false);
+			setLODEnabled(false);
 			return false;
 		}
 	}
@@ -6270,7 +6263,7 @@ void ccGLWindowInterface::processMouseMoveEvent(QMouseEvent *event)
 
 	int dx = x - m_lastMousePos.x();
 	int dy = y - m_lastMousePos.y();
-	setLODEnabled(true, false);
+	setLODEnabled(true);
 
 	if ((event->buttons() & Qt::RightButton)
 #ifdef CC_MAC_OS
@@ -6808,14 +6801,14 @@ void ccGLWindowInterface::processWheelEvent(QWheelEvent* event)
 
 	if (doRedraw)
 	{
-		setLODEnabled(true, true);
+		setLODEnabled(true);
 		m_currentLODState.level = 0;
 
 		redraw();
 	}
 }
 
-//draw a unit circle in a given plane (0=YZ, 1 = XZ, 2=XY) 
+//draw a unit circle in a given plane (0=YZ, 1 = XZ, 2=XY)
 static void glDrawUnitCircle(QOpenGLContext* context, unsigned char dim, unsigned steps = 64)
 {
 	assert(context);

--- a/qCC/db_tree/ccDBRoot.h
+++ b/qCC/db_tree/ccDBRoot.h
@@ -19,7 +19,6 @@
 #define CC_DB_ROOT_HEADER
 
 //Qt
-#include "ccPointCloud.h"
 #include <QAbstractItemModel>
 #include <QPoint>
 #include <QTreeView>
@@ -62,7 +61,7 @@ struct dbTreeSelectionInfo
 class ccCustomQTreeView : public QTreeView
 {
 	Q_OBJECT
-	
+
 public:
 
 	//! Default constructor
@@ -287,7 +286,7 @@ protected:
 	//! Context menu action: hide/show selected entities SF
 	QAction* m_toggleSelectedEntitiesSF;
 	//! Context menu action: hide/show selected entities 3D name
-	QAction* m_toggleSelectedEntities3DName;	
+	QAction* m_toggleSelectedEntities3DName;
 	//! Context menu action: add empty group
 	QAction* m_addEmptyGroup;
 	//! Context menu action: use 3-points labels or planes to orient camera

--- a/qCC/db_tree/ccPropertiesTreeDelegate.cpp
+++ b/qCC/db_tree/ccPropertiesTreeDelegate.cpp
@@ -628,7 +628,7 @@ void ccPropertiesTreeDelegate::fillWithPointCloud(ccGenericPointCloud* _obj)
 			fillWithDrawNormals(_obj);
 		}
 
-		if(cloud->hasUsableLOD())
+		if (cloud->hasUsableLOD())
 		{
 			fillWithPointCloudLOD(_obj);
 		}
@@ -663,14 +663,15 @@ void ccPropertiesTreeDelegate::fillWithDrawNormals(ccGenericPointCloud* _obj)
 
 void ccPropertiesTreeDelegate::fillWithPointCloudLOD(ccGenericPointCloud* _obj)
 {
-	assert(_obj && m_model);
 	if (!_obj || !m_model)
 	{
+		assert(false);
 		return;
 	}
-	assert(_obj->isA(CC_TYPES::POINT_CLOUD));
+
 	if (!_obj->isA(CC_TYPES::POINT_CLOUD))
 	{
+		assert(false);
 		return;
 	}
 
@@ -2290,9 +2291,9 @@ void ccPropertiesTreeDelegate::updateItem(QStandardItem * item)
 	case OBJECT_CLOUD_DRAW_NORMALS:
 	{
 		ccGenericPointCloud* cloud = ccHObjectCaster::ToGenericPointCloud(m_currentObject);
-		bool isChecked = (item->checkState() == Qt::Checked);
 		if (cloud)
 		{
+			bool isChecked = (item->checkState() == Qt::Checked);
 			static_cast<ccPointCloud*>(cloud)->showNormalsAsLines(isChecked);
 		}
 	}
@@ -2301,9 +2302,9 @@ void ccPropertiesTreeDelegate::updateItem(QStandardItem * item)
 	case OBJECT_CLOUD_USE_LOD:
 	{
 		ccGenericPointCloud* cloud = ccHObjectCaster::ToGenericPointCloud(m_currentObject);
-		bool isChecked = (item->checkState() == Qt::Checked);
 		if (cloud)
 		{
+			bool isChecked = (item->checkState() == Qt::Checked);
 			static_cast<ccPointCloud*>(cloud)->setLODRendering(isChecked);
 		}
 	}

--- a/qCC/db_tree/ccPropertiesTreeDelegate.cpp
+++ b/qCC/db_tree/ccPropertiesTreeDelegate.cpp
@@ -376,7 +376,7 @@ void ccPropertiesTreeDelegate::appendWideRow(QStandardItem* item, bool openPersi
 	if (m_model && item)
 	{
 		m_model->appendRow(item);
-		
+
 		if (openPersistentEditor && (m_view != nullptr))
 		{
 			m_view->openPersistentEditor(m_model->index(m_model->rowCount() - 1, 0));
@@ -395,7 +395,7 @@ void ccPropertiesTreeDelegate::addSeparator(const QString& title)
 		leftItem->setData(TREE_VIEW_HEADER);
 		leftItem->setAccessibleDescription(title);
 		m_model->appendRow(leftItem);
-		
+
 		if ( m_view != nullptr )
 		{
 			m_view->openPersistentEditor(m_model->index(m_model->rowCount() - 1, 0));
@@ -422,7 +422,7 @@ void ccPropertiesTreeDelegate::fillWithMetaData(const ccObject* _obj)
 	{
 		QVariant var = it.value();
 		QString value;
-		
+
 		if (var.canConvert(QVariant::String))
 		{
 			var.convert(QVariant::String);
@@ -627,6 +627,11 @@ void ccPropertiesTreeDelegate::fillWithPointCloud(ccGenericPointCloud* _obj)
 		{
 			fillWithDrawNormals(_obj);
 		}
+
+		if(cloud->hasUsableLOD())
+		{
+			fillWithPointCloudLOD(_obj);
+		}
 	}
 }
 
@@ -654,6 +659,26 @@ void ccPropertiesTreeDelegate::fillWithDrawNormals(ccGenericPointCloud* _obj)
 
 	//normals color
 	appendRow(ITEM(tr("Color")), PERSISTENT_EDITOR(OBJECT_CLOUD_NORMAL_COLOR), true);
+}
+
+void ccPropertiesTreeDelegate::fillWithPointCloudLOD(ccGenericPointCloud* _obj)
+{
+	assert(_obj && m_model);
+	if (!_obj || !m_model)
+	{
+		return;
+	}
+	assert(_obj->isA(CC_TYPES::POINT_CLOUD));
+	if (!_obj->isA(CC_TYPES::POINT_CLOUD))
+	{
+		return;
+	}
+
+	addSeparator( tr( "LOD rendering" ) );
+
+	//visibility
+	const ccPointCloud* cloud = static_cast<const ccPointCloud*>(_obj);
+	appendRow(ITEM(tr("Use LOD Rendering")), CHECKABLE_ITEM(cloud->useLODRendering(), OBJECT_CLOUD_USE_LOD));
 }
 
 void ccPropertiesTreeDelegate::fillSFWithPointCloud(ccGenericPointCloud* _obj)
@@ -1017,7 +1042,7 @@ void ccPropertiesTreeDelegate::fillWithViewportObject(const cc2DViewportObject* 
 
 	//"Update Viewport" button
 	appendRow(ITEM( tr( "Update viewport" ) ), PERSISTENT_EDITOR(OBJECT_UPDATE_LABEL_VIEWPORT), true);
-	
+
 }
 
 void ccPropertiesTreeDelegate::fillWithTransBuffer(const ccIndexedTransformationBuffer* _obj)
@@ -1103,7 +1128,7 @@ void ccPropertiesTreeDelegate::fillWithGBLSensor(const ccGBLSensor* _obj)
 				  ITEM( QStringLiteral("[%1 ; %2]")
 						.arg( CCCoreLib::RadiansToDegrees( yawMin ), 0, 'f', 2)
 						.arg( CCCoreLib::RadiansToDegrees( yawMax ), 0, 'f', 2)));
-		
+
 		//Angular steps (yaw)
 		PointCoordinateType yawStep = _obj->getYawStep();
 		appendRow(ITEM( tr( "Yaw step" ) ),
@@ -1293,7 +1318,7 @@ QWidget* ccPropertiesTreeDelegate::createEditor(QWidget *parent,
 	case OBJECT_CURRENT_SCALAR_FIELD:
 	{
 		ccPointCloud* cloud = ccHObjectCaster::ToPointCloud(m_currentObject);
-		assert(cloud);		
+		assert(cloud);
 
 		QComboBox *comboBox = new QComboBox(parent);
 
@@ -1474,7 +1499,7 @@ QWidget* ccPropertiesTreeDelegate::createEditor(QWidget *parent,
 	{
 		ccSensor* sensor = ccHObjectCaster::ToSensor(m_currentObject);
 		assert(sensor);
-		
+
 		double minIndex = 0.0;
 		double maxIndex = 0.0;
 		if (sensor)
@@ -1570,7 +1595,7 @@ QWidget* ccPropertiesTreeDelegate::createEditor(QWidget *parent,
 		QComboBox *comboBox = new QComboBox(parent);
 
 		comboBox->addItem( tr( s_defaultPointSizeString ) ); //size = 0
-		
+
 		for (int i = static_cast<int>(ccGLWindowInterface::MIN_POINT_SIZE_F); i <= static_cast<int>(ccGLWindowInterface::MAX_POINT_SIZE_F); ++i)
 		{
 			comboBox->addItem(QString::number(i));
@@ -1587,7 +1612,7 @@ QWidget* ccPropertiesTreeDelegate::createEditor(QWidget *parent,
 		QComboBox *comboBox = new QComboBox(parent);
 
 		comboBox->addItem( tr( s_defaultPolyWidthSizeString ) ); //size = 0
-				
+
 		for (int i = static_cast<int>(ccGLWindowInterface::MIN_LINE_WIDTH_F); i <= static_cast<int>(ccGLWindowInterface::MAX_LINE_WIDTH_F); ++i)
 		{
 			comboBox->addItem(QString::number(i));
@@ -1604,7 +1629,7 @@ QWidget* ccPropertiesTreeDelegate::createEditor(QWidget *parent,
 		QComboBox *comboBox = new QComboBox(parent);
 
 		comboBox->addItem( tr( s_noneString ) );
-		
+
 		if (m_currentObject)
 		{
 			if (m_currentObject->hasColors())
@@ -1656,7 +1681,7 @@ QWidget* ccPropertiesTreeDelegate::createEditor(QWidget *parent,
 		{
 			spinBox->setValue(cs->getDisplayScale());
 		}
-		
+
 		connect(spinBox, qOverload<double>(&QDoubleSpinBox::valueChanged),
 			this, &ccPropertiesTreeDelegate::coordinateSystemDisplayScaleChanged);
 
@@ -2148,7 +2173,7 @@ void ccPropertiesTreeDelegate::updateItem(QStandardItem * item)
 		cloud->showSFColorsScale(item->checkState() == Qt::Checked);
 	}
 	redraw = true;
-	break;	
+	break;
 	case OBJECT_COORDINATE_SYSTEM_DISP_AXES:
 	{
 		ccCoordinateSystem* cs = ccHObjectCaster::ToCoordinateSystem(m_currentObject);
@@ -2269,6 +2294,17 @@ void ccPropertiesTreeDelegate::updateItem(QStandardItem * item)
 		if (cloud)
 		{
 			static_cast<ccPointCloud*>(cloud)->showNormalsAsLines(isChecked);
+		}
+	}
+	redraw = true;
+	break;
+	case OBJECT_CLOUD_USE_LOD:
+	{
+		ccGenericPointCloud* cloud = ccHObjectCaster::ToGenericPointCloud(m_currentObject);
+		bool isChecked = (item->checkState() == Qt::Checked);
+		if (cloud)
+		{
+			static_cast<ccPointCloud*>(cloud)->setLODRendering(isChecked);
 		}
 	}
 	redraw = true;

--- a/qCC/db_tree/ccPropertiesTreeDelegate.h
+++ b/qCC/db_tree/ccPropertiesTreeDelegate.h
@@ -111,6 +111,7 @@ public:
 							OBJECT_CLOUD_NORMAL_COLOR				,
 							OBJECT_CLOUD_NORMAL_LENGTH				,
 							OBJECT_CLOUD_DRAW_NORMALS				,
+							OBJECT_CLOUD_USE_LOD					,
 	};
 
 	//! Default constructor
@@ -124,7 +125,7 @@ public:
 	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 	void updateEditorGeometry(QWidget* editor, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
 	void setEditorData(QWidget *editor, const QModelIndex &index) const override;
-	
+
 	void unbind();
 
 	//! Fill property view with QItems corresponding to object's type
@@ -144,7 +145,7 @@ private:
 	static const char* s_sfColor;
 	static const char* s_defaultPointSizeString;
 	static const char* s_defaultPolyWidthSizeString;
-	
+
 	void updateItem(QStandardItem*);
 	void scalarFieldChanged(int);
 	void colorScaleChanged(int);
@@ -183,6 +184,7 @@ private:
 	void fillWithHObject(ccHObject*);
 	void fillWithPointCloud(ccGenericPointCloud*);
 	void fillWithDrawNormals(ccGenericPointCloud*);
+	void fillWithPointCloudLOD(ccGenericPointCloud*);
 	void fillSFWithPointCloud(ccGenericPointCloud*);
 	void fillWithMesh(const ccGenericMesh*);
 	void fillWithFacet(const ccFacet*);
@@ -203,7 +205,7 @@ private:
 	void fillWithMetaData(const ccObject*);
 	void fillWithShifted(const ccShiftedObject*);
 	void fillWithCoordinateSystem(const ccCoordinateSystem*);
-	
+
 	template<class Type, int N, class ComponentType>
 	void fillWithCCArray(const ccArray<Type, N, ComponentType>*);
 

--- a/qCC/db_tree/sfEditDlg.cpp
+++ b/qCC/db_tree/sfEditDlg.cpp
@@ -29,7 +29,6 @@
 
 //system
 #include <cassert>
-#include <cmath>
 
 //! Default number of steps for spin-boxes
 const int SPIN_BOX_STEPS = 1000;


### PR DESCRIPTION
- Clean VBOs memory when using LOD
- Remove LODAutoDisable mechanism that could trigger a VBO allocation at the end of the LOD rendering cycle and seems to have no utility.
- Add some options in the PropertiesTree to tweak the LOD for each cloud individually.