### PR TITLE
Remove deprecated QGLBuffer in favor of QOpenGLBuffer

### DIFF
--- a/libs/qCC_db/include/ccPointCloud.h
+++ b/libs/qCC_db/include/ccPointCloud.h
@@ -31,7 +31,7 @@
 #include "ccWaveform.h"
 
 //Qt
-#include <QGLBuffer>
+#include <qopenglbuffer.h>
 
 class ccScalarField;
 class ccPolyline;
@@ -876,7 +876,7 @@ protected: // VBO
 	//! Init/updates VBOs
 	bool updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams& glParams);
 
-	class VBO : public QGLBuffer
+	class VBO : public QOpenGLBuffer
 	{
 	public:
 		int rgbShift;
@@ -888,7 +888,7 @@ protected: // VBO
 		int init(int count, bool withColors, bool withNormals, bool* reallocated = nullptr);
 
 		VBO()
-			: QGLBuffer(QGLBuffer::VertexBuffer)
+			: QOpenGLBuffer(QOpenGLBuffer::VertexBuffer)
 			, rgbShift(0)
 			, normalShift(0)
 		{}

--- a/libs/qCC_db/include/ccPointCloud.h
+++ b/libs/qCC_db/include/ccPointCloud.h
@@ -31,7 +31,7 @@
 #include "ccWaveform.h"
 
 //Qt
-#include <qopenglbuffer.h>
+#include <QOpenGLBuffer>
 
 class ccScalarField;
 class ccPolyline;

--- a/libs/qCC_db/include/ccPointCloud.h
+++ b/libs/qCC_db/include/ccPointCloud.h
@@ -36,7 +36,7 @@
 class ccScalarField;
 class ccPolyline;
 class ccMesh;
-class QGLBuffer;
+class QOpenGLBuffer;
 class ccProgressDialog;
 class ccPointCloudLOD;
 

--- a/libs/qCC_db/src/cc2DLabel.cpp
+++ b/libs/qCC_db/src/cc2DLabel.cpp
@@ -19,7 +19,6 @@
 
 //Local
 #include "cc2DLabel.h"
-#include "ccBasicTypes.h"
 #include "ccGenericGLDisplay.h"
 #include "ccGenericPointCloud.h"
 #include "ccPointCloud.h"
@@ -28,6 +27,7 @@
 #include "ccSphere.h"
 
 //Qt
+#include <QFontMetrics>
 #include <QSharedPointer>
 
 //System
@@ -131,7 +131,7 @@ ccGenericPointCloud* cc2DLabel::PickedPoint::cloudOrVertices() const
 		return _cloud;
 	if (_mesh)
 		return _mesh->getAssociatedCloud();
-	
+
 	assert(false);
 	return nullptr;
 }
@@ -358,7 +358,7 @@ void cc2DLabel::updateName()
 		setName(m_pickedPoints[0].prefix(POINT_INDEX_0));
 	}
 	break;
-	
+
 	case 2:
 	{
 		if (m_pickedPoints[0].entity() == m_pickedPoints[1].entity())
@@ -373,7 +373,7 @@ void cc2DLabel::updateName()
 		}
 	}
 	break;
-	
+
 	case 3:
 	{
 		if (	m_pickedPoints[0].entity() == m_pickedPoints[2].entity() && m_pickedPoints[1].entity() == m_pickedPoints[2].entity() )
@@ -390,7 +390,7 @@ void cc2DLabel::updateName()
 		}
 	}
 	break;
-	
+
 	}
 }
 
@@ -487,7 +487,7 @@ bool cc2DLabel::toFile_MeOnly(QFile& out, short dataVersion) const
 		uint32_t meshID = static_cast<uint32_t>(it->_mesh ? it->_mesh->getUniqueID() : 0);
 		if (out.write((const char*)&meshID, 4) < 0)
 			return WriteError();
-		
+
 		//uv coordinates in the triangle (dataVersion >= 49)
 		if (out.write((const char*)it->uv.u, sizeof(double) * 2) < 0)
 			return WriteError();
@@ -649,7 +649,7 @@ void AddPointCoordinates(QStringList& body, const cc2DLabel::PickedPoint& pp, in
 {
 	QString pointShortName;
 	ccShiftedObject* shiftedObject = nullptr;
-	
+
 	if (pp._cloud)
 	{
 		shiftedObject = pp._cloud;
@@ -780,7 +780,7 @@ void cc2DLabel::getLabelInfo1(LabelInfo1& info) const
 					s2 = vertices->getPointScalarValue(vi->i2);
 					s3 = vertices->getPointScalarValue(vi->i3);
 				}
-			
+
 				//interpolate the SF value
 				if (ccScalarField::ValidValue(s1) && ccScalarField::ValidValue(s2) && ccScalarField::ValidValue(s3))
 				{

--- a/libs/qCC_db/src/ccGenericMesh.cpp
+++ b/libs/qCC_db/src/ccGenericMesh.cpp
@@ -41,6 +41,9 @@
 //system
 #include <cassert>
 
+//QT
+#include <QPainter>
+
 #if defined(_OPENMP)
 //OpenMP
 #include <omp.h>
@@ -925,7 +928,7 @@ void ccGenericMesh::importParametersFrom(const ccGenericMesh* mesh)
 	enableStippling(mesh->stipplingEnabled());
 	//wired style
 	showWired(mesh->isShownAsWire());
-	
+
 	//keep the transformation history!
 	setGLTransformationHistory(mesh->getGLTransformationHistory());
 	//and meta-data
@@ -1098,7 +1101,7 @@ bool ccGenericMesh::trianglePicking(const CCVector2d& clickPos,
 	{
 		CCVector3d P;
 		CCVector3d BC;
-		if (!trianglePicking(	i,	
+		if (!trianglePicking(	i,
 								clickPos,
 								trans,
 								noGLTrans,
@@ -1163,7 +1166,7 @@ bool ccGenericMesh::computePointPosition(unsigned triIndex, const CCVector2d& uv
 		ccLog::Warning("Index out of range");
 		return true;
 	}
-	
+
 	CCVector3 A;
 	CCVector3 B;
 	CCVector3 C;
@@ -1174,7 +1177,7 @@ bool ccGenericMesh::computePointPosition(unsigned triIndex, const CCVector2d& uv
 	{
 		ccLog::Warning("Point falls outside of the triangle");
 	}
-	
+
 	P = CCVector3(	static_cast<PointCoordinateType>(uv.x * A.x + uv.y * B.x + z * C.x),
 					static_cast<PointCoordinateType>(uv.x * A.y + uv.y * B.y + z * C.y),
 					static_cast<PointCoordinateType>(uv.x * A.z + uv.y * B.z + z * C.z));
@@ -1231,7 +1234,7 @@ bool ccGenericMesh::IsCloudVerticesOfMesh(ccGenericPointCloud* cloud, ccGenericM
 		assert(false);
 		return false;
 	}
-	
+
 	// check whether the input point cloud acts as the vertices of a mesh
 	{
 		ccHObject* parent = cloud->getParent();

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -5768,7 +5768,7 @@ int ccPointCloud::VBO::init(int count, bool withColors, bool withNormals, bool* 
 			return -1;
 		}
 
-		setUsagePattern(QGLBuffer::DynamicDraw);	//"StaticDraw: The data will be set once and used many times for drawing operations."
+		setUsagePattern(QOpenGLBuffer::DynamicDraw);	//"StaticDraw: The data will be set once and used many times for drawing operations."
 													//"DynamicDraw: The data will be modified repeatedly and used many times for drawing operations.
 	}
 

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -5585,15 +5585,17 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 		{
 			int chunkSize = static_cast<int>(ccChunk::Size(chunkIndex, m_points));
 
+			VBO * currentVBO = m_vboManager.vbos[chunkIndex];
+
 			int chunkUpdateFlags = m_vboManager.updateFlags;
 			bool reallocated = false;
-			if (!m_vboManager.vbos[chunkIndex])
+			if (!currentVBO)
 			{
-				m_vboManager.vbos[chunkIndex] = new VBO;
+				currentVBO = new VBO;
 			}
 
 			//allocate memory for current VBO
-			int vboSizeBytes = m_vboManager.vbos[chunkIndex]->init(chunkSize, m_vboManager.hasColors, m_vboManager.hasNormals, &reallocated);
+			int vboSizeBytes = currentVBO->init(chunkSize, m_vboManager.hasColors, m_vboManager.hasNormals, &reallocated);
 
 			QOpenGLFunctions_2_1* glFunc = context.glFunctions<QOpenGLFunctions_2_1>();
 			if (glFunc)
@@ -5611,12 +5613,12 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 					chunkUpdateFlags = vboSet::UPDATE_ALL;
 				}
 
-				m_vboManager.vbos[chunkIndex]->bind();
+				currentVBO->bind();
 
 				//load points
 				if (chunkUpdateFlags & vboSet::UPDATE_POINTS)
 				{
-					m_vboManager.vbos[chunkIndex]->write(0, ccChunk::Start(m_points, chunkIndex), sizeof(PointCoordinateType)*chunkSize * 3);
+					currentVBO->write(0, ccChunk::Start(m_points, chunkIndex), sizeof(PointCoordinateType)*chunkSize * 3);
 				}
 				//load colors
 				if (chunkUpdateFlags & vboSet::UPDATE_COLORS)
@@ -5657,13 +5659,13 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 							}
 						}
 						//then send them in VRAM
-						m_vboManager.vbos[chunkIndex]->write(m_vboManager.vbos[chunkIndex]->rgbShift, s_rgbBuffer4ub, sizeof(ColorCompType) * chunkSize * 4);
+						currentVBO->write(currentVBO->rgbShift, s_rgbBuffer4ub, sizeof(ColorCompType) * chunkSize * 4);
 						//upadte 'modification' flag for current displayed SF
 						m_vboManager.sourceSF->setModificationFlag(false);
 					}
 					else if (glParams.showColors)
 					{
-						m_vboManager.vbos[chunkIndex]->write(m_vboManager.vbos[chunkIndex]->rgbShift, ccChunk::Start(*m_rgbaColors, chunkIndex), sizeof(ColorCompType) * chunkSize * 4);
+						currentVBO->write(currentVBO->rgbShift, ccChunk::Start(*m_rgbaColors, chunkIndex), sizeof(ColorCompType) * chunkSize * 4);
 					}
 				}
 #ifndef DONT_LOAD_NORMALS_IN_VBOS
@@ -5680,10 +5682,10 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 						*(outNorms)++ = N.y;
 						*(outNorms)++ = N.z;
 					}
-					m_vboManager.vbos[chunkIndex]->write(m_vboManager.vbos[chunkIndex]->normalShift, s_normalBuffer, sizeof(PointCoordinateType)*chunkSize * 3);
+					currentVBO->write(currentVBO->normalShift, s_normalBuffer, sizeof(PointCoordinateType)*chunkSize * 3);
 				}
 #endif
-				m_vboManager.vbos[chunkIndex]->release();
+				currentVBO->release();
 
 				//if an error is detected
 				QOpenGLFunctions_2_1* glFunc = context.glFunctions<QOpenGLFunctions_2_1>();
@@ -5701,9 +5703,9 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 
 			if (vboSizeBytes < 0) //VBO initialization failed
 			{
-				m_vboManager.vbos[chunkIndex]->destroy();
-				delete m_vboManager.vbos[chunkIndex];
-				m_vboManager.vbos[chunkIndex] = nullptr;
+				currentVBO->destroy();
+				delete currentVBO;
+				currentVBO = nullptr;
 
 				//we can stop here
 				if (chunkIndex == 0)

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -5585,7 +5585,7 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 		{
 			int chunkSize = static_cast<int>(ccChunk::Size(chunkIndex, m_points));
 
-			VBO * currentVBO = m_vboManager.vbos[chunkIndex];
+			VBO* currentVBO = m_vboManager.vbos[chunkIndex];
 
 			int chunkUpdateFlags = m_vboManager.updateFlags;
 			bool reallocated = false;

--- a/libs/qCC_db/src/ccSphere.cpp
+++ b/libs/qCC_db/src/ccSphere.cpp
@@ -20,6 +20,9 @@
 //Local
 #include "ccPointCloud.h"
 
+//QT
+#include <QFontMetrics>
+
 
 ccSphere::ccSphere(	PointCoordinateType radius,
 					const ccGLMatrix* transMat/*=nullptr*/,

--- a/libs/qCC_glWindow/src/ccGLWindowInterface.cpp
+++ b/libs/qCC_glWindow/src/ccGLWindowInterface.cpp
@@ -42,6 +42,7 @@
 #include <QOpenGLBuffer>
 #include <QOpenGLDebugLogger>
 #include <QOffscreenSurface>
+#include <QPainter>
 #include <QPushButton>
 #include <QSettings>
 #include <QTouchEvent>

--- a/plugins/core/Standard/qSRA/src/ccSymbolCloud.cpp
+++ b/plugins/core/Standard/qSRA/src/ccSymbolCloud.cpp
@@ -3,6 +3,9 @@
 //qCC_db
 #include <ccGenericGLDisplay.h>
 
+//QT
+#include <QFontMetrics>
+
 ccSymbolCloud::ccSymbolCloud(QString name/*=QString()*/)
 	: ccPointCloud(name)
 	, m_symbolSize(10.0)
@@ -17,10 +20,10 @@ bool ccSymbolCloud::reserve(unsigned numberOfPoints)
 {
 	if (!ccPointCloud::reserve(numberOfPoints))
 		return false;
-	
+
 	if (m_labels.size())
 		return reserveLabelArray(numberOfPoints);
-	
+
 	return true;
 }
 
@@ -28,10 +31,10 @@ bool ccSymbolCloud::resize(unsigned numberOfPoints)
 {
 	if (!ccPointCloud::resize(numberOfPoints))
 		return false;
-	
+
 	if (m_labels.size())
 		return resizeLabelArray(numberOfPoints);
-	
+
 	return true;
 }
 
@@ -90,7 +93,7 @@ QString ccSymbolCloud::getLabel(unsigned index) const
 	{
 		return m_labels[index];
 	}
-	
+
 	return QString();
 }
 
@@ -188,7 +191,7 @@ void ccSymbolCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 			color = &m_tempColor;
 			glParams.showColors = false;
 		}
-		
+
 		unsigned numberOfPoints = size();
 
 		//viewport parameters (will be used to project 3D positions to 2D)

--- a/plugins/core/Standard/qSRA/src/qSRA.cpp
+++ b/plugins/core/Standard/qSRA/src/qSRA.cpp
@@ -42,9 +42,7 @@
 #include <ccScalarField.h>
 
 //System
-#include <string.h>
-#include <algorithm>
-#include <vector>
+#include <cstring>
 
 qSRA::qSRA(QObject* parent/*=nullptr*/)
 	: QObject(parent)
@@ -508,7 +506,7 @@ void qSRA::doProjectCloudDistsInGrid(ccPointCloud* cloud, ccPolyline* polyline) 
 			{
 				QString message = QString("Cloud has no '%1' field and no active scalar field!").arg(RADIAL_DIST_SF_NAME);
 				ccLog::Error(message);
-				
+
 				//additional indications
 				if (m_doCompareCloudToProfile)
 				{

--- a/qCC/main.cpp
+++ b/qCC/main.cpp
@@ -19,6 +19,7 @@
 
 //Qt
 #include <QDir>
+#include <QGLFormat>
 #include <QMessageBox>
 #include <QPixmap>
 #include <QSettings>
@@ -81,7 +82,7 @@ static bool IsCommandLine(int argc, char **argv)
 
 int main(int argc, char **argv)
 {
-#ifdef _WIN32 //This will allow printf to function on windows when opened from command line	
+#ifdef _WIN32 //This will allow printf to function on windows when opened from command line
 	DWORD stdout_type = GetFileType(GetStdHandle(STD_OUTPUT_HANDLE));
 	if (AttachConsole(ATTACH_PARENT_PROCESS))
 	{
@@ -216,7 +217,7 @@ int main(int argc, char **argv)
 		settings.endGroup();
 
 		ccLog::Print(QString("[Global Shift] Max abs. coord = %1 / max abs. diag = %2").arg(maxAbsCoord, 0, 'e', 0).arg(maxAbsDiag, 0, 'e', 0));
-		
+
 		ccGlobalShiftManager::SetMaxCoordinateAbsValue(maxAbsCoord);
 		ccGlobalShiftManager::SetMaxBoundgBoxDiagonal(maxAbsDiag);
 	}
@@ -299,9 +300,9 @@ int main(int argc, char **argv)
 
 		//change the default path to the application one (do this AFTER processing the command line)
 		QDir workingDir = QCoreApplication::applicationDirPath();
-		
+
 	#ifdef Q_OS_MAC
-		// This makes sure that our "working directory" is not within the application bundle	
+		// This makes sure that our "working directory" is not within the application bundle
 		if ( workingDir.dirName() == "MacOS" )
 		{
 			workingDir.cdUp();


### PR DESCRIPTION
- QT documentation state that `QGLBuffer` is deprecated and `QOPenGLBuffer` has better performance (I'm pretty sure we won't notice any improvement thought :D). 
While we already use `QOpenGLBuffer` in some parts of our code, it has not yet been used the ccPointCloud class. This PR addresses this by making the necessary changes.