### PR TITLE
Increased header line buffer size for ply files

### DIFF
--- a/libs/qCC_io/src/rply.c
+++ b/libs/qCC_io/src/rply.c
@@ -61,7 +61,7 @@ typedef uint32_t t_ply_uint32;
  * Constants 
  * ---------------------------------------------------------------------- */
 #define WORDSIZE 256
-#define LINESIZE 1024
+#define LINESIZE 2048
 #define BUFFERSIZE (8*1024)
 
 typedef enum e_ply_io_mode_ {


### PR DESCRIPTION
We often encounter ply files where the upstream systems piggyback additional information in the ply headers. Regularly this information exceeds the 1024 byte buffer limit. Please consider accepting a doubling of the line buffer size. To not impact overall header parsing overhead, the total buffer size stays at 8kb.