### PR TITLE
Fix minor typo

### DIFF
--- a/qCC/translations/CloudCompare_chs.ts
+++ b/qCC/translations/CloudCompare_chs.ts
@@ -8090,7 +8090,7 @@ Parameter</source>
     <message>
         <location filename="../ui_templates/mainWindow.ui" line="819"/>
         <location filename="../ui_templates/mainWindow.ui" line="822"/>
-        <source>Open one or severa files</source>
+        <source>Open one or several files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/qCC/translations/CloudCompare_de.ts
+++ b/qCC/translations/CloudCompare_de.ts
@@ -8606,7 +8606,7 @@ The active scalar field should have integer values.</source>
     <message>
         <location filename="../ui_templates/mainWindow.ui" line="819"/>
         <location filename="../ui_templates/mainWindow.ui" line="822"/>
-        <source>Open one or severa files</source>
+        <source>Open one or several files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/qCC/translations/CloudCompare_es_AR.ts
+++ b/qCC/translations/CloudCompare_es_AR.ts
@@ -8600,7 +8600,7 @@ The active scalar field should have integer values.</source>
     <message>
         <location filename="../ui_templates/mainWindow.ui" line="819"/>
         <location filename="../ui_templates/mainWindow.ui" line="822"/>
-        <source>Open one or severa files</source>
+        <source>Open one or several files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/qCC/translations/CloudCompare_fr.ts
+++ b/qCC/translations/CloudCompare_fr.ts
@@ -8465,7 +8465,7 @@ The active scalar field should have integer values.</source>
     <message>
         <location filename="../ui_templates/mainWindow.ui" line="819"/>
         <location filename="../ui_templates/mainWindow.ui" line="822"/>
-        <source>Open one or severa files</source>
+        <source>Open one or several files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/qCC/translations/CloudCompare_ja.ts
+++ b/qCC/translations/CloudCompare_ja.ts
@@ -8550,7 +8550,7 @@ The active scalar field should have integer values.</source>
     <message>
         <location filename="../ui_templates/mainWindow.ui" line="819"/>
         <location filename="../ui_templates/mainWindow.ui" line="822"/>
-        <source>Open one or severa files</source>
+        <source>Open one or several files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/qCC/translations/CloudCompare_ko.ts
+++ b/qCC/translations/CloudCompare_ko.ts
@@ -8287,7 +8287,7 @@ Parameter</source>
     <message>
         <location filename="../ui_templates/mainWindow.ui" line="819"/>
         <location filename="../ui_templates/mainWindow.ui" line="822"/>
-        <source>Open one or severa files</source>
+        <source>Open one or several files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/qCC/translations/CloudCompare_pt.ts
+++ b/qCC/translations/CloudCompare_pt.ts
@@ -8464,7 +8464,7 @@ The active scalar field should have integer values.</source>
     <message>
         <location filename="../ui_templates/mainWindow.ui" line="819"/>
         <location filename="../ui_templates/mainWindow.ui" line="822"/>
-        <source>Open one or severa files</source>
+        <source>Open one or several files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/qCC/translations/CloudCompare_ru.ts
+++ b/qCC/translations/CloudCompare_ru.ts
@@ -8611,7 +8611,7 @@ The active scalar field should have integer values.</source>
     <message>
         <location filename="../ui_templates/mainWindow.ui" line="819"/>
         <location filename="../ui_templates/mainWindow.ui" line="822"/>
-        <source>Open one or severa files</source>
+        <source>Open one or several files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/qCC/translations/CloudCompare_zh.ts
+++ b/qCC/translations/CloudCompare_zh.ts
@@ -8556,7 +8556,7 @@ The active scalar field should have integer values.</source>
     <message>
         <location filename="../ui_templates/mainWindow.ui" line="819"/>
         <location filename="../ui_templates/mainWindow.ui" line="822"/>
-        <source>Open one or severa files</source>
+        <source>Open one or several files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/qCC/ui_templates/mainWindow.ui
+++ b/qCC/ui_templates/mainWindow.ui
@@ -823,10 +823,10 @@ QTreeView::branch:open:has-children:has-siblings  {
     <string>&amp;Open</string>
    </property>
    <property name="toolTip">
-    <string>Open one or severa files</string>
+    <string>Open one or several files</string>
    </property>
    <property name="statusTip">
-    <string>Open one or severa files</string>
+    <string>Open one or several files</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+O</string>


### PR DESCRIPTION
Fixed all occasions of the typo "severa" into "several" for translation and ui files.

This is my first contribution to this repo, so I appologise if there are some convention I haven't followed, please let me know and I'll fix it. 