### PR TITLE
Master e57 command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ Improvements:
 			this means the user really wants to apply the input Global shift to all the entities (instead of showing the dialog again and again)
 
 	- Command line:
+		- new options
+			- -DISTANCES_FROM_SENSOR [-SQUARED]
+			- -SCATTERING_ANGLES [-DEGREES]
+			- -OCTREE_NORMALS {radius} [-WITH_GRIDS {angle}] [-ORIENT WITH_GRIDS]
 		- the -SF_OP command now supports MIN/DISP_MIN/SAT_MIN/N_SIGMA_MIN/MAX/DISP_MAX/SAT_MAX/N_SIGMA_MAX as input values
 		- Rename -CSF command's resulting clouds to be able to select them later:
 			- {original cloud name} + '_ground_points'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ Improvements:
 		- new options
 			- -DISTANCES_FROM_SENSOR [-SQUARED]
 			- -SCATTERING_ANGLES [-DEGREES]
-			- -OCTREE_NORMALS {radius} [-WITH_GRIDS {angle}] [-ORIENT WITH_GRIDS]
+			- -OCTREE_NORMALS {radius} [-WITH_GRIDS {angle}] [-ORIENT WITH_GRIDS] [-ORIENT WITH_SENSOR] 
 		- the -SF_OP command now supports MIN/DISP_MIN/SAT_MIN/N_SIGMA_MIN/MAX/DISP_MAX/SAT_MAX/N_SIGMA_MAX as input values
 		- Rename -CSF command's resulting clouds to be able to select them later:
 			- {original cloud name} + '_ground_points'

--- a/qCC/ccCommandLineCommands.h
+++ b/qCC/ccCommandLineCommands.h
@@ -617,4 +617,18 @@ struct CommandSetVerbosity : public ccCommandLineInterface::Command
 	bool process(ccCommandLineInterface& cmd) override;
 };
 
+struct CommandComputeDistancesFromSensor : public ccCommandLineInterface::Command
+{
+	CommandComputeDistancesFromSensor();
+
+	bool process(ccCommandLineInterface& cmd) override;
+};
+
+struct CommandComputeScatteringAngles : public ccCommandLineInterface::Command
+{
+	CommandComputeScatteringAngles();
+
+	bool process(ccCommandLineInterface& cmd) override;
+};
+
 #endif //COMMAND_LINE_COMMANDS_HEADER

--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -942,6 +942,8 @@ void ccCommandLineParser::registerBuiltInCommands()
 	registerCommand(Command::Shared(new CommandRGBConvertToSF));
 	registerCommand(Command::Shared(new CommandFlipTriangles));
 	registerCommand(Command::Shared(new CommandSetVerbosity));
+	registerCommand(Command::Shared(new CommandComputeDistancesFromSensor));
+	registerCommand(Command::Shared(new CommandComputeScatteringAngles));
 }
 
 void ccCommandLineParser::cleanup()


### PR DESCRIPTION
Several options added to the command line.

Use grids to compute or orient normals:
-OCTREE_NORMALS {radius} [-WITH_GRIDS {angle}] [-ORIENT WITH_GRIDS]

Use a sensor to compute distances and scattering angles:
-DISTANCES_FROM_SENSOR [-SQUARED]
-SCATTERING_ANGLES [-DEGREES]