### PR TITLE
Don't ignore empty csv fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,7 @@ Bug fixes:
 	- The circular cursor of the 'Cloud layers' and 'Compass' plugins was not displayed at the right position on high DPI screens
 	- The Compass plugin was not transferring the Global Shift & Scale information from the cloud to the generated planes or polylines
 	- UHD screens were not properly supported (rotation center picking with double click, entity selection with a rectangle, etc.)
+	- ASCII cloud file import will now respect empty fields instead of shifting all following columns left
 
 v2.13.2 (Kharkiv) - (06/30/2024)
 ----------------------

--- a/libs/qCC_io/src/AsciiFilter.cpp
+++ b/libs/qCC_io/src/AsciiFilter.cpp
@@ -970,7 +970,7 @@ CC_FILE_ERROR AsciiFilter::loadCloudFromFormatedAsciiStream(QTextStream& stream,
 		}
 
 		//we split current line
-		QStringList parts = currentLine.simplified().split(separator, QString::SkipEmptyParts);
+		QStringList parts = currentLine.simplified().split(separator);
 
 		int nParts = parts.size();
 		if (nParts > maxPartIndex) //fake loop for easy break

--- a/libs/qCC_io/src/AsciiOpenDlg.cpp
+++ b/libs/qCC_io/src/AsciiOpenDlg.cpp
@@ -389,8 +389,7 @@ void AsciiOpenDlg::updateTable()
 		//we recognize "//" as the beginning of a comment
 		if (!currentLine.startsWith("//")/* || !currentLine.startsWith("#")*/)
 		{
-			QStringList parts = currentLine.simplified().split(m_separator, QString::SkipEmptyParts);
-			
+			QStringList parts = currentLine.simplified().split(m_separator);
 			if (lineCount < DISPLAYED_LINES)
 			{
 				unsigned partsCount = std::min(MAX_COLUMNS, static_cast<unsigned>(parts.size()));
@@ -646,7 +645,7 @@ void AsciiOpenDlg::updateTable()
 		unsigned assignedQuaternionFlags = 0;
 
 		//split header (if any)
-		QStringList headerParts = m_headerLine.simplified().split(m_separator, QString::SkipEmptyParts);
+		QStringList headerParts = m_headerLine.simplified().split(m_separator);
 		bool validHeader = (headerParts.size() >= static_cast<int>(columnsCount));
 		m_ui->extractSFNamesFrom1stLineCheckBox->setEnabled(validHeader); //can we consider the first ignored line as a header?
 		if (!validHeader)
@@ -1193,7 +1192,7 @@ AsciiOpenDlg::Sequence AsciiOpenDlg::getOpenSequence() const
 			&& m_ui->extractSFNamesFrom1stLineCheckBox->isEnabled()
 			&& m_ui->extractSFNamesFrom1stLineCheckBox->isChecked())
 		{
-			headerParts = m_headerLine.simplified().split(m_separator, QString::SkipEmptyParts);
+			headerParts = m_headerLine.simplified().split(m_separator);
 		}
 
 		seq.reserve(m_columnsCount - 1);
@@ -1221,7 +1220,7 @@ bool AsciiOpenDlg::safeSequence() const
 		return false;
 
 	AsciiOpenDlg::Sequence seq = getOpenSequence();
-	QStringList headerParts = m_headerLine.simplified().split(m_separator, QString::SkipEmptyParts);
+	QStringList headerParts = m_headerLine.simplified().split(m_separator);
 
 	//not enough column headers?
 	if (headerParts.size() < static_cast<int>(seq.size()))


### PR DESCRIPTION
Previously, an empty CSV field would cause columns in a CSV to get misaligned. E.g.
```csv
x,y
,42
```
would be the same as:
```csv
x,y
42
```

That is, "42" would be treated as if it were in the "x" column, not the "y" column. Now, empty fields are not discarded.