### PR TITLE
Fix duplicate assignment of LAS extra scalar fields

### DIFF
--- a/plugins/core/IO/qLASIO/src/LasSaveDialog.cpp
+++ b/plugins/core/IO/qLASIO/src/LasSaveDialog.cpp
@@ -508,11 +508,21 @@ void LasSaveDialog::setExtraScalarFields(const std::vector<LasExtraScalarField>&
 		return;
 	}
 
+	// We received extra scalar fields spec saved from the file's metadata
+	// But we may have already default-assigned some fields as extra scalar fields
+	// so we have to clear them
+	unassignDefaultFields();
+
 	for (const LasExtraScalarField& field : extraScalarFields)
 	{
 		auto* card = createCard();
 		extraScalarFieldsLayout->insertWidget(extraScalarFieldsLayout->count(), card);
 		card->fillFrom(field);
+	}
+
+	if (shouldAutomaticallyAssignLeftoverSFsAsExtra())
+	{
+		assignLeftoverScalarFieldsAsExtra();
 	}
 }
 


### PR DESCRIPTION
When saving a LAS file that originally had extra scalar fields we could end up creating duplicates of them when saving.

This bug was due to the dialog auto assigning non standard field name to new scalar extra scalar field with some default options. This was done every time the point format changed (but here it was properly handled).

What was missing is that when we tell the dialog, which extra scalar field we know of thanks to the meta data attached to the cloud, we did not clear the default created extra scalar fields, so we ended up with duplicates.