### PR TITLE
[M3C2] better handling of normal mode + bug correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,10 @@ Improvements:
 			or the camera FOV and other parameters
 		- option to export the colors as RGB
 
+	- M3C2 plugin
+		- better handling of the normal mode
+		- option to select either 2 (ref + comp) or 3 (ref + comp + core) clouds to activate the plugin
+
 	- TreeIso plugin
 		- updated version, faster and more robust
 		- detection of ill-formed clouds (i.e. with ground points for instance)
@@ -201,10 +205,8 @@ Bug fixes:
 	- When specifying some scalar fields by name or by index as weights to the ICP command line, those would be ignored
 	- E57/PCD: when saving a cloud after having applied a 'reflection' transformation (e.g. inverting a single axis), the saved
 		sensor pose was truncated due to the internal representation of these formats (as a quaternion)
-	- M3C2: 
-		- better handling of the normal mode
+	- M3C2:
 		- bug corrected: when the "use other cloud" is checked, do not propose the use of cloud #1 as a possible source for the normals
-		- option to select either 2 (ref + comp) or 3 (ref + comp + core) clouds to activate the plugin
 		- force the vertical mode in CLI call when NormalMode=3 is requested (needed in case of multiple calls in the same command line)
 	- Waveform
 		- each LAS point with missing waveform data was triggering a warning message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,9 @@ Bug fixes:
 	- E57/PCD: when saving a cloud after having applied a 'reflection' transformation (e.g. inverting a single axis), the saved
 		sensor pose was truncated due to the internal representation of these formats (as a quaternion)
 	- M3C2: 
+		- better handling of the normal mode
+		- bug corrected: when the "use other cloud" is checked, do not propose the use of cloud #1 as a possible source for the normals
+		- option to select either 2 (ref + comp) or 3 (ref + comp + core) clouds to activate the plugin
 		- force the vertical mode in CLI call when NormalMode=3 is requested (needed in case of multiple calls in the same command line)
 	- Waveform
 		- each LAS point with missing waveform data was triggering a warning message

--- a/plugins/core/Standard/qM3C2/include/qM3C2Commands.h
+++ b/plugins/core/Standard/qM3C2/include/qM3C2Commands.h
@@ -32,7 +32,6 @@ struct CommandM3C2 : public ccCommandLineInterface::Command
 
 	virtual bool process(ccCommandLineInterface& cmd) override
 	{
-		cmd.print("[M3C2]");
 		if (cmd.arguments().empty())
 		{
 			return cmd.error(QString("Missing parameter: parameters filename after \"-%1\"").arg(COMMAND_M3C2));
@@ -53,12 +52,11 @@ struct CommandM3C2 : public ccCommandLineInterface::Command
 		ccPointCloud* corePointsCloud = (cmd.clouds().size() > 2 ? cmd.clouds()[2].pc : nullptr);
 
 		//display dialog
-		qM3C2Dialog dlg(cloud1, cloud2, nullptr);
+		qM3C2Dialog dlg(cloud1, cloud2, nullptr, corePointsCloud);
 		if (!dlg.loadParamsFromFile(paramFilename))
 		{
 			return false;
 		}
-		dlg.setCorePointsCloud(corePointsCloud);
 
 		QString errorMessage;
 		ccPointCloud* outputCloud = nullptr; //only necessary for the command line version in fact

--- a/plugins/core/Standard/qM3C2/include/qM3C2Dialog.h
+++ b/plugins/core/Standard/qM3C2/include/qM3C2Dialog.h
@@ -37,7 +37,7 @@ class qM3C2Dialog : public QDialog, public Ui::M3C2Dialog
 public:
 
 	//! Default constructor
-	qM3C2Dialog(ccPointCloud* cloud1, ccPointCloud* cloud2, ccMainAppInterface* app);
+	qM3C2Dialog(ccPointCloud* cloud1, ccPointCloud* cloud2, ccMainAppInterface* app, ccPointCloud* corePointsCloud=nullptr);
 
 	//! Returns cloud #1
 	ccPointCloud* getCloud1() const { return m_cloud1; }
@@ -52,7 +52,7 @@ public:
 	ccPointCloud* getCorePointsCloud() const;
 
 	//! Sets the core points cloud
-	void setCorePointsCloud(ccPointCloud* cloud) { m_corePointsCloud = cloud; }
+	void setCorePointsCloud(ccPointCloud* cloud);
 
 	//! Returns the cloud to be used for normals orientation (if any)
 	ccPointCloud* getNormalsOrientationCloud() const;

--- a/plugins/core/Standard/qM3C2/src/qM3C2.cpp
+++ b/plugins/core/Standard/qM3C2/src/qM3C2.cpp
@@ -42,9 +42,14 @@ void qM3C2Plugin::onNewSelection(const ccHObject::Container& selectedEntities)
 {
 	if (m_action)
 	{
-		m_action->setEnabled(	selectedEntities.size() == 2
-							&&	selectedEntities[0]->isA(CC_TYPES::POINT_CLOUD)
-							&&	selectedEntities[1]->isA(CC_TYPES::POINT_CLOUD) );
+		bool twoCloudsSelection = selectedEntities.size() == 2
+								  &&	selectedEntities[0]->isA(CC_TYPES::POINT_CLOUD)
+								  &&	selectedEntities[1]->isA(CC_TYPES::POINT_CLOUD);
+		bool threeCloudsSelection = selectedEntities.size() == 3
+									&&	selectedEntities[0]->isA(CC_TYPES::POINT_CLOUD)
+									&&	selectedEntities[1]->isA(CC_TYPES::POINT_CLOUD)
+									&&	selectedEntities[2]->isA(CC_TYPES::POINT_CLOUD);
+		m_action->setEnabled(twoCloudsSelection || threeCloudsSelection);
 	}
 
 	m_selectedEntities = selectedEntities;
@@ -74,19 +79,26 @@ void qM3C2Plugin::doAction()
 	if (!m_app)
 		return;
 
-	if (m_selectedEntities.size() != 2
-		|| !m_selectedEntities[0]->isA(CC_TYPES::POINT_CLOUD)
-		|| !m_selectedEntities[1]->isA(CC_TYPES::POINT_CLOUD))
+	bool twoCloudsSelection = m_selectedEntities.size() == 2
+							  &&	m_selectedEntities[0]->isA(CC_TYPES::POINT_CLOUD)
+							  &&	m_selectedEntities[1]->isA(CC_TYPES::POINT_CLOUD);
+	bool threeCloudsSelection = m_selectedEntities.size() == 3
+								&&	m_selectedEntities[0]->isA(CC_TYPES::POINT_CLOUD)
+								&&	m_selectedEntities[1]->isA(CC_TYPES::POINT_CLOUD)
+								&&	m_selectedEntities[2]->isA(CC_TYPES::POINT_CLOUD);
+
+	if (!twoCloudsSelection && !threeCloudsSelection)
 	{
-		m_app->dispToConsole("Select two point clouds!", ccMainAppInterface::ERR_CONSOLE_MESSAGE);
+		m_app->dispToConsole("Select two or three point clouds!", ccMainAppInterface::ERR_CONSOLE_MESSAGE);
 		return;
 	}
 
 	ccPointCloud* cloud1 = ccHObjectCaster::ToPointCloud(m_selectedEntities[0]);
 	ccPointCloud* cloud2 = ccHObjectCaster::ToPointCloud(m_selectedEntities[1]);
+	ccPointCloud* cloud3 = threeCloudsSelection ? ccHObjectCaster::ToPointCloud(m_selectedEntities[2]) : nullptr;
 
 	//display dialog
-	qM3C2Dialog dlg(cloud1, cloud2, m_app);
+	qM3C2Dialog dlg(cloud1, cloud2, m_app, cloud3);
 	if (!dlg.exec())
 	{
 		//process cancelled by the user

--- a/plugins/core/Standard/qM3C2/src/qM3C2Dialog.cpp
+++ b/plugins/core/Standard/qM3C2/src/qM3C2Dialog.cpp
@@ -81,13 +81,13 @@ static ccPointCloud* GetCloudFromCombo(QComboBox* comboBox, ccHObject* dbRoot)
 
 /*** HELPERS (END) ***/
 
-qM3C2Dialog::qM3C2Dialog(ccPointCloud* cloud1, ccPointCloud* cloud2, ccMainAppInterface* app)
+qM3C2Dialog::qM3C2Dialog(ccPointCloud* cloud1, ccPointCloud* cloud2, ccMainAppInterface* app, ccPointCloud *corePointsCloud)
 	: QDialog(app ? app->getMainWindow() : nullptr)
 	, Ui::M3C2Dialog()
 	, m_app(app)
 	, m_cloud1(nullptr)
 	, m_cloud2(nullptr)
-	, m_corePointsCloud(nullptr)
+	, m_corePointsCloud(corePointsCloud)
 {
 	setupUi(this);
 
@@ -133,8 +133,16 @@ qM3C2Dialog::qM3C2Dialog(ccPointCloud* cloud1, ccPointCloud* cloud2, ccMainAppIn
 	}
 	else
 	{
-		//command line mode: we need to update the combo-box
-		updateNormalComboBox();
+		if (m_corePointsCloud)
+		{
+			cpOtherCloudComboBox->addItem(GetEntityName(m_corePointsCloud), QVariant(m_corePointsCloud->getUniqueID()));
+			normOriCloudComboBox->addItem(GetEntityName(m_corePointsCloud), QVariant(m_corePointsCloud->getUniqueID()));
+		}
+	}
+
+	if (m_corePointsCloud)
+	{
+		setCorePointsCloud(corePointsCloud);
 	}
 
 	loadParamsFromPersistentSettings(); // must be done after updating the 'normal source' combox-box!
@@ -280,7 +288,7 @@ void qM3C2Dialog::updateNormalComboBox()
 		normalSourceComboBox->setCurrentIndex(lastIndex); //default mode
 	}
 
-	if (m_cloud1 && m_cloud1->hasNormals())
+	if (m_cloud1 && m_cloud1->hasNormals() && cpUseCloud1RadioButton->isChecked())
 	{
 		normalSourceComboBox->addItem("Use cloud #1 normals", QVariant(qM3C2Normals::USE_CLOUD1_NORMALS));
 		++lastIndex;
@@ -293,16 +301,31 @@ void qM3C2Dialog::updateNormalComboBox()
 
 	if (cpUseOtherCloudRadioButton->isChecked())
 	{
-		//return the cloud currently selected in the combox box
-		ccPointCloud* otherCloud = GetCloudFromCombo(cpOtherCloudComboBox, m_app->dbRootObject());
-		if (otherCloud && otherCloud->hasNormals())
+		if (m_app)
 		{
-			normalSourceComboBox->addItem("Use core points normals", QVariant(qM3C2Normals::USE_CORE_POINTS_NORMALS));
-			++lastIndex;
-			if (previouslySelectedItem == qM3C2Normals::USE_CORE_POINTS_NORMALS || previouslySelectedItem < 0)
+			//return the cloud currently selected in the combox box
+			ccPointCloud* otherCloud = GetCloudFromCombo(cpOtherCloudComboBox, m_app->dbRootObject());
+			if (otherCloud && otherCloud->hasNormals())
 			{
-				normalSourceComboBox->setCurrentIndex(lastIndex);
-				previouslySelectedItem = qM3C2Normals::USE_CORE_POINTS_NORMALS;
+				normalSourceComboBox->addItem("Use core points normals", QVariant(qM3C2Normals::USE_CORE_POINTS_NORMALS));
+				++lastIndex;
+				if (previouslySelectedItem == qM3C2Normals::USE_CORE_POINTS_NORMALS || previouslySelectedItem < 0)
+				{
+					normalSourceComboBox->setCurrentIndex(lastIndex);
+				}
+			}
+		}
+		else // command line interface
+		{
+			//return the core points cloud
+			if (m_corePointsCloud && m_corePointsCloud->hasNormals())
+			{
+				normalSourceComboBox->addItem("Use core points normals", QVariant(qM3C2Normals::USE_CORE_POINTS_NORMALS));
+				++lastIndex;
+				if (previouslySelectedItem == qM3C2Normals::USE_CORE_POINTS_NORMALS || previouslySelectedItem < 0)
+				{
+					normalSourceComboBox->setCurrentIndex(lastIndex);
+				}
 			}
 		}
 	}
@@ -320,13 +343,45 @@ ccPointCloud* qM3C2Dialog::getCorePointsCloud() const
 	}
 	else if (cpUseOtherCloudRadioButton->isChecked())
 	{
-		//return the cloud currently selected in the combox box
-		return GetCloudFromCombo(cpOtherCloudComboBox, m_app->dbRootObject());
+		if(m_app)
+		{
+			//return the cloud currently selected in the combox box
+			return GetCloudFromCombo(cpOtherCloudComboBox, m_app->dbRootObject());
+		}
+		else // command line interface
+		{
+			return m_corePointsCloud;
+		}
 	}
 	else
 	{
 		return nullptr;
 	}
+}
+
+void qM3C2Dialog::setCorePointsCloud(ccPointCloud* cloud)
+{
+	m_corePointsCloud = cloud;
+	// the combo box cpOtherCloudComboBox is populated at the creation of the dialog, so the core cloud should already be in it
+	// look for the index of the core cloud and set cpOtherCloudComboBox
+	int index = -1;
+	for (int i = 0; i < cpOtherCloudComboBox->count(); ++i)
+	{
+		if (cpOtherCloudComboBox->itemData(i) == QVariant(cloud->getUniqueID()))
+		{
+			// ccLog::Print("[qM3C2Dialog::setCorePointsCloud] index of core cloud " + cloud->getName() + " is " + QString::number(i));
+			index = i;
+			break;
+		}
+	}
+	if (index == -1)
+	{
+		ccLog::Error("[qM3C2Dialog::setCorePointsCloud] core cloud " + cloud->getName() + " not found in the cpOtherCloudComboBox");
+	}
+
+	cpOtherCloudComboBox->setCurrentIndex(index);
+
+	QApplication::processEvents();
 }
 
 ccPointCloud* qM3C2Dialog::getNormalsOrientationCloud() const
@@ -375,11 +430,16 @@ qM3C2Normals::ComputationMode qM3C2Dialog::getNormalsComputationMode() const
 	// force vertical mode if needed in command line mode
 	if (!m_app)
 	{
-		if (getRequestedComputationMode() == qM3C2Normals::VERT_MODE)
-		{
-			ccLog::Print("[M3C2] force vertical mode as requested in the parameter file");
-			return qM3C2Normals::VERT_MODE;
-		}
+		// if (getRequestedComputationMode() == qM3C2Normals::VERT_MODE)
+		// {
+		// 	ccLog::Print("[M3C2] force computation mode VERT_MODE as requested in the parameter file");
+		// 	return qM3C2Normals::VERT_MODE;
+		// }
+		// else if (getRequestedComputationMode() == qM3C2Normals::USE_CORE_POINTS_NORMALS)
+		// {
+		// 	ccLog::Print("[M3C2] force computation mode USE_CORE_POINTS_NORMALS as requested in the parameter file");
+		// 	return qM3C2Normals::USE_CORE_POINTS_NORMALS;
+		// }
 	}
 
 	//special case
@@ -501,6 +561,24 @@ void qM3C2Dialog::loadParamsFrom(const QSettings& settings)
 
 	//apply parameters
 	normalScaleDoubleSpinBox->setValue(normalScale);
+
+	// NORMAL MODE
+	// Check the correct radio button between:  cpUseCloud1RadioButton / cpSubsampleRadioButton / cpUseOtherCloudRadioButton
+	// Normal modes: DEFAULT_MODE / USE_CLOUD1_NORMAL / MULTI_SCALE_MODE / VERT_MODE / HORIZ_MODE /USE_CORE_POINTS_NORMALS
+	if (normModeInt == qM3C2Normals::USE_CORE_POINTS_NORMALS)
+	{
+		cpUseOtherCloudRadioButton->setChecked(true);
+	}
+	else
+	{
+		if (subsampleEnabled)
+			cpSubsampleRadioButton->setChecked(true);
+		else
+			cpUseCloud1RadioButton->setChecked(true);
+	}
+	QApplication::processEvents(); // force refreshing normalSourceComboBox
+	cpSubsamplingDoubleSpinBox->setValue(subsampleRadius);
+
 	switch(normModeInt)
 	{
 	case qM3C2Normals::USE_CLOUD1_NORMALS:
@@ -552,12 +630,6 @@ void qM3C2Dialog::loadParamsFrom(const QSettings& settings)
 
 	cylDiameterDoubleSpinBox->setValue(seachScale);
 	cylHalfHeightDoubleSpinBox->setValue(searchDepth);
-	
-	cpSubsamplingDoubleSpinBox->setValue(subsampleRadius);
-	if (subsampleEnabled)
-		cpSubsampleRadioButton->setChecked(true);
-	else
-		cpUseCloud1RadioButton->setChecked(true);
 
 	rmsCheckBox->setChecked(registrationErrorEnabled);
 	rmsDoubleSpinBox->setValue(registrationError);

--- a/plugins/core/Standard/qM3C2/src/qM3C2Dialog.cpp
+++ b/plugins/core/Standard/qM3C2/src/qM3C2Dialog.cpp
@@ -427,21 +427,6 @@ void qM3C2Dialog::setCloud2Visibility(bool state)
 
 qM3C2Normals::ComputationMode qM3C2Dialog::getNormalsComputationMode() const
 {
-	// force vertical mode if needed in command line mode
-	if (!m_app)
-	{
-		// if (getRequestedComputationMode() == qM3C2Normals::VERT_MODE)
-		// {
-		// 	ccLog::Print("[M3C2] force computation mode VERT_MODE as requested in the parameter file");
-		// 	return qM3C2Normals::VERT_MODE;
-		// }
-		// else if (getRequestedComputationMode() == qM3C2Normals::USE_CORE_POINTS_NORMALS)
-		// {
-		// 	ccLog::Print("[M3C2] force computation mode USE_CORE_POINTS_NORMALS as requested in the parameter file");
-		// 	return qM3C2Normals::USE_CORE_POINTS_NORMALS;
-		// }
-	}
-
 	//special case
 	if (normalSourceComboBox->currentIndex() >= 0)
 	{

--- a/plugins/core/Standard/qM3C2/src/qM3C2Process.cpp
+++ b/plugins/core/Standard/qM3C2/src/qM3C2Process.cpp
@@ -464,6 +464,37 @@ bool qM3C2Process::Compute(const qM3C2Dialog& dlg, QString& errorMessage, ccPoin
 	double normalScale = dlg.normalScaleDoubleSpinBox->value();
 	double projectionScale = dlg.cylDiameterDoubleSpinBox->value();
 	qM3C2Normals::ComputationMode normMode = dlg.getNormalsComputationMode();
+	// 		DEFAULT_MODE			= 0, //compute normals on core points
+	// USE_CLOUD1_NORMALS		= 1,
+	// 	MULTI_SCALE_MODE		= 2,
+	// 	VERT_MODE				= 3,
+	// 	HORIZ_MODE				= 4,
+	// 	USE_CORE_POINTS_NORMALS	= 5,
+	QString msg("[qM3C2Process::Compute] normal mode: ");
+	switch (normMode) {
+	case qM3C2Normals::DEFAULT_MODE:
+		msg += "DEFAULT_MODE";
+		break;
+	case qM3C2Normals::USE_CLOUD1_NORMALS:
+		msg += "USE_CLOUD1_NORMALS";
+		break;
+	case qM3C2Normals::MULTI_SCALE_MODE:
+		msg += "MULTI_SCALE_MODE";
+		break;
+	case qM3C2Normals::VERT_MODE:
+		msg += "VERT_MODE";
+		break;
+	case qM3C2Normals::HORIZ_MODE:
+		msg += "HORIZ_MODE";
+		break;
+	case qM3C2Normals::USE_CORE_POINTS_NORMALS:
+		msg += "USE_CORE_POINTS_NORMALS";
+		break;
+	default:
+		ccLog::Error("[qM3C2Process::Compute] Unexpected normal mode " + QString::number(normMode));
+		break;
+	}
+	ccLog::Print(msg);
 	double samplingDist = dlg.cpSubsamplingDoubleSpinBox->value();
 	ccScalarField* normalScaleSF = nullptr; //normal scale (multi-scale mode only)
 


### PR DESCRIPTION
In command line, the normal mode was not properly handled, resulting in hazardous behavior with NormalMode set to 5
In GUI mode, do not allow the option 'normals of cloud#1' in the combo box when the 'use other cloud' radio button is checked
Option added to allow the selection of 3 point clouds (ref + comp + core)