### PR TITLE
change the way options are handled to compute normals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,9 @@ Improvements:
 	- 'Tools > Fit > Sphere'
 		- introduction of a dialog to let the user set the fitting parameters or force the sphere radius
 
+	- 'Edit > Normals > Compute'
+		- When "use scan grid(s) whenever possible" is checked for Neighbors, it is now possible to use a preferred orientation when "Use scan grid(s) whenever possible" and "Use sensor(s) whenever possible" are unchecked
+
 	- Others:
 		- the shortcut to the 'Level' tool in the 'View' toolbar (left) has been removed. Contrarily to the other options in this toolbar,
 			the Level tool can change the cloud coordinates, and not only the camera position. This could lead to strange issues when the

--- a/libs/qCC_db/include/ccPointCloud.h
+++ b/libs/qCC_db/include/ccPointCloud.h
@@ -340,7 +340,8 @@ public: //normals computation/orientation
 	/** Can also orient the normals in the same run.
 	**/
 	bool computeNormalsWithGrids(	double minTriangleAngle_deg = 1.0,
-									ccProgressDialog* pDlg = nullptr );
+									ccProgressDialog* pDlg = nullptr,
+									ccNormalVectors::Orientation preferredOrientation = ccNormalVectors::Orientation::UNDEFINED);
 
 	//! Orient the normals with the associated grid structure(s)
 	bool orientNormalsWithGrids(    ccProgressDialog* pDlg = nullptr );

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -1193,7 +1193,7 @@ bool CommandOctreeNormal::process(ccCommandLineInterface& cmd)
 				ccLog::Print("\tcompute normals with grids, preferred orientation: " + QString::number(orientation));
 				success = cloud->computeNormalsWithGrids(angle, progressDialog.data(), orientation);
 			}
-			if(!success)
+			if (!success)
 			{
 				return cmd.error(QObject::tr("computeNormalsWithGrids failed"));
 			}
@@ -1202,11 +1202,7 @@ bool CommandOctreeNormal::process(ccCommandLineInterface& cmd)
 		{
 			ccLog::Print("\tcompute normals with octree, preferred orientation: " + QString::number(orientation));
 			success = cloud->computeNormalsWithOctree(model, orientation, thisCloudRadius, progressDialog.data());
-			if(success)
-			{
-				cmd.print(QObject::tr("computeNormalsWithOctree success"));
-			}
-			else
+			if (!success)
 			{
 				return cmd.error(QObject::tr("computeNormalsWithOctree failed"));
 			}
@@ -1222,7 +1218,7 @@ bool CommandOctreeNormal::process(ccCommandLineInterface& cmd)
 			}
 			else
 			{
-				return cmd.error(QObject::tr("orient normals with grids failed"));
+				return cmd.error(QObject::tr("Orient normals with grids failed"));
 			}
 		}
 
@@ -1250,7 +1246,7 @@ bool CommandOctreeNormal::process(ccCommandLineInterface& cmd)
 						}
 						else
 						{
-							return cmd.error(QObject::tr("orient normals with sensors failed"));
+							return cmd.error(QObject::tr("Orient normals with sensors failed"));
 						}
 					}
 				}

--- a/qCC/ccEntityAction.cpp
+++ b/qCC/ccEntityAction.cpp
@@ -2247,27 +2247,27 @@ namespace ccEntityAction
 						addToDB(newCloud);
 					}
 #endif
-					if(s_orientNormals)
+					if (s_orientNormals)
 					{
 						if (orientNormalsWithGrids || orientNormalsWithSensors) // withGrids and withSensors take precedence over other methods
 						{
-							ccLog::Print("[computeNormals] compute + orient normals with grids");
+							ccLog::Print("[computeNormals] Compute + orient normals with grids");
 							result = cloud->computeNormalsWithGrids(minGridAngle_deg, &pDlg, ccNormalVectors::UNDEFINED);
-							if (orientNormalsWithGrids) // it is possible to orient the normals later with sensors of MST
+							if (orientNormalsWithGrids) // it is possible to orient the normals later with sensors or MST
 							{
 								normalsAlreadyOriented = true;
 							}
 						}
 						else
 						{
-							ccLog::Print("[computeNormals] compute normals with grids, preferred orientation: " + QString::number(preferredOrientation) + " (255 = undefined)");
+							ccLog::Print("[computeNormals] Compute normals with grids, preferred orientation: " + QString::number(preferredOrientation) + " (255 = undefined)");
 							normalsAlreadyOriented = preferredOrientation != ccNormalVectors::UNDEFINED;
 							result = cloud->computeNormalsWithGrids(minGridAngle_deg, &pDlg, preferredOrientation); // the previous normals are overwritten if any
 						}
 					}
 					else
 					{
-						ccLog::Print("[computeNormals] compute + orient normals with grids");
+						ccLog::Print("[computeNormals] Compute + orient normals with grids");
 						normalsAlreadyOriented = true;
 						result = cloud->computeNormalsWithGrids(minGridAngle_deg, &pDlg, ccNormalVectors::UNDEFINED);
 					}


### PR DESCRIPTION
When "use scan grid(s) whenever possible" is checked for Neighbors, it is now possible to use a preferred orientation when "Use scan grid(s) whenever possible" and "Use sensor(s) whenever possible" are unchecked