### PR TITLE
Add shortcut settings dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ New features:
 		- choice is now persistent, and will be reactivated when running CC again, or creating a new 3D view
 		- currently ignored by 3D mice and controllers
 
+	- New setting dialog to customize keyboard shortcuts for common CC actions
+
 New plugins
 
 	- G3 Point: granulometry made simple in CloudCompare

--- a/libs/CCPluginAPI/include/ccPersistentSettings.h
+++ b/libs/CCPluginAPI/include/ccPersistentSettings.h
@@ -48,4 +48,5 @@ namespace ccPS
 	inline const QString Options                     () { return QStringLiteral( "Options" ); }
 	inline const QString Plugins                     () { return QStringLiteral( "Plugins" ); }
 	inline const QString Translation                 () { return QStringLiteral( "Translation" ); }
+	inline const QString Shortcuts                   () { return QStringLiteral( "Shortcuts" ); }
 };

--- a/qCC/ccShortcutDialog.cpp
+++ b/qCC/ccShortcutDialog.cpp
@@ -1,0 +1,139 @@
+#include "ccShortcutDialog.h"
+
+#include <QAction>
+#include <QMenu>
+#include <QMessageBox>
+#include <QSettings>
+
+#include "ccPersistentSettings.h"
+
+constexpr int ACTION_NAME_COLUMN = 0;
+constexpr int KEY_SEQUENCE_COLUMN = 1;
+
+ccShortcutEditDialog::ccShortcutEditDialog(QWidget *parent): QDialog(parent), m_ui(new Ui_ShortcutEditDialog)
+{
+	m_ui->setupUi(this);
+	connect(m_ui->clearButton, &QPushButton::clicked, m_ui->keySequenceEdit, &QKeySequenceEdit::clear);
+}
+
+QKeySequence ccShortcutEditDialog::keySequence() const
+{
+	return m_ui->keySequenceEdit->keySequence();
+}
+
+void ccShortcutEditDialog::setKeySequence(const QKeySequence &sequence) const
+{
+	m_ui->keySequenceEdit->setKeySequence(sequence);
+}
+
+int ccShortcutEditDialog::exec()
+{
+	m_ui->keySequenceEdit->setFocus();
+	return QDialog::exec();
+}
+
+
+ccShortcutDialog::ccShortcutDialog(const QList<QAction *> &actions, QWidget *parent) : QDialog(parent),
+	m_ui(new Ui_ShortcutDialog), m_editDialog(new ccShortcutEditDialog(this))
+{
+	m_ui->setupUi(this);
+	m_ui->tableWidget->setRowCount(actions.count());
+	m_ui->tableWidget->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+	m_ui->tableWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
+
+	connect(m_ui->tableWidget, &QTableWidget::itemDoubleClicked, this, &ccShortcutDialog::handleDoubleClick);
+
+	int row = 0;
+	for (QAction *action: actions)
+	{
+		auto *actionWidget = new QTableWidgetItem(action->icon(), action->text());
+		actionWidget->setFlags(actionWidget->flags() & ~Qt::ItemIsEditable);
+		m_ui->tableWidget->setItem(row, ACTION_NAME_COLUMN, actionWidget);
+
+		auto *shortcutWidget = new QTableWidgetItem(action->shortcut().toString());
+		shortcutWidget->setFlags(actionWidget->flags() & ~Qt::ItemIsEditable);
+		shortcutWidget->setData(Qt::UserRole, QVariant::fromValue(action));
+		m_ui->tableWidget->setItem(row, KEY_SEQUENCE_COLUMN, shortcutWidget);
+		row += 1;
+	}
+}
+
+void ccShortcutDialog::restoreShortcutsFromQSettings() const
+{
+	QSettings settings;
+	settings.beginGroup(ccPS::Shortcuts());
+
+	for (int i = 0; i < m_ui->tableWidget->rowCount(); i++)
+	{
+		QTableWidgetItem *item = m_ui->tableWidget->item(i, KEY_SEQUENCE_COLUMN);
+		auto *action = item->data(Qt::UserRole).value<QAction *>();
+
+		if (settings.contains(action->text()))
+		{
+			const QKeySequence defaultValue;
+			const auto sequence = settings.value(action->text(), defaultValue).value<QKeySequence>();
+
+			item->setText(sequence.toString());
+			action->setShortcut(sequence);
+		}
+	}
+	settings.endGroup();
+}
+
+const QAction *ccShortcutDialog::checkConflict(const QKeySequence &sequence) const
+{
+	for (int i = 0; i < m_ui->tableWidget->rowCount(); i++)
+	{
+		const QTableWidgetItem *item = m_ui->tableWidget->item(i, 1);
+		const auto *action = item->data(Qt::UserRole).value<QAction *>();
+		if (action->shortcut() == sequence)
+		{
+			return action;
+		}
+	}
+
+	return nullptr;
+}
+
+void ccShortcutDialog::handleDoubleClick(QTableWidgetItem *item)
+{
+	if (!item)
+	{
+		return;
+	}
+
+	auto *action = item->data(Qt::UserRole).value<QAction *>();
+	m_editDialog->setKeySequence(action->shortcut());
+
+	if (m_editDialog->exec() == Rejected)
+	{
+		return;
+	}
+
+	const QKeySequence keySequence = m_editDialog->keySequence();
+	if (keySequence == action->shortcut())
+	{
+		// User did not change it
+		return;
+	}
+
+	if (!keySequence.isEmpty())
+	{
+		const QAction *conflict = checkConflict(keySequence);
+		if (conflict)
+		{
+			QMessageBox::critical(
+				this,
+				"Shortcut conflict",
+				QString("The shortcut entered would conflict with the one for `%1`").arg(conflict->text()));
+			return;
+		}
+	}
+
+	item->setText(keySequence.toString());
+	action->setShortcut(keySequence);
+
+	QSettings settings;
+	settings.beginGroup(ccPS::Shortcuts());
+	settings.setValue(action->text(), keySequence);
+}

--- a/qCC/ccShortcutDialog.h
+++ b/qCC/ccShortcutDialog.h
@@ -1,0 +1,50 @@
+#ifndef CC_SHORTCUTDIALOG_H
+#define CC_SHORTCUTDIALOG_H
+
+
+#include "ui_shorcutSettings.h"
+#include "ui_shortcutEditDialog.h"
+
+
+//! Widget that captures key sequences to be able to edit a shortcut assigned to
+//! an action
+class ccShortcutEditDialog final: public QDialog
+{
+	Q_OBJECT
+
+public:
+	explicit ccShortcutEditDialog(QWidget *parent = nullptr);
+
+	QKeySequence keySequence() const;
+
+	void setKeySequence(const QKeySequence &sequence) const;
+
+	int exec() override;
+
+private:
+	Ui_ShortcutEditDialog *m_ui;
+};
+
+
+//! Shortcut edit dialog
+//!
+//! List shortcuts for known actions, and allows to edit them
+//! Saves to QSettings on each edit
+class ccShortcutDialog final : public QDialog
+{
+	Q_OBJECT
+public:
+	explicit ccShortcutDialog(const QList<QAction*> &actions, QWidget *parent = nullptr);
+
+	void restoreShortcutsFromQSettings() const;
+
+private:
+	const QAction * checkConflict(const QKeySequence& sequence) const ;
+	void handleDoubleClick(QTableWidgetItem *item);
+
+	Ui_ShortcutDialog *m_ui;
+	ccShortcutEditDialog *m_editDialog;
+};
+
+
+#endif //CC_SHORTCUTDIALOG_H

--- a/qCC/mainwindow.h
+++ b/qCC/mainwindow.h
@@ -56,6 +56,7 @@ class ccRecentFiles;
 class ccSectionExtractionTool;
 class ccStdPluginInterface;
 class ccTracePolylineTool;
+class ccShortcutDialog;
 
 struct dbTreeSelectionInfo;
 
@@ -561,6 +562,9 @@ private:
 	//! Adds a single value SF to the active point cloud
 	void addConstantSF(ccPointCloud* cloud, QString sfName, bool integerValue);
 
+	void populateActionList();
+	void showShortcutDialog();
+
 private: //members
 
 	//! Main UI
@@ -644,10 +648,14 @@ private: //members
 	ccPointPairRegistrationDlg* m_pprDlg;
 	//! Primitive factory dialog
 	ccPrimitiveFactoryDlg* m_pfDlg;
+	//! Shortcut management dialog
+	ccShortcutDialog *m_shortcutDlg;
 
 	/*** plugins ***/
 	//! Manages plugins - menus, toolbars, and the about dialog
 	ccPluginUIManager	*m_pluginUIManager;
+
+	QList<QAction *> m_actions;
 };
 
 #endif

--- a/qCC/ui_templates/mainWindow.ui
+++ b/qCC/ui_templates/mainWindow.ui
@@ -50,6 +50,7 @@
     <addaction name="actionSave"/>
     <addaction name="actionSaveProject"/>
     <addaction name="actionGlobalShiftSettings"/>
+    <addaction name="actionShortcutSettings"/>
     <addaction name="separator"/>
     <addaction name="actionPrimitiveFactory"/>
     <addaction name="separator"/>
@@ -3308,6 +3309,11 @@ The active scalar field should have integer values.</string>
    </property>
    <property name="toolTip">
     <string>Lock 3D camera rotation about an axis (turntable mode)</string>
+   </property>
+  </action>
+  <action name="actionShortcutSettings">
+   <property name="text">
+    <string>Shortcut settings</string>
    </property>
   </action>
  </widget>

--- a/qCC/ui_templates/shorcutSettings.ui
+++ b/qCC/ui_templates/shorcutSettings.ui
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ShortcutDialog</class>
+ <widget class="QDialog" name="ShortcutDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>780</width>
+    <height>634</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Shortcuts</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTableWidget" name="tableWidget">
+     <property name="toolTip">
+      <string>Double click to edit</string>
+     </property>
+     <property name="layoutDirection">
+      <enum>Qt::LayoutDirection::LeftToRight</enum>
+     </property>
+     <property name="columnCount">
+      <number>2</number>
+     </property>
+     <attribute name="horizontalHeaderCascadingSectionResizes">
+      <bool>false</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Action</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Shortcut</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ShortcutDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ShortcutDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/qCC/ui_templates/shortcutEditDialog.ui
+++ b/qCC/ui_templates/shortcutEditDialog.ui
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ShortcutEditDialog</class>
+ <widget class="QDialog" name="ShortcutEditDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>390</width>
+    <height>88</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Create Shortcut</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QKeySequenceEdit" name="keySequenceEdit"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="clearButton">
+       <property name="text">
+        <string>Clear</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ShortcutEditDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ShortcutEditDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
This adds a new entry to the file menu which opens a dialog that allows users to edit shortcuts for actions.

The actions available are the ones of the main window, but it could be extended to also include other actions like the ones coming from plugins.

When a shortcut is edited, it is saved to QSettings so it is restored next time CloudCompare is opened.

Although QAction can support multiple shortcut, the UI only allows one, which should be enough for a starting point.

The dialog tries to prevent the user from setting shortcut which could conflict

Improvements for later could be:
- Add more actions (especially plugins)
- Add import/export shortcuts to/from a text file to be able to share / save
- Have default from which users could reset their state and start clean
- Add a search box