### PR TITLE
Fix ShorcutDlg crash on windows

### DIFF
--- a/qCC/ccShortcutDialog.cpp
+++ b/qCC/ccShortcutDialog.cpp
@@ -102,6 +102,10 @@ void ccShortcutDialog::handleDoubleClick(QTableWidgetItem *item)
 		return;
 	}
 
+	if (item->column() != KEY_SEQUENCE_COLUMN) {
+		item = m_ui->tableWidget->item(item->row(), KEY_SEQUENCE_COLUMN);
+	}
+
 	auto *action = item->data(Qt::UserRole).value<QAction *>();
 	m_editDialog->setKeySequence(action->shortcut());
 


### PR DESCRIPTION
Seems like the behavior is a bit different on windows and linux.

As the QAction on which we want to change the shortcut is attached to the item in the second column, we need to make sure the item we get and use in the handleDoubleClick gets the item in the second column