### PR TITLE
qLASIO minor linux build issues (clang format fixed)

### DIFF
--- a/plugins/core/IO/qLASIO/src/LasExtraScalarField.cpp
+++ b/plugins/core/IO/qLASIO/src/LasExtraScalarField.cpp
@@ -292,8 +292,7 @@ LasExtraScalarField::Kind LasExtraScalarField::kind() const
 	return Unsigned;
 }
 
-void LasExtraScalarField::InitExtraBytesVlr(laszip_vlr_struct&                 vlr,
-                                            const std::vector<LasExtraScalarField>& extraFields)
+void LasExtraScalarField::InitExtraBytesVlr(laszip_vlr_struct& vlr, const std::vector<LasExtraScalarField>& extraFields)
 {
 	strcpy(vlr.user_id, "LASF_Spec");
 	vlr.record_id                  = 4;
@@ -379,8 +378,7 @@ void LasExtraScalarField::UpdateByteOffsets(std::vector<LasExtraScalarField>& ex
 	}
 }
 
-void LasExtraScalarField::MatchExtraBytesToScalarFields(std::vector<LasExtraScalarField>& extraScalarFields,
-                                                        const ccPointCloud&          pointCloud)
+void LasExtraScalarField::MatchExtraBytesToScalarFields(std::vector<LasExtraScalarField>& extraScalarFields, const ccPointCloud& pointCloud)
 {
 	for (LasExtraScalarField& extraScalarField : extraScalarFields)
 	{

--- a/plugins/core/IO/qLASIO/src/LasExtraScalarField.cpp
+++ b/plugins/core/IO/qLASIO/src/LasExtraScalarField.cpp
@@ -293,7 +293,7 @@ LasExtraScalarField::Kind LasExtraScalarField::kind() const
 }
 
 void LasExtraScalarField::InitExtraBytesVlr(laszip_vlr_struct&                 vlr,
-                                            const vector<LasExtraScalarField>& extraFields)
+                                            const std::vector<LasExtraScalarField>& extraFields)
 {
 	strcpy(vlr.user_id, "LASF_Spec");
 	vlr.record_id                  = 4;
@@ -369,7 +369,7 @@ void LasExtraScalarField::resetScalarFieldsPointers()
 	}
 }
 
-void LasExtraScalarField::UpdateByteOffsets(vector<LasExtraScalarField>& extraFields)
+void LasExtraScalarField::UpdateByteOffsets(std::vector<LasExtraScalarField>& extraFields)
 {
 	unsigned byteOffset{0};
 	for (LasExtraScalarField& extraScalarField : extraFields)
@@ -379,7 +379,7 @@ void LasExtraScalarField::UpdateByteOffsets(vector<LasExtraScalarField>& extraFi
 	}
 }
 
-void LasExtraScalarField::MatchExtraBytesToScalarFields(vector<LasExtraScalarField>& extraScalarFields,
+void LasExtraScalarField::MatchExtraBytesToScalarFields(std::vector<LasExtraScalarField>& extraScalarFields,
                                                         const ccPointCloud&          pointCloud)
 {
 	for (LasExtraScalarField& extraScalarField : extraScalarFields)


### PR DESCRIPTION
When I tried to build with qLASIO I faced some errors that were fixed with those minor syntax edits.
Clang format errors from previous PR too.