### PR TITLE
Fix native dialogs not showing up on macOS

### DIFF
--- a/qCC/Mac/CMakeLists.txt
+++ b/qCC/Mac/CMakeLists.txt
@@ -2,6 +2,7 @@
 if( APPLE )
 	set_target_properties( ${PROJECT_NAME} PROPERTIES
 		INSTALL_RPATH "@executable_path/../Frameworks"
+		MACOSX_BUNDLE_GUI_IDENTIFIER "org.cloudcompare.CloudCompare"
 		MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/CloudCompare.plist
 		MACOSX_BUNDLE_ICON_FILE cc_icon.icns
 		MACOSX_BUNDLE_SHORT_VERSION_STRING "${PROJECT_VERSION}"


### PR DESCRIPTION
Adding a GUI identifier to the bundle seems to fix it


Fixes #2152