### PR TITLE
Update mainwindow.cpp

### DIFF
--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -393,12 +393,6 @@ MainWindow::~MainWindow()
 	// m_mdiDialogs.clear();
 	m_mdiArea->closeAllSubWindows();
 
-	// if (ccRoot)
-	// {
-	// 	delete ccRoot;
-	// 	ccRoot = nullptr;
-	// }
-
 	delete m_UI;
 	m_UI = nullptr;
 


### PR DESCRIPTION
ccRoot is automatically deleted by his parent as created with: m_ccRoot = new ccDBRoot(m_UI->dbTreeView, m_UI->propertiesTreeView, this);