### PR TITLE
Remove hardcoded colors from UI dialogs (Batch 1)

### DIFF
--- a/libs/qCC_io/ui/openAsciiFileDlg.ui
+++ b/libs/qCC_io/ui/openAsciiFileDlg.ui
@@ -106,9 +106,6 @@
    </item>
    <item>
     <widget class="QLabel" name="headerLabel">
-     <property name="styleSheet">
-      <string notr="true">color: grey;</string>
-     </property>
      <property name="text">
       <string>Header:</string>
      </property>

--- a/qCC/ui_templates/boundingBoxEditorDlg.ui
+++ b/qCC/ui_templates/boundingBoxEditorDlg.ui
@@ -222,9 +222,6 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="styleSheet">
-      <string notr="true">color: red;</string>
-     </property>
      <property name="text">
       <string>Warning, this box doesn't include the cloud bounding-box!</string>
      </property>

--- a/qCC/ui_templates/histogramDlg.ui
+++ b/qCC/ui_templates/histogramDlg.ui
@@ -13,9 +13,6 @@
   <property name="windowTitle">
    <string>Histogram</string>
   </property>
-  <property name="styleSheet">
-   <string notr="true">QDialog { background-color: white; }</string>
-  </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <property name="leftMargin">
     <number>3</number>

--- a/qCC/ui_templates/pointPairRegistrationDlg.ui
+++ b/qCC/ui_templates/pointPairRegistrationDlg.ui
@@ -18,9 +18,6 @@
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QCheckBox" name="showAlignedCheckBox">
-       <property name="styleSheet">
-        <string notr="true">background-color: red; color: white;</string>
-       </property>
        <property name="text">
         <string>show 'to be aligned' entities</string>
        </property>
@@ -210,9 +207,6 @@
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QCheckBox" name="showReferenceCheckBox">
-       <property name="styleSheet">
-        <string notr="true">background-color: yellow;</string>
-       </property>
        <property name="text">
         <string>show 'reference' entities</string>
        </property>

--- a/qCC/ui_templates/volumeCalcDlg.ui
+++ b/qCC/ui_templates/volumeCalcDlg.ui
@@ -500,9 +500,6 @@
            <property name="toolTip">
             <string>Update the grid / display / measurements</string>
            </property>
-           <property name="styleSheet">
-            <string notr="true">color: white; background-color:red;</string>
-           </property>
            <property name="text">
             <string>Update</string>
            </property>
@@ -519,9 +516,6 @@
         <layout class="QVBoxLayout" name="verticalLayout">
          <item>
           <widget class="QLabel" name="spareseWarningLabel">
-           <property name="styleSheet">
-            <string notr="true">color:red;</string>
-           </property>
            <property name="text">
             <string>At least one of the cloud is sparse!
 You should fill the empty cells...</string>


### PR DESCRIPTION
Remove hardcoded colors to enable proper theme support across light and dark themes. This change addresses P0 critical theming issues.

Changes:
- boundingBoxEditorDlg.ui: Remove red warning text color
- pointPairRegistrationDlg.ui: Remove red/white and yellow backgrounds
- histogramDlg.ui: Remove white dialog background
- openAsciiFileDlg.ui: Remove grey header text color
- volumeCalcDlg.ui: Remove red button colors and warning text

These dialogs will now respect the system/application theme, improving readability in dark mode and ensuring consistent appearance across different color schemes.

Part of UI Modernization Plan - Phase 1.1