### PR TITLE
Fix cloud sampling failure when the density for a single object is too low

### DIFF
--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -4581,12 +4581,15 @@ bool CommandSampleMesh::process(ccCommandLineInterface& cmd)
 		progressDialog->setAutoClose(false);
 	}
 
+	bool errors = false;
+
 	for (CLMeshDesc& desc : cmd.meshes())
 	{
 		ccPointCloud* cloud = desc.mesh->samplePoints(useDensity, parameter, true, true, true, progressDialog.data());
 
 		if (!cloud)
 		{
+			errors = true;
 			continue;
 		}
 
@@ -4610,6 +4613,9 @@ bool CommandSampleMesh::process(ccCommandLineInterface& cmd)
 		progressDialog->close();
 		QCoreApplication::processEvents();
 	}
+
+	if (errors)
+		ccLog::Error(QObject::tr("Errors occurred during the process! Result may be incomplete!"));
 
 	return true;
 }


### PR DESCRIPTION
When sampling points on a mesh using the CLI, the execution should not terminate when ccGenericMesh::samplePoints returns nullptr. This is specially important when an object of the mesh is too small to have its cloud generated (in this case sampledCloud->size() == 0), so the sampling of rest of the objects should continue, as it does in the GUI.