### PR TITLE
Update pixi.toml: add support for x86_64-linux-gnu

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -4,7 +4,7 @@ version = "2.14.0"
 description = "CloudCompare is a 3D point cloud processing software."
 authors = ["Daniel Girardeau-Montaut <admin@cloudcompare.org>"]
 channels = ["conda-forge"]
-platforms = ["osx-arm64"]
+platforms = ["osx-arm64", "linux-64"]
 
 [tasks.CloudCompare]
 # Start the built executable


### PR DESCRIPTION
Appreciate your hard work for this project. I tried to build this project on Ubuntu2204 by pixi, which succeed, following is the build log:

```
root@8bcc03c136a7:/app# pixi run build
✨ Pixi task (configure in build): cmake -GNinja -S. -B.build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.build/install -DBUILD_SHARED_LIBS=OFF -DCMAKE_PREFIX_PATH=$CONDA_PREFIX/lib -DCCCORELIB_USE_TBB=ON -DCCCORELIB_USE_CGAL=ON -DEIGEN_ROOT_DIR=$CONDA_PREFIX/include/eigen3 -DCC_USE_EIGEN=ON -DOPTION_USE_GDAL=ON -DPLUGIN_IO_QLAS=ON -DPLUGIN_STANDARD_3DMASC=ON -DPLUGIN_PYTHON=ON -DPLUGIN_STANDARD_QM3C2=ON -DPLUGIN_STANDARD_QANIMATION=ON -DQANIMATION_WITH_FFMPEG_SUPPORT=ON -DPLUGIN_STANDARD_QBROOM=ON -DPLUGIN_STANDARD_QCSF=ON -DPLUGIN_STANDARD_QCANUPO=ON -DPLUGIN_STANDARD_QCLOUDLAYERS=ON -DPLUGIN_STANDARD_QCOMPASS=ON -DPLUGIN_STANDARD_QCOLORIMETRIC_SEGMENTER=ON -DPLUGIN_STANDARD_QFACETS=ON -DPLUGIN_STANDARD_QHPR=ON -DPLUGIN_STANDARD_QHOUGH_NORMALS=ON -DPLUGIN_STANDARD_QM3C2=ON -DPLUGIN_STANDARD_QMPLANE=ON -DPLUGIN_STANDARD_QMESH_BOOLEAN=OFF -DPLUGIN_STANDARD_QPCL=ON -DPLUGIN_STANDARD_QPCV=ON -DPLUGIN_STANDARD_QPOISSON_RECON=ON -DPLUGIN_STANDARD_QRANSAC_SD=ON -DPLUGIN_STANDARD_QSRA=ON -DPLUGIN_STANDARD_QTREEISO=OFF -DPLUGIN_STANDARD_QVOXFALL=ON -DPLUGIN_IO_QADDITIONAL=ON -DPLUGIN_IO_QCORE=ON -DPLUGIN_IO_QDRACO=OFF -DPLUGIN_IO_QE57=ON -DE57_RELEASE_LTO=OFF -DPLUGIN_IO_QFBX=OFF -DPLUGIN_IO_QPHOTOSCAN=ON -DQUAZIP_INSTALL=OFF -DPLUGIN_IO_QRDB=OFF -DPLUGIN_IO_QSTEP=ON -DOPENCASCADE_INC_DIR=$CONDA_PREFIX/include/opencascade -DOPENCASCADE_LIB_DIR=$CONDA_PREFIX/lib -DOPENCASCADE_78_OR_NEWER=ON -DPLUGIN_GL_QEDL=ON -DPLUGIN_GL_QSSAO=ON
 WARN Skipped running the post-link scripts because `run-post-link-scripts` = `false`
        - bin/.librsvg-pre-unlink.sh

To enable them, run:
        pixi config set --local run-post-link-scripts insecure

More info:
        https://pixi.sh/latest/reference/pixi_configuration/#run-post-link-scripts

-- The C compiler identification is GNU 13.4.0
-- The CXX compiler identification is GNU 13.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /app/.pixi/envs/build/bin/x86_64-conda-linux-gnu-cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /app/.pixi/envs/build/bin/x86_64-conda-linux-gnu-c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Check if compiler accepts -pthread
-- Check if compiler accepts -pthread - yes
-- Found Threads: TRUE
-- Performing Test HAVE_STDATOMIC
-- Performing Test HAVE_STDATOMIC - Success
-- Found WrapAtomic: TRUE
-- Found OpenGL: /app/.pixi/envs/build/lib/libOpenGL.so
-- Found WrapOpenGL: TRUE
-- Could NOT find WrapVulkanHeaders (missing: Vulkan_INCLUDE_DIR)
-- Could NOT find WrapVulkanHeaders (missing: Vulkan_INCLUDE_DIR)
-- Found Cups: /app/.pixi/envs/build/lib/libcups.so (found version "2.3.3")
-- OpenMP found
-- Install shared library: CC_FBO_LIB
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
-- nanoflann version: 1.7.1
-- Targeting Ninja
-- Using /app/.pixi/envs/build/bin/x86_64-conda-linux-gnu-c++ compiler.
-- Boost include dirs: /app/.pixi/envs/build/include
-- Boost libraries:
-- Using gcc version 4 or later. Adding -frounding-math
CMake Deprecation Warning at .pixi/envs/build/lib/cmake/CGAL/CGAL_target_use_TBB.cmake:9 (message):
  This file CGAL_target_use_TBB.cmake is deprecated, and the imported target
  `CGAL::TBB_support` from CGAL_TBB_support.cmake should be used instead.
Call Stack (most recent call first):
  libs/qCC_db/extern/CCCoreLib/CMakeLists.txt:190 (CGAL_target_use_TBB)


-- Install shared library: CCCoreLib
-- Install shared library: QCC_DB_LIB
-- Found GDAL: /app/.pixi/envs/build/lib/libgdal.so (found version "3.12.0")
-- Install shared library: QCC_IO_LIB
-- Install shared library: QCC_GL_LIB
-- Install shared library: CCPluginAPI
-- Install shared library: CCAppCommon
-- Added gl plugin: QEDL_GL_PLUGIN
-- Added gl plugin: QSSAO_GL_PLUGIN
-- Added io plugin: QADDITIONAL_IO_PLUGIN
-- Added io plugin: QCORE_IO_PLUGIN
-- Added io plugin: QE57_IO_PLUGIN
-- Using CMake 4.1.3
-- Found XercesC: /app/.pixi/envs/build/lib/libxerces-c.so (found version "3.3.0")
-- [E57Format] Revision ID: E57Format-3.2.0-x86_64-gcc134
-- [E57Format] Building static library
-- [E57Format] Setting validation level to 1
-- [E57Format] CMake files install to /app/.build/install/lib/cmake/E57Format
-- Added io plugin: QLAS_IO_PLUGIN
-- Found LASzip: /app/.pixi/envs/build/lib/liblaszip.so
-- Added io plugin: QPHOTOSCAN_IO_PLUGIN
-- QUAZIP_QT_MAJOR_VERSION set to 6
-- CMAKE_CXX_STANDARD set to 17
-- Found Qt version 6.9.3 at /app/.pixi/envs/build/lib/cmake/Qt6
-- Using Qt version 6
-- Found ZLIB: /app/.pixi/envs/build/lib/libz.so (found version "1.3.1")
-- Using BZIP2 1.0.8
-- Found BZip2: /app/.pixi/envs/build/lib/libbz2.so (found version "1.0.8")
-- QTextCodec explicitly disabled by QUAZIP_ENABLE_QTEXTCODEC=OFF
-- Added io plugin: QSTEP_IO_PLUGIN
-- Added standard plugin: QANIMATION_PLUGIN
-- Setting FFmpeg include dir: /app/.pixi/envs/build/include
-- Setting FFmpeg library dir: /app/.pixi/envs/build/lib
-- Added standard plugin: QBROOM_PLUGIN
-- Added standard plugin: QCANUPO_PLUGIN
-- Using CMake version: 4.1.3
-- Compiling dlib version: 20.0.0
-- Found system copy of libpng: /app/.pixi/envs/build/lib/libpng.so;/app/.pixi/envs/build/lib/libz.so
-- Found system copy of libjpeg: /app/.pixi/envs/build/lib/libjpeg.so
-- Found WebP: /app/.pixi/envs/build/lib/libwebp.so
-- Searching for JPEG XL
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
-- PkgConfig could not be found, JPEG XL support won't be available
-- Searching for BLAS and LAPACK
-- Searching for BLAS and LAPACK
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
-- Looking for cblas_ddot
-- Looking for cblas_ddot - not found
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of void*
-- Check size of void* - done
-- Found LAPACK library
-- Found CBLAS library
-- Looking for cblas_ddot
-- Looking for cblas_ddot - found
-- Looking for sgesv
-- Looking for sgesv - not found
-- Looking for sgesv_
-- Looking for sgesv_ - found
-- Searching for FFMPEG/LIBAV
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
-- PkgConfig could not be found, FFMPEG won't be available
-- Added standard plugin: QCLOUDLAYERS_PLUGIN
-- Added standard plugin: QCOMPASS_PLUGIN
-- Added standard plugin: QCSF_PLUGIN
-- Added standard plugin: QFACETS_PLUGIN
-- Added standard plugin: QHOUGH_NORMALS_PLUGIN
-- Added standard plugin: QHPR_PLUGIN
-- Added standard plugin: QM3C2_PLUGIN
-- Added standard plugin: QPCL_PLUGIN
-- Found flann version 1.9.2
-- Found OpenMP_CXX: -fopenmp (found version "4.5")
-- Found OpenMP: TRUE (found version "4.5") found components: CXX
-- Found nlohmann_json: /app/.pixi/envs/build/share/cmake/nlohmann_json/nlohmann_jsonConfig.cmake (found version "3.12.0")
-- Found X11: /app/.pixi/envs/build/include
-- Looking for XOpenDisplay in /app/.pixi/envs/build/lib/libX11.so;/app/.pixi/envs/build/lib/libXext.so
-- Looking for XOpenDisplay in /app/.pixi/envs/build/lib/libX11.so;/app/.pixi/envs/build/lib/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Looking for IceConnectionNumber in ICE
-- Looking for IceConnectionNumber in ICE - found
-- Found utf8cpp: /app/.pixi/envs/build/include
-- Found PNG: /app/.pixi/envs/build/lib/libpng.so (found version "1.6.53")
-- Found Eigen3: /app/.pixi/envs/build/include/eigen3 (found version "3.4.0")
-- Found EXPAT: /app/.pixi/envs/build/lib/libexpat.so (found suitable version "2.7.3", minimum required is "2.5.0")
-- Found LZ4: /app/.pixi/envs/build/lib/liblz4.so (found version "1.10.0")
-- Found LZMA: /app/.pixi/envs/build/lib/liblzma.so (found version "5.8.1")
-- Found JPEG: /app/.pixi/envs/build/lib/libjpeg.so (found version "80")
-- Found TIFF: /app/.pixi/envs/build/lib/libtiff.so (found version "4.7.1")
-- Could NOT find freetype (missing: freetype_DIR)
-- Found Freetype: /app/.pixi/envs/build/lib/libfreetype.so (found version "2.14.1")
-- Found double-conversion: /app/.pixi/envs/build/lib/libdouble-conversion.so
-- Could NOT find freetype (missing: freetype_DIR)
-- Found Qhull version 8.0.2
-- Could NOT find freetype (missing: freetype_DIR)
-- looking for PCL_COMMON
-- Found PCL_COMMON: /app/.pixi/envs/build/lib/libpcl_common.so
-- looking for PCL_KDTREE
-- Found PCL_KDTREE: /app/.pixi/envs/build/lib/libpcl_kdtree.so
-- looking for PCL_OCTREE
-- Found PCL_OCTREE: /app/.pixi/envs/build/lib/libpcl_octree.so
-- looking for PCL_SEARCH
-- Found PCL_SEARCH: /app/.pixi/envs/build/lib/libpcl_search.so
-- looking for PCL_SAMPLE_CONSENSUS
-- Found PCL_SAMPLE_CONSENSUS: /app/.pixi/envs/build/lib/libpcl_sample_consensus.so
-- looking for PCL_FILTERS
-- Found PCL_FILTERS: /app/.pixi/envs/build/lib/libpcl_filters.so
-- looking for PCL_2D
-- Found PCL_2D: /app/.pixi/envs/build/include/pcl-1.15
-- looking for PCL_GEOMETRY
-- Found PCL_GEOMETRY: /app/.pixi/envs/build/include/pcl-1.15
-- looking for PCL_IO_PLY
-- Found PCL_IO_PLY: /app/.pixi/envs/build/lib/libpcl_io_ply.so
-- looking for PCL_IO
-- Found PCL_IO: /app/.pixi/envs/build/lib/libpcl_io.so
-- looking for PCL_FEATURES
-- Found PCL_FEATURES: /app/.pixi/envs/build/lib/libpcl_features.so
-- looking for PCL_ML
-- Found PCL_ML: /app/.pixi/envs/build/lib/libpcl_ml.so
-- looking for PCL_SEGMENTATION
-- Found PCL_SEGMENTATION: /app/.pixi/envs/build/lib/libpcl_segmentation.so
-- looking for PCL_VISUALIZATION
-- Found PCL_VISUALIZATION: /app/.pixi/envs/build/lib/libpcl_visualization.so
-- looking for PCL_SURFACE
-- Found PCL_SURFACE: /app/.pixi/envs/build/lib/libpcl_surface.so
-- looking for PCL_REGISTRATION
-- Found PCL_REGISTRATION: /app/.pixi/envs/build/lib/libpcl_registration.so
-- looking for PCL_KEYPOINTS
-- Found PCL_KEYPOINTS: /app/.pixi/envs/build/lib/libpcl_keypoints.so
-- looking for PCL_TRACKING
-- Found PCL_TRACKING: /app/.pixi/envs/build/lib/libpcl_tracking.so
-- looking for PCL_RECOGNITION
-- Found PCL_RECOGNITION: /app/.pixi/envs/build/lib/libpcl_recognition.so
-- looking for PCL_STEREO
-- Found PCL_STEREO: /app/.pixi/envs/build/lib/libpcl_stereo.so
-- looking for PCL_OUTOFCORE
-- Found PCL_OUTOFCORE: /app/.pixi/envs/build/lib/libpcl_outofcore.so
-- looking for PCL_PEOPLE
-- Found PCL_PEOPLE: /app/.pixi/envs/build/lib/libpcl_people.so
-- Found PCL: pcl_common;pcl_kdtree;pcl_octree;pcl_search;pcl_sample_consensus;pcl_filters;pcl_io_ply;pcl_io;pcl_features;pcl_ml;pcl_segmentation;pcl_visualization;pcl_surface;pcl_registration;pcl_keypoints;pcl_tracking;pcl_recognition;pcl_stereo;pcl_outofcore;pcl_people;Boost::system;Boost::iostreams;Boost::filesystem;Boost::serialization;VTK::ChartsCore;VTK::CommonColor;VTK::CommonComputationalGeometry;VTK::CommonCore;VTK::CommonDataModel;VTK::CommonExecutionModel;VTK::CommonMath;VTK::CommonMisc;VTK::CommonTransforms;VTK::FiltersCore;VTK::FiltersExtraction;VTK::FiltersGeneral;VTK::FiltersGeometry;VTK::FiltersModeling;VTK::FiltersSources;VTK::ImagingCore;VTK::ImagingSources;VTK::InteractionImage;VTK::InteractionStyle;VTK::InteractionWidgets;VTK::IOCore;VTK::IOGeometry;VTK::IOImage;VTK::IOLegacy;VTK::IOPLY;VTK::RenderingAnnotation;VTK::RenderingCore;VTK::RenderingContext2D;VTK::RenderingLOD;VTK::RenderingFreeType;VTK::ViewsCore;VTK::ViewsContext2D;VTK::RenderingOpenGL2;VTK::RenderingContextOpenGL2;VTK::GUISupportQt;FLANN::FLANN;QHULL::QHULL (Required is at least version "1.9")
-- Found OpenMP_C: -fopenmp (found version "4.5")
-- Found OpenMP: TRUE (found version "4.5")
-- Added io plugin: QPCL_IO_PLUGIN
-- Added standard plugin: QPCV_PLUGIN
-- Added standard plugin: QPOISSON_RECON_PLUGIN
-- Added standard plugin: QRANSAC_SD_PLUGIN
-- Added standard plugin: QSRA_PLUGIN
-- Found submodule plugin: /app/plugins/core/Standard/q3DMASC
CMake Deprecation Warning at plugins/core/Standard/q3DMASC/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


-- Added standard plugin: Q3DMASC_PLUGIN
-- Found OpenCV: /app/.pixi/envs/build (found version "4.12.0")
-- Files:  will be installed in bin
-- Found submodule plugin: /app/plugins/core/Standard/qColorimetricSegmenter
CMake Deprecation Warning at plugins/core/Standard/qColorimetricSegmenter/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


-- Added standard plugin: QCOLORIMETRIC_SEGMENTER_PLUGIN
-- Found submodule plugin: /app/plugins/core/Standard/qG3Point
-- Found submodule plugin: /app/plugins/core/Standard/qJSonRPCPlugin
-- Found submodule plugin: /app/plugins/core/Standard/qMPlane
-- Added standard plugin: QMPLANE_PLUGIN
-- Found submodule plugin: /app/plugins/core/Standard/qTreeIso
-- Found submodule plugin: /app/plugins/core/Standard/qVoxFall
-- Added standard plugin: QVOXFALL_PLUGIN
-- Install plugins
--  Types: gl;io;standard
--  Destination: lib/cloudcompare/plugins/
--  Shader Destination: share/cloudcompare/shaders/
--  Install QEDL_GL_PLUGIN (gl)
--   + shader: EDL (/app/plugins/core/GL/qEDL/shaders/EDL)
--  Install QSSAO_GL_PLUGIN (gl)
--   + shader: SSAO (/app/plugins/core/GL/qSSAO/shaders/SSAO)
--  Install QADDITIONAL_IO_PLUGIN (io)
--  Install QCORE_IO_PLUGIN (io)
--  Install QE57_IO_PLUGIN (io)
--  Install QLAS_IO_PLUGIN (io)
--  Install QPHOTOSCAN_IO_PLUGIN (io)
--  Install QSTEP_IO_PLUGIN (io)
--  Install QANIMATION_PLUGIN (standard)
--  Install QBROOM_PLUGIN (standard)
--  Install QCANUPO_PLUGIN (standard)
--  Install QCLOUDLAYERS_PLUGIN (standard)
--  Install QCOMPASS_PLUGIN (standard)
--  Install QCSF_PLUGIN (standard)
--  Install QFACETS_PLUGIN (standard)
--  Install QHOUGH_NORMALS_PLUGIN (standard)
--  Install QHPR_PLUGIN (standard)
--  Install QM3C2_PLUGIN (standard)
--  Install QPCL_PLUGIN (standard)
--  Install QPCL_IO_PLUGIN (io)
--  Install QPCV_PLUGIN (standard)
--  Install QPOISSON_RECON_PLUGIN (standard)
--  Install QRANSAC_SD_PLUGIN (standard)
--  Install QSRA_PLUGIN (standard)
--  Install Q3DMASC_PLUGIN (standard)
--  Install QCOLORIMETRIC_SEGMENTER_PLUGIN (standard)
--  Install QMPLANE_PLUGIN (standard)
--  Install QVOXFALL_PLUGIN (standard)
-- Install plugins
--  Types: gl;io
--  Destination: lib/cloudcompare/plugins/
--  Shader Destination: share/cloudcompare/shaders/
--  Install QEDL_GL_PLUGIN (gl)
--   + shader: EDL (/app/plugins/core/GL/qEDL/shaders/EDL)
--  Install QSSAO_GL_PLUGIN (gl)
--   + shader: SSAO (/app/plugins/core/GL/qSSAO/shaders/SSAO)
--  Install QADDITIONAL_IO_PLUGIN (io)
--  Install QCORE_IO_PLUGIN (io)
--  Install QE57_IO_PLUGIN (io)
--  Install QLAS_IO_PLUGIN (io)
--  Install QPHOTOSCAN_IO_PLUGIN (io)
--  Install QSTEP_IO_PLUGIN (io)
--  Install QPCL_IO_PLUGIN (io)
-- Configuring done (4.7s)
-- Generating done (0.5s)
CMake Warning:
  Manually-specified variables were not used by the project:

    PLUGIN_PYTHON


-- Build files have been written to: /app/.build
                                                                                                                                                                                                                                            [321/877] Generating CloudCompare_chs.qm
Updating '/app/.build/qCC/translations/CloudCompare_chs.qm'...
    Generated 0 translation(s) (0 finished and 0 unfinished)
    Ignored 4203 untranslated source text(s)
[322/877] Generating CloudCompare_de.qm
Updating '/app/.build/qCC/translations/CloudCompare_de.qm'...
    Generated 3293 translation(s) (3161 finished and 132 unfinished)
    Ignored 910 untranslated source text(s)
[323/877] Generating CloudCompare_es_AR.qm
Updating '/app/.build/qCC/translations/CloudCompare_es_AR.qm'...
    Generated 2398 translation(s) (2162 finished and 236 unfinished)
    Ignored 1805 untranslated source text(s)
[324/877] Generating CloudCompare_ja.qm
Updating '/app/.build/qCC/translations/CloudCompare_ja.qm'...
    Generated 666 translation(s) (523 finished and 143 unfinished)
    Ignored 3537 untranslated source text(s)
[325/877] Generating CloudCompare_fr.qm
Updating '/app/.build/qCC/translations/CloudCompare_fr.qm'...
    Generated 522 translation(s) (383 finished and 139 unfinished)
    Ignored 3681 untranslated source text(s)
[326/877] Generating CloudCompare_pt.qm
Updating '/app/.build/qCC/translations/CloudCompare_pt.qm'...
    Generated 583 translation(s) (96 finished and 487 unfinished)
    Ignored 3620 untranslated source text(s)
[327/877] Generating CloudCompare_ko.qm
Updating '/app/.build/qCC/translations/CloudCompare_ko.qm'...
    Generated 3944 translation(s) (3909 finished and 35 unfinished)
    Ignored 259 untranslated source text(s)
[328/877] Generating CloudCompare_ru.qm
Updating '/app/.build/qCC/translations/CloudCompare_ru.qm'...
    Generated 3272 translation(s) (3136 finished and 136 unfinished)
    Ignored 931 untranslated source text(s)
[329/877] Generating CloudCompare_uk.qm
Updating '/app/.build/qCC/translations/CloudCompare_uk.qm'...
    Generated 4203 translation(s) (4203 finished and 0 unfinished)
[331/877] Generating CloudCompare_zh.qm
Updating '/app/.build/qCC/translations/CloudCompare_zh.qm'...
    Generated 2787 translation(s) (2499 finished and 288 unfinished)
    Ignored 1416 untranslated source text(s)
[610/877] Building CXX object plugins/core/Standard/qPCL/PclIO/CMakeFiles/QPCL_IO_PLUGIN.dir/src/PcdFilter.cpp.o
In file included from /app/.pixi/envs/build/include/boost/bind.hpp:30,
                 from /app/plugins/core/Standard/qPCL/PclIO/src/PcdFilter.cpp:38:
/app/.pixi/envs/build/include/boost/bind.hpp:36:1: note: '#pragma message: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.'
   36 | BOOST_PRAGMA_MESSAGE(
      | ^~~~~~~~~~~~~~~~~~~~
[700/877] Generating qrc_icons.cpp
/app/qCC/icons.qrc: Warning: potential duplicate alias detected: 'dbCircle.png'
[785/877] Generating qrc_icons.cpp
/app/qCC/icons.qrc: Warning: potential duplicate alias detected: 'dbCircle.png'
[877/877] Linking CXX executable qCC/CloudCompare
 WARN No files matched the output globs for task 'build'
 WARN Output globs: `.build/qCC/CloudCompare`
root@8bcc03c136a7:/app#
```

Therefore, I enabled `linux-64` in pixi.toml and sent this patch.