### PR TITLE
Prevent user from changing global scale at loading time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,6 +333,7 @@ Bug fixes:
 	- some SHP files could not be opened due to longer records than specified
 	- DXF files: the 'elevation' of LWPOLYLINE entities was ignored
 	- High DPI displays with a 1.5 ratio would be badly handled (point picking, 2D labels, etc.)
+	- When loading a file, the user could change the Global scale, but the value was ignored. The field will be disabled to avoid confusion for the time being.
 
 Unresolved anomalies:
 	- 'LAS.vlrs' meta-data items saved in BIN files with any version prior to 2.14.beta cannot be restored anymore due to Qt 6

--- a/libs/qCC_io/include/ccShiftAndScaleCloudDlg.h
+++ b/libs/qCC_io/include/ccShiftAndScaleCloudDlg.h
@@ -61,7 +61,7 @@ class QCC_IO_LIB_API ccShiftAndScaleCloudDlg : public QDialog
 	}
 
 	//! Whether to show dialog items related to scale
-	void showScaleItems(bool state);
+	void showScaleItems(bool state, bool autoSetScaleToOneIfDisabled);
 
 	//! Whether to show the 'Apply all' button or not
 	void showApplyAllButton(bool state);

--- a/libs/qCC_io/src/ccGlobalShiftManager.cpp
+++ b/libs/qCC_io/src/ccGlobalShiftManager.cpp
@@ -264,7 +264,7 @@ bool ccGlobalShiftManager::Handle(const CCVector3d& P,
 	{
 		ccShiftAndScaleCloudDlg sasDlg(P, diagonal);
 		sasDlg.showApplyAllButton(_applyAll != nullptr);
-		sasDlg.showScaleItems(_coordinatesScale != nullptr);
+		sasDlg.showScaleItems(_coordinatesScale != nullptr, true);
 		sasDlg.showWarning(needShift || needRescale);
 		sasDlg.setPreserveShiftOnSave(preserveCoordinateShift);
 		sasDlg.showPreserveShiftOnSave(_preserveCoordinateShift != nullptr);

--- a/libs/qCC_io/src/ccShiftAndScaleCloudDlg.cpp
+++ b/libs/qCC_io/src/ccShiftAndScaleCloudDlg.cpp
@@ -58,7 +58,7 @@ ccShiftAndScaleCloudDlg::ccShiftAndScaleCloudDlg(const CCVector3d& Pg,
 	showWarning(false);
 	showKeepGlobalPosCheckbox(false);
 	showPreserveShiftOnSave(true);
-	showScaleItems(m_originalDiagonal > 0.0);
+	showScaleItems(m_originalDiagonal > 0.0, false);
 	showCancelButton(false);
 }
 
@@ -84,7 +84,7 @@ ccShiftAndScaleCloudDlg::ccShiftAndScaleCloudDlg(const CCVector3d& Pl,
 	showTitle(false);
 	showKeepGlobalPosCheckbox(true);
 	showPreserveShiftOnSave(false);
-	showScaleItems(m_originalDiagonal > 0.0 && m_localDiagonal > 0.0);
+	showScaleItems(m_originalDiagonal > 0.0 && m_localDiagonal > 0.0, false);
 	showCancelButton(true);
 
 	// to update the GUI accordingly
@@ -229,11 +229,15 @@ double ccShiftAndScaleCloudDlg::getScale() const
 	return m_ui->scaleSpinBox->value();
 }
 
-void ccShiftAndScaleCloudDlg::showScaleItems(bool state)
+void ccShiftAndScaleCloudDlg::showScaleItems(bool state, bool autoSetScaleToOneIfDisabled)
 {
 	m_ui->diagOriginLabel->setVisible(state);
 	m_ui->diagDestLabel->setVisible(state);
-	// m_ui->scaleFrame->setVisible(state);
+	m_ui->scaleSpinBox->setEnabled(state);
+	if (!state && autoSetScaleToOneIfDisabled)
+	{
+		m_ui->scaleSpinBox->setValue(1.0);
+	}
 }
 
 void ccShiftAndScaleCloudDlg::showApplyAllButton(bool state)


### PR DESCRIPTION
When loading a file, the user could change the Global scale, but the value was ignored. The field will be disabled to avoid confusion for the time being.