### PR TITLE
Update CloudCompare_x64_InnoSetup.iss

### DIFF
--- a/scripts/windows/CloudCompare_x64_InnoSetup.iss
+++ b/scripts/windows/CloudCompare_x64_InnoSetup.iss
@@ -36,7 +36,7 @@ OutputDir={#MyOutputDir}
 InternalCompressLevel=Ultra64
 ; "ArchitecturesAllowed=x64" specifies that Setup cannot run on
 ; anything but x64.
-ArchitecturesAllowed=x64os
+ArchitecturesAllowed=x64compatible
 ; "ArchitecturesInstallIn64BitMode=x64" requests that the install be
 ; done in "64-bit mode" on x64, meaning it should use the native
 ; 64-bit Program Files directory and the 64-bit view of the registry.


### PR DESCRIPTION
x64compatible should be used instead of x64os, because x64compatible allows x64 apps to be installed on Arm64 Windows 11 systems as well

#2278 