### PR TITLE
fix: correctly render rect labels when rendering viewport to image

### DIFF
--- a/libs/qCC_db/src/cc2DViewportLabel.cpp
+++ b/libs/qCC_db/src/cc2DViewportLabel.cpp
@@ -126,13 +126,13 @@ void cc2DViewportLabel::drawMeOnly(CC_DRAW_CONTEXT& context)
 	glFunc->glPushAttrib(GL_LINE_BIT);
 
 	// focal distance change compensation
-	double relativeZoom = m_params.getFocalDistance() / params.getFocalDistance();
+	double relativeZoom = (m_params.getFocalDistance() / params.getFocalDistance()) * context.renderZoom;
 
 	// camera center shift compensation
 	CCVector3d dC = relativeZoom * context.glW * (m_params.getCameraCenter() - params.getCameraCenter()) / m_params.computeWidthAtFocalDist(context.glW, context.glH);
 
 	// thick dotted line
-	glFunc->glLineWidth(2);
+	glFunc->glLineWidth(2 * context.renderZoom);
 	glFunc->glLineStipple(1, 0xAAAA);
 	glFunc->glEnable(GL_LINE_STIPPLE);
 


### PR DESCRIPTION
Currently when rendering the viewport to a file using the "Display > Render To File" tool with "Zoom" != 1 (for example 2x or 3x, which I commonly need), the rectangular labels get misplaced and wrongly sized. This is fixed by applying the context.renderZoom to the relativeZoom of the label and by increasing the line width by the same factor. I don't know if this is a complete fix but it worked for me.

For example, previously, when rendering with zoom 2x, a label like the following (this is a just a screenshot, to show how it should be displayed):
<img width="1920" height="1044" alt="screenshot" src="https://github.com/user-attachments/assets/0352c472-4e57-4bab-a261-3bcc2f6dda22" />
Would come out like this in the render (misplaced):
<img width="6621" height="2868" alt="render_old" src="https://github.com/user-attachments/assets/a6fa8208-d661-4a8c-a893-1ff2460699e9" />
Now, after the change, it comes out like this:
<img width="6621" height="2868" alt="render_new" src="https://github.com/user-attachments/assets/9555a338-f339-4d3e-8196-6c8816efa003" />

Please, if anything is not correct, let me know, it's the first time for me touching this codebase so I don't know if my fix is complete. Thanks.