### PR TITLE
Introduce a ccArgumentParser to shorten arg parsing

### DIFF
--- a/qCC/CMakeLists.txt
+++ b/qCC/CMakeLists.txt
@@ -131,6 +131,11 @@ if( APPLE )
     add_subdirectory( Mac )
 endif()
 
+# Testing
+if ( BUILD_TESTING )
+	add_subdirectory( test )
+endif()
+
 # Translation
 add_subdirectory(translations)
 

--- a/qCC/ccArgumentParser.cpp
+++ b/qCC/ccArgumentParser.cpp
@@ -1,0 +1,100 @@
+// ##########################################################################
+// #                                                                        #
+// #                            CLOUDCOMPARE                                #
+// #                                                                        #
+// #  This program is free software; you can redistribute it and/or modify  #
+// #  it under the terms of the GNU General Public License as published by  #
+// #  the Free Software Foundation; version 2 of the License.               #
+// #                                                                        #
+// #  This program is distributed in the hope that it will be useful,       #
+// #  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+// #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+// #  GNU General Public License for more details.                          #
+// #                                                                        #
+// #                   COPYRIGHT: CloudCompare project                      #
+// #                                                                        #
+// ##########################################################################
+#include "ccArgumentParser.h"
+
+#include <cassert>
+#include <ccLog.h>
+
+ccArgumentParser::ccArgumentParser(QStringList& arguments)
+    : m_arguments(arguments)
+{
+}
+
+const QString ccArgumentParser::peek() const
+{
+	if (m_arguments.isEmpty())
+	{
+		return QString();
+	}
+	return m_arguments.first();
+}
+
+void ccArgumentParser::skip()
+{
+	assert(!m_arguments.isEmpty());
+	if (!m_arguments.isEmpty())
+	{
+		m_arguments.removeFirst();
+	}
+}
+
+bool ccArgumentParser::isEmpty() const
+{
+	return m_arguments.isEmpty();
+}
+
+std::optional<QString> ccArgumentParser::takeNext()
+{
+	if (m_arguments.isEmpty())
+	{
+		return std::nullopt;
+	}
+	return m_arguments.takeFirst();
+}
+
+std::optional<float> ccArgumentParser::takeFloat(const QString& context)
+{
+	if (m_arguments.isEmpty())
+	{
+		ccLog::Error(QObject::tr("Missing parameter: %1").arg(context));
+		return std::nullopt;
+	}
+
+	const QString arg = m_arguments.takeFirst();
+	return ParseFloat(arg, context);
+}
+
+bool ccArgumentParser::tryConsumeOption(const QString& option)
+{
+	if (isEmpty())
+	{
+		return false;
+	}
+
+	const QString arg = m_arguments.first();
+
+	if (arg.startsWith("-") && arg.mid(1).toUpper() == option)
+	{
+		m_arguments.removeFirst();
+		return true;
+	}
+
+	return false;
+}
+
+std::optional<float> ccArgumentParser::ParseFloat(const QString& arg, const QString& name)
+{
+	bool        ok;
+	const float value = arg.toFloat(&ok);
+	if (!ok)
+	{
+		ccLog::Error(QObject::tr("Invalid float value '%1' for %2").arg(arg, name));
+		return std::nullopt;
+	}
+
+	return value;
+}

--- a/qCC/ccArgumentParser.h
+++ b/qCC/ccArgumentParser.h
@@ -1,0 +1,90 @@
+// ##########################################################################
+// #                                                                        #
+// #                            CLOUDCOMPARE                                #
+// #                                                                        #
+// #  This program is free software; you can redistribute it and/or modify  #
+// #  it under the terms of the GNU General Public License as published by  #
+// #  the Free Software Foundation; version 2 of the License.               #
+// #                                                                        #
+// #  This program is distributed in the hope that it will be useful,       #
+// #  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+// #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+// #  GNU General Public License for more details.                          #
+// #                                                                        #
+// #                   COPYRIGHT: CloudCompare project                      #
+// #                                                                        #
+// ##########################################################################
+#pragma once
+
+#include <QObject>
+#include <QStringList>
+#include <ccLog.h>
+#include <initializer_list>
+#include <optional>
+#include <utility>
+
+//! Argument parser for command line arguments
+//!
+//! Meant to simplify parsing.
+//! Functions will log errors when necessary
+class ccArgumentParser
+{
+  public:
+	explicit ccArgumentParser(QStringList& arguments);
+
+	// Returns the next argument without consuming it, or nullptr if there are none
+	const QString peek() const;
+	// Skips the next argument, to be used with `peek`
+	void skip();
+	// Returns true if there are no arguments left
+	bool isEmpty() const;
+
+	// Returns the next argument in the list, or std::nullopt if there are none
+	std::optional<QString> takeNext();
+	// Returns the next argument in the list parsed as a float, or std::nullopt if there are none
+	// Logs errors
+	std::optional<float> takeFloat(const QString& context);
+	// Checks if the next argument is `-OPTION` (case insensitive)
+	// - if yes: consumes it and returns true
+	// - if not: returns false without consuming
+	bool tryConsumeOption(const QString& option);
+
+	// Returns the next argument parsed as an enum
+	// Takes a list that matches strings to enum values
+	// strings should be `UPPER_CASE`, the user value will not be case sensitive
+	template <typename T>
+	std::optional<T> takeEnum(const std::initializer_list<std::pair<const char*, T>>& mapping, const QString& context)
+	{
+		if (m_arguments.isEmpty())
+		{
+			ccLog::Error(QObject::tr("Missing parameter: %1").arg(context));
+			return std::nullopt;
+		}
+
+		const QString arg = m_arguments.takeFirst().toUpper();
+
+		for (const auto& [key, value] : mapping)
+		{
+			if (key == arg)
+			{
+				return value;
+			}
+		}
+
+		QStringList valid;
+		for (const auto& [key, value] : mapping)
+			valid << key;
+
+		ccLog::Error(QObject::tr("Invalid %1: '%2' (expected one of: %3)")
+		                 .arg(context, arg, valid.join(", ")));
+
+		return std::nullopt;
+	}
+
+	// Parses a float from a string
+	// Logs an error on failure
+	static std::optional<float> ParseFloat(const QString& arg, const QString& name);
+
+  private:
+	QStringList& m_arguments;
+};

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -38,10 +38,14 @@
 #include "ccCommandLineCommands.h"
 
 // Local
+#include "ccArgumentParser.h"
 #include "ccEntityAction.h"
 
 #include <QDateTime>
 #include <QFileInfo>
+#include <limits>
+#include <optional>
+#include <utility>
 
 // commands
 constexpr char COMMAND_CLOUD_EXPORT_FORMAT[]              = "C_EXPORT_FMT";
@@ -990,24 +994,24 @@ bool CommandOctreeNormal::process(ccCommandLineInterface& cmd)
 	{
 		return cmd.error(QObject::tr("No point cloud to compute normals (be sure to open one with \"-%1 [cloud filename]\" before \"-%2\")").arg(COMMAND_OPEN, COMMAND_COMPUTE_OCTREE_NORMALS));
 	}
+	ccArgumentParser parser(cmd.arguments());
 
-	if (cmd.arguments().empty())
+	const std::optional<QString> radiusArg = parser.takeNext();
+	if (!radiusArg)
 	{
 		return cmd.error(QObject::tr("Missing parameter: radius after \"-%1\"").arg(COMMAND_COMPUTE_OCTREE_NORMALS));
 	}
 
-	float   radius    = std::numeric_limits<float>::quiet_NaN(); // if this stays
-	QString radiusArg = cmd.arguments().takeFirst();
-	if (radiusArg.toUpper() != "AUTO")
+	float radius = std::numeric_limits<float>::quiet_NaN();
+	if (radiusArg->toUpper() != "AUTO")
 	{
-		bool ok = false;
-		radius  = radiusArg.toFloat(&ok);
-		if (!ok)
-		{
-			return cmd.error(QObject::tr("Invalid radius"));
-		}
+		auto maybeRadius = ccArgumentParser::ParseFloat(*radiusArg, QObject::tr("radius"));
+		if (!maybeRadius)
+			return false;
+		radius = *maybeRadius;
 	}
-	cmd.print(QObject::tr("\tRadius: %1").arg(radiusArg));
+
+	cmd.print(QObject::tr("\tRadius: %1").arg(*radiusArg));
 
 	CCCoreLib::LOCAL_MODEL_TYPES model       = CCCoreLib::QUADRIC;
 	ccNormalVectors::Orientation orientation = ccNormalVectors::Orientation::UNDEFINED;
@@ -1016,134 +1020,77 @@ bool CommandOctreeNormal::process(ccCommandLineInterface& cmd)
 	bool  orientNormalsWithGrids   = false;
 	bool  orientNormalsWithSensors = false;
 	float angle                    = std::numeric_limits<float>::quiet_NaN(); // if this stays
-	while (!cmd.arguments().isEmpty())
+	while (!parser.isEmpty())
 	{
-		QString argument = cmd.arguments().front().toUpper();
-		if (ccCommandLineInterface::IsCommand(argument, OPTION_ORIENT))
+		if (parser.tryConsumeOption(OPTION_ORIENT))
 		{
-			cmd.arguments().takeFirst();
-			if (!cmd.arguments().isEmpty())
-			{
-				QString orient_argument = cmd.arguments().takeFirst().toUpper();
-				if (orient_argument == "PLUS_ZERO" || orient_argument == "PLUS_ORIGIN")
-				{
-					orientation = ccNormalVectors::Orientation::PLUS_ORIGIN;
-				}
-				else if (orient_argument == "MINUS_ZERO" || orient_argument == "MINUS_ORIGIN")
-				{
-					orientation = ccNormalVectors::Orientation::MINUS_ORIGIN;
-				}
-				else if (orient_argument == "PLUS_BARYCENTER")
-				{
-					orientation = ccNormalVectors::Orientation::PLUS_BARYCENTER;
-				}
-				else if (orient_argument == "MINUS_BARYCENTER")
-				{
-					orientation = ccNormalVectors::Orientation::MINUS_BARYCENTER;
-				}
-				else if (orient_argument == "PLUS_X")
-				{
-					orientation = ccNormalVectors::Orientation::PLUS_X;
-				}
-				else if (orient_argument == "MINUS_X")
-				{
-					orientation = ccNormalVectors::Orientation::MINUS_X;
-				}
-				else if (orient_argument == "PLUS_Y")
-				{
-					orientation = ccNormalVectors::Orientation::PLUS_Y;
-				}
-				else if (orient_argument == "MINUS_Y")
-				{
-					orientation = ccNormalVectors::Orientation::MINUS_Y;
-				}
-				else if (orient_argument == "PLUS_Z")
-				{
-					orientation = ccNormalVectors::Orientation::PLUS_Z;
-				}
-				else if (orient_argument == "MINUS_Z")
-				{
-					orientation = ccNormalVectors::Orientation::MINUS_Z;
-				}
-				else if (orient_argument == "PREVIOUS")
-				{
-					orientation = ccNormalVectors::Orientation::PREVIOUS;
-				}
-				else if (orient_argument == "PLUS_SENSOR_ORIGIN")
-				{
-					orientation = ccNormalVectors::Orientation::PLUS_SENSOR_ORIGIN;
-				}
-				else if (orient_argument == "MINUS_SENSOR_ORIGIN")
-				{
-					orientation = ccNormalVectors::Orientation::MINUS_SENSOR_ORIGIN;
-				}
-				else if (orient_argument == OPTION_WITH_GRIDS)
-				{
-					orientation            = ccNormalVectors::Orientation::UNDEFINED;
-					orientNormalsWithGrids = true;
-				}
-				else if (orient_argument == OPTION_WITH_SENSOR)
-				{
-					orientation              = ccNormalVectors::Orientation::UNDEFINED;
-					orientNormalsWithSensors = true;
-				}
-				else
-				{
-					return cmd.error(QObject::tr("Invalid parameter: unknown orientation '%1'").arg(orient_argument));
-				}
-			}
-			else
+			const QString orientArg = parser.peek();
+			if (orientArg.isNull())
 			{
 				return cmd.error(QObject::tr("Missing orientation"));
 			}
-		}
-		else if (ccCommandLineInterface::IsCommand(argument, OPTION_MODEL))
-		{
-			cmd.arguments().takeFirst();
-			if (!cmd.arguments().isEmpty())
+
+			QString upper = orientArg.toUpper();
+			if (upper == OPTION_WITH_GRIDS)
 			{
-				QString model_arg = cmd.arguments().takeFirst().toUpper();
-				if (model_arg == "LS")
-				{
-					model = CCCoreLib::LOCAL_MODEL_TYPES::LS;
-				}
-				else if (model_arg == "TRI")
-				{
-					model = CCCoreLib::LOCAL_MODEL_TYPES::TRI;
-				}
-				else if (model_arg == "QUADRIC")
-				{
-					model = CCCoreLib::LOCAL_MODEL_TYPES::QUADRIC;
-				}
-				else
-				{
-					return cmd.error(QObject::tr("Invalid parameter: unknown model '%1'").arg(model_arg));
-				}
+				parser.skip();
+				orientation            = ccNormalVectors::Orientation::UNDEFINED;
+				orientNormalsWithGrids = true;
+			}
+			else if (upper == OPTION_WITH_SENSOR)
+			{
+				parser.skip();
+				orientation              = ccNormalVectors::Orientation::UNDEFINED;
+				orientNormalsWithSensors = true;
 			}
 			else
 			{
-				return cmd.error(QObject::tr("Missing model"));
+				auto maybeOrientation = parser.takeEnum<ccNormalVectors::Orientation>({
+				                                                                          {"PLUS_ORIGIN", ccNormalVectors::Orientation::PLUS_ORIGIN},
+				                                                                          {"PLUS_ZERO", ccNormalVectors::Orientation::PLUS_ORIGIN},
+				                                                                          {"MINUS_ORIGIN", ccNormalVectors::Orientation::MINUS_ORIGIN},
+				                                                                          {"MINUS_ZERO", ccNormalVectors::Orientation::MINUS_ORIGIN},
+				                                                                          {"PLUS_BARYCENTER", ccNormalVectors::Orientation::PLUS_BARYCENTER},
+				                                                                          {"MINUS_BARYCENTER", ccNormalVectors::Orientation::MINUS_BARYCENTER},
+				                                                                          {"PLUS_X", ccNormalVectors::Orientation::PLUS_X},
+				                                                                          {"MINUS_X", ccNormalVectors::Orientation::MINUS_X},
+				                                                                          {"PLUS_Y", ccNormalVectors::Orientation::PLUS_Y},
+				                                                                          {"MINUS_Y", ccNormalVectors::Orientation::MINUS_Y},
+				                                                                          {"PLUS_Z", ccNormalVectors::Orientation::PLUS_Z},
+				                                                                          {"MINUS_Z", ccNormalVectors::Orientation::MINUS_Z},
+				                                                                          {"PREVIOUS", ccNormalVectors::Orientation::PREVIOUS},
+				                                                                          {"PLUS_SENSOR_ORIGIN", ccNormalVectors::Orientation::PLUS_SENSOR_ORIGIN},
+				                                                                          {"MINUS_SENSOR_ORIGIN", ccNormalVectors::Orientation::MINUS_SENSOR_ORIGIN},
+				                                                                      },
+				                                                                      QObject::tr("orientation"));
+				if (!maybeOrientation)
+					return false;
+				orientation = *maybeOrientation;
 			}
 		}
-		else if (ccCommandLineInterface::IsCommand(argument, OPTION_WITH_GRIDS))
+		else if (parser.tryConsumeOption(OPTION_MODEL))
 		{
-			cmd.arguments().takeFirst();
-			if (!cmd.arguments().isEmpty())
-			{
-				bool    ok       = false;
-				QString angleArg = cmd.arguments().takeFirst();
-				angle            = angleArg.toFloat(&ok);
-				if (!ok)
-				{
-					return cmd.error(QObject::tr("Invalid angle for scan grids"));
-				}
-				cmd.print(QObject::tr("\tAngle for scan grids: %1").arg(angleArg));
-				useGridStructure = true;
-			}
-			else
-			{
+			auto maybeModel = parser.takeEnum<CCCoreLib::LOCAL_MODEL_TYPES>({
+			                                                                    {"LS", CCCoreLib::LOCAL_MODEL_TYPES::LS},
+			                                                                    {"TRI", CCCoreLib::LOCAL_MODEL_TYPES::TRI},
+			                                                                    {"QUADRIC", CCCoreLib::LOCAL_MODEL_TYPES::QUADRIC},
+			                                                                },
+			                                                                QObject::tr("model"));
+			if (!maybeModel)
+				return false;
+			model = *maybeModel;
+		}
+		else if (parser.tryConsumeOption(OPTION_WITH_GRIDS))
+		{
+			auto angleArg = parser.takeNext();
+			if (!angleArg)
 				return cmd.error(QObject::tr("Missing min angle for scan grids"));
-			}
+			auto maybeAngle = ccArgumentParser::ParseFloat(*angleArg, QObject::tr("angle for scan grids"));
+			if (!maybeAngle)
+				return false;
+			angle = *maybeAngle;
+			cmd.print(QObject::tr("\tAngle for scan grids: %1").arg(*angleArg));
+			useGridStructure = true;
 		}
 		else
 		{

--- a/qCC/test/CMakeLists.txt
+++ b/qCC/test/CMakeLists.txt
@@ -1,0 +1,16 @@
+find_package(Qt6 REQUIRED COMPONENTS Test)
+
+add_executable(TestArgumentParser
+    TestArgumentParser.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../ccArgumentParser.cpp
+)
+
+target_include_directories(TestArgumentParser PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+target_link_libraries(TestArgumentParser
+    PRIVATE
+        QCC_DB_LIB
+        Qt6::Test
+)
+
+add_test(NAME TestArgumentParser COMMAND TestArgumentParser)

--- a/qCC/test/TestArgumentParser.cpp
+++ b/qCC/test/TestArgumentParser.cpp
@@ -1,0 +1,290 @@
+#include "ccArgumentParser.h"
+
+#include <QTest>
+
+enum class Color
+{
+	RED,
+	GREEN,
+	BLUE
+};
+
+class TestArgumentParser : public QObject
+{
+	Q_OBJECT
+
+  private slots:
+
+	// peek()
+	void peekOnEmptyReturnsNull()
+	{
+		QStringList      args;
+		ccArgumentParser parser(args);
+		QCOMPARE(parser.peek(), QString());
+	}
+
+	void peekReturnsFirstWithoutConsuming()
+	{
+		QStringList      args{"hello", "world"};
+		ccArgumentParser parser(args);
+
+		const QString first = parser.peek();
+		QVERIFY(!first.isNull());
+		QCOMPARE(first, "hello");
+		QCOMPARE(args.size(), 2);
+	}
+
+	void consecutivePeeksReturnSameElement()
+	{
+		QStringList      args{"hello"};
+		ccArgumentParser parser(args);
+
+		QCOMPARE(parser.peek(), parser.peek());
+	}
+
+	// skip()
+	void skipRemovesFirstElement()
+	{
+		QStringList      args{"a", "b", "c"};
+		ccArgumentParser parser(args);
+
+		parser.skip();
+		QCOMPARE(args.size(), 2);
+		QCOMPARE(args.first(), "b");
+	}
+
+	// isEmpty()
+	void isEmptyOnEmptyList()
+	{
+		QStringList      args;
+		ccArgumentParser parser(args);
+		QVERIFY(parser.isEmpty());
+	}
+
+	void isEmptyOnNonEmptyList()
+	{
+		QStringList      args{"a"};
+		ccArgumentParser parser(args);
+		QVERIFY(!parser.isEmpty());
+	}
+
+	// takeNext()
+	void takeNextOnEmptyReturnsNullopt()
+	{
+		QStringList      args;
+		ccArgumentParser parser(args);
+
+		auto result = parser.takeNext();
+		QVERIFY(!result.has_value());
+	}
+
+	void takeNextReturnsAndConsumes()
+	{
+		QStringList      args{"first", "second"};
+		ccArgumentParser parser(args);
+
+		auto result = parser.takeNext();
+		QVERIFY(result.has_value());
+		QCOMPARE(*result, "first");
+		QCOMPARE(args.size(), 1);
+	}
+
+	void takeNextSuccessiveCalls()
+	{
+		QStringList      args{"a", "b", "c"};
+		ccArgumentParser parser(args);
+
+		QCOMPARE(*parser.takeNext(), "a");
+		QCOMPARE(*parser.takeNext(), "b");
+		QCOMPARE(*parser.takeNext(), "c");
+		QVERIFY(!parser.takeNext().has_value());
+	}
+
+	// takeFloat()
+	void takeFloatParsesValid()
+	{
+		QStringList      args{"3.14"};
+		ccArgumentParser parser(args);
+
+		auto result = parser.takeFloat("test");
+		QVERIFY(result.has_value());
+		QCOMPARE(*result, 3.14f);
+		QVERIFY(args.isEmpty());
+	}
+
+	void takeFloatOnEmptyReturnsNullopt()
+	{
+		QStringList      args;
+		ccArgumentParser parser(args);
+
+		auto result = parser.takeFloat("test");
+		QVERIFY(!result.has_value());
+	}
+
+	void takeFloatOnInvalidReturnsNullopt()
+	{
+		QStringList      args{"not_a_number"};
+		ccArgumentParser parser(args);
+
+		auto result = parser.takeFloat("test");
+		QVERIFY(!result.has_value());
+		QVERIFY(args.isEmpty());
+	}
+
+	// ParseFloat() static
+	void ParseFloatValid()
+	{
+		auto result = ccArgumentParser::ParseFloat("42.5", "test");
+		QVERIFY(result.has_value());
+		QCOMPARE(*result, 42.5f);
+	}
+
+	void ParseFloatInvalid()
+	{
+		auto result = ccArgumentParser::ParseFloat("abc", "test");
+		QVERIFY(!result.has_value());
+	}
+
+	void ParseFloatZero()
+	{
+		auto result = ccArgumentParser::ParseFloat("0", "test");
+		QVERIFY(result.has_value());
+		QCOMPARE(*result, 0.0f);
+	}
+
+	void ParseFloatNegative()
+	{
+		auto result = ccArgumentParser::ParseFloat("-1.5", "test");
+		QVERIFY(result.has_value());
+		QCOMPARE(*result, -1.5f);
+	}
+
+	void ParseFloatScientific()
+	{
+		auto result = ccArgumentParser::ParseFloat("1.5e3", "test");
+		QVERIFY(result.has_value());
+		QCOMPARE(*result, 1500.0f);
+	}
+
+	// tryConsumeOption()
+	void tryConsumeOptionMatchesCaseInsensitive()
+	{
+		QStringList      args{"-orient"};
+		ccArgumentParser parser(args);
+
+		QVERIFY(parser.tryConsumeOption("ORIENT"));
+		QVERIFY(args.isEmpty());
+	}
+
+	void tryConsumeOptionMatchesUpperCase()
+	{
+		QStringList      args{"-ORIENT"};
+		ccArgumentParser parser(args);
+
+		QVERIFY(parser.tryConsumeOption("ORIENT"));
+		QVERIFY(args.isEmpty());
+	}
+
+	void tryConsumeOptionNoMatchDoesNotConsume()
+	{
+		QStringList      args{"-OTHER"};
+		ccArgumentParser parser(args);
+
+		QVERIFY(!parser.tryConsumeOption("ORIENT"));
+		QCOMPARE(args.size(), 1);
+	}
+
+	void tryConsumeOptionOnEmptyReturnsFalse()
+	{
+		QStringList      args;
+		ccArgumentParser parser(args);
+
+		QVERIFY(!parser.tryConsumeOption("ORIENT"));
+	}
+
+	void tryConsumeOptionRequiresDashPrefix()
+	{
+		QStringList      args{"ORIENT"};
+		ccArgumentParser parser(args);
+
+		QVERIFY(!parser.tryConsumeOption("ORIENT"));
+		QCOMPARE(args.size(), 1);
+	}
+
+	// takeEnum()
+	void takeEnumReturnsCorrectValue()
+	{
+		QStringList      args{"GREEN"};
+		ccArgumentParser parser(args);
+
+		auto result = parser.takeEnum<Color>({
+		                                         {"RED", Color::RED},
+		                                         {"GREEN", Color::GREEN},
+		                                         {"BLUE", Color::BLUE},
+		                                     },
+		                                     "color");
+		QVERIFY(result.has_value());
+		QCOMPARE(*result, Color::GREEN);
+		QVERIFY(args.isEmpty());
+	}
+
+	void takeEnumCaseInsensitive()
+	{
+		QStringList      args{"red"};
+		ccArgumentParser parser(args);
+
+		auto result = parser.takeEnum<Color>({
+		                                         {"RED", Color::RED},
+		                                         {"GREEN", Color::GREEN},
+		                                         {"BLUE", Color::BLUE},
+		                                     },
+		                                     "color");
+		QVERIFY(result.has_value());
+		QCOMPARE(*result, Color::RED);
+	}
+
+	void takeEnumOnEmptyReturnsNullopt()
+	{
+		QStringList      args;
+		ccArgumentParser parser(args);
+
+		auto result = parser.takeEnum<Color>({
+		                                         {"RED", Color::RED},
+		                                     },
+		                                     "color");
+		QVERIFY(!result.has_value());
+	}
+
+	void takeEnumUnrecognizedReturnsNullopt()
+	{
+		QStringList      args{"YELLOW"};
+		ccArgumentParser parser(args);
+
+		auto result = parser.takeEnum<Color>({
+		                                         {"RED", Color::RED},
+		                                         {"GREEN", Color::GREEN},
+		                                         {"BLUE", Color::BLUE},
+		                                     },
+		                                     "color");
+		QVERIFY(!result.has_value());
+		QVERIFY(args.isEmpty());
+	}
+
+	void takeEnumWithAliases()
+	{
+		QStringList      args{"CRIMSON"};
+		ccArgumentParser parser(args);
+
+		auto result = parser.takeEnum<Color>({
+		                                         {"RED", Color::RED},
+		                                         {"CRIMSON", Color::RED},
+		                                         {"GREEN", Color::GREEN},
+		                                     },
+		                                     "color");
+		QVERIFY(result.has_value());
+		QCOMPARE(*result, Color::RED);
+	}
+};
+
+QTEST_GUILESS_MAIN(TestArgumentParser)
+#include "TestArgumentParser.moc"


### PR DESCRIPTION
The goal is to make the parsing of arguments in
the commandline mode less verbose.