### PR TITLE
Fix macOS bundle identifier for ccViewer

### DIFF
--- a/.ci/verify_macos_bundle_identifiers.py
+++ b/.ci/verify_macos_bundle_identifiers.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+BUNDLES = (
+    (
+        "CloudCompare",
+        Path("qCC/Mac/CloudCompare.plist"),
+        Path("qCC/Mac/CMakeLists.txt"),
+    ),
+    (
+        "ccViewer",
+        Path("ccViewer/Mac/ccViewer.plist"),
+        Path("ccViewer/Mac/CMakeLists.txt"),
+    ),
+)
+
+PLACEHOLDER = "${MACOSX_BUNDLE_GUI_IDENTIFIER}"
+IDENTIFIER_RE = re.compile(r'MACOSX_BUNDLE_GUI_IDENTIFIER\s+"[^"]+"')
+
+
+def main() -> int:
+    repo_root = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else Path.cwd()
+    errors: list[str] = []
+
+    for bundle_name, plist_relpath, cmake_relpath in BUNDLES:
+        plist_path = repo_root / plist_relpath
+        cmake_path = repo_root / cmake_relpath
+
+        plist_text = plist_path.read_text(encoding="utf-8")
+        if PLACEHOLDER not in plist_text:
+            errors.append(
+                f"{bundle_name}: expected {plist_relpath} to reference {PLACEHOLDER}"
+            )
+
+        cmake_text = cmake_path.read_text(encoding="utf-8")
+        if not IDENTIFIER_RE.search(cmake_text):
+            errors.append(
+                f"{bundle_name}: expected {cmake_relpath} to set a non-empty "
+                "MACOSX_BUNDLE_GUI_IDENTIFIER"
+            )
+
+    if errors:
+        print("macOS bundle identifier verification failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print("macOS bundle identifiers are configured for all checked app bundles.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,10 @@ jobs:
           channels: conda-forge
           conda-remove-defaults: "true"
 
+      - name: Verify macOS bundle identifiers
+        shell: bash -l {0}
+        run: python .ci/verify_macos_bundle_identifiers.py .
+
       - name: Configure MSVC console (Windows)
         if: matrix.config.os == 'windows-latest'
         uses: ilammy/msvc-dev-cmd@v1

--- a/ccViewer/Mac/CMakeLists.txt
+++ b/ccViewer/Mac/CMakeLists.txt
@@ -2,6 +2,7 @@
 if( APPLE )
 	set_target_properties( ${PROJECT_NAME} PROPERTIES
 		INSTALL_RPATH "@executable_path/../Frameworks"
+		MACOSX_BUNDLE_GUI_IDENTIFIER "org.cloudcompare.ccViewer"
 		MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/ccViewer.plist
 		MACOSX_BUNDLE_ICON_FILE cc_viewer_icon.icns
 		MACOSX_BUNDLE_SHORT_VERSION_STRING "${PROJECT_VERSION}"


### PR DESCRIPTION
## Summary
- add a non-empty `MACOSX_BUNDLE_GUI_IDENTIFIER` for the macOS `ccViewer` app bundle
- add a lightweight CI regression check that verifies macOS app bundles don't leave `MACOSX_BUNDLE_GUI_IDENTIFIER` unset when their plist templates reference it

## Context
`qCC` gained a macOS bundle identifier in #2209, but `ccViewer` still uses a plist template that references `${MACOSX_BUNDLE_GUI_IDENTIFIER}` without setting that property in `ccViewer/Mac/CMakeLists.txt`.

That leaves the generated `ccViewer.app/Contents/Info.plist` with an empty `CFBundleIdentifier`, which is the same failure mode behind the macOS native open/save dialog regression discussed in #2152.

## Verification
- `python3 .ci/verify_macos_bundle_identifiers.py .`
