### PR TITLE
Fix build failure with GDAL 3.13.0.

### DIFF
--- a/qCC/ccRasterizeTool.cpp
+++ b/qCC/ccRasterizeTool.cpp
@@ -1372,7 +1372,11 @@ bool ccRasterizeTool::ExportGeoTiff(const QString&                    outputFile
 		return false;
 	}
 
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 13, 0)
+	CSLConstList papszMetadata = poDriver->GetMetadata();
+#else
 	char** papszMetadata = poDriver->GetMetadata();
+#endif
 	if (!CSLFetchBoolean(papszMetadata, GDAL_DCAP_CREATE, FALSE))
 	{
 		ccLog::Error("[GDAL] Driver %s doesn't support Create() method", pszFormat);


### PR DESCRIPTION
```
error: invalid conversion from 'CSLConstList' {aka 'const char* const*'} to 'char**' [-fpermissive]
```
From [GDAL 3.13.0. NEWS](https://github.com/OSGeo/gdal/blob/v3.13.0beta1/NEWS.md):
> * GDALMajorObject: Use CSLConstList for GetMetadata, SetMetadata (API breakage)