### PR TITLE
Add 3DConnexion SpaceMouse support on macOS via hidapi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,6 +156,7 @@ jobs:
           libopencv-dev
           libboost-dev libboost-iostreams-dev libboost-system-dev libpcap-dev libflann-dev
           libglu1-mesa-dev
+          udev libudev-dev libhidapi-dev libusb-1.0-0-dev
           xvfb
 
       - name: Setup GCC
@@ -237,6 +238,7 @@ jobs:
           -DPLUGIN_STANDARD_QCLOUDLAYERS=ON
           -DPLUGIN_STANDARD_QVOXFALL=ON
           -DBUILD_TESTING=ON
+          -DOPTION_SUPPORT_3DCONNEXION_DEVICES=ON
 
       - name: Build
         run: cmake --build build --parallel

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,6 +56,7 @@ jobs:
           libopencv-dev
           libboost-dev libboost-iostreams-dev libboost-system-dev libpcap-dev libflann-dev
           libglu1-mesa-dev
+          udev libudev-dev libhidapi-dev libusb-1.0-0-dev
           xvfb
 
       - name: Configure cmake

--- a/.gitmodules
+++ b/.gitmodules
@@ -50,3 +50,6 @@
 [submodule "plugins/core/Standard/cc3DFin"]
 	path = plugins/core/Standard/cc3DFin
 	url = https://github.com/3DFin/cc3DFin.git
+[submodule "extern/hidapi"]
+	path = extern/hidapi
+	url = https://github.com/libusb/hidapi.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -50,6 +50,6 @@
 [submodule "plugins/core/Standard/cc3DFin"]
 	path = plugins/core/Standard/cc3DFin
 	url = https://github.com/3DFin/cc3DFin.git
-[submodule "extern/hidapi"]
-	path = extern/hidapi
+[submodule "libs/CCAppCommon/devices/3dConnexion/extern/hidapi"]
+	path = libs/CCAppCommon/devices/3dConnexion/extern/hidapi
 	url = https://github.com/libusb/hidapi.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,6 +322,10 @@ Improvements:
 			now apply to all selected DB tree item
 		- the 'Search by name and/or type' entry can now be applied with multiple entities selected at once
 
+	- 3D mouse support
+		- 3D mouse support on macOS, Linux and Windows (thanks to https://github.com/braunsi23 and Paul Rascle!)
+		- on Windows, option to compile with the 3DxWare SDK or the generic hidapi library
+
 	- Others:
 		- the Subsampling dialog won't allow the user to input sampling modulation parameters if all SF values are the same
 		- the shortcut to the 'Level' tool in the 'View' toolbar (left) has been removed. Contrarily to the other options in this toolbar,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ file(REMOVE "${SOURCES_LIST_FILE}")
 
 append_sources_to_file(source_list qCC EXCLUDE_DIRS extern)
 append_sources_to_file(source_list ccViewer EXCLUDE_DIRS extern)
-append_sources_to_file(source_list libs EXCLUDE_DIRS CCAppCommon/QDarkStyleSheet qCC_db/extern qCC_io/extern)
+append_sources_to_file(source_list libs EXCLUDE_DIRS CCAppCommon/QDarkStyleSheet qCC_db/extern qCC_io/extern CCAppCommon/devices/3dConnexion/extern/hidapi)
 append_sources_to_file(source_list plugins/core/GL EXCLUDE_DIRS qSSAO/extern)
 append_sources_to_file(source_list plugins/core/IO EXCLUDE_DIRS qE57IO/extern qPhotoscanIO/extern MeshIO/extern)
 

--- a/ccViewer/ccviewer.cpp
+++ b/ccViewer/ccviewer.cpp
@@ -44,7 +44,7 @@
 #include "ccPluginManager.h"
 
 // 3D mouse handler
-#ifdef CC_3DXWARE_SUPPORT
+#ifdef CC_3DMOUSE_SUPPORT
 #include "Mouse3DInput.h"
 #endif
 
@@ -94,7 +94,7 @@ ccViewer::ccViewer(QWidget* parent, Qt::WindowFlags flags)
 	reflectPerspectiveState();
 	reflectPivotVisibilityState();
 
-#ifdef CC_3DXWARE_SUPPORT
+#ifdef CC_3DMOUSE_SUPPORT
 	enable3DMouse(true);
 #else
 	ui.actionEnable3DMouse->setEnabled(false);
@@ -1098,7 +1098,7 @@ void ccViewer::doActionAbout()
 
 void ccViewer::release3DMouse()
 {
-#ifdef CC_3DXWARE_SUPPORT
+#ifdef CC_3DMOUSE_SUPPORT
 	if (m_3dMouseInput)
 	{
 		m_3dMouseInput->disconnect(); // disconnect from the driver
@@ -1112,7 +1112,7 @@ void ccViewer::release3DMouse()
 
 void ccViewer::enable3DMouse(bool state)
 {
-#ifdef CC_3DXWARE_SUPPORT
+#ifdef CC_3DMOUSE_SUPPORT
 	if (m_3dMouseInput)
 		release3DMouse();
 
@@ -1158,7 +1158,7 @@ void ccViewer::on3DMouseKeyUp(int)
 // ANY CHANGE/BUG FIX SHOULD BE REFLECTED TO THE EQUIVALENT METHODS IN QCC "MainWindow.cpp" FILE!
 void ccViewer::on3DMouseKeyDown(int key)
 {
-#ifdef CC_3DXWARE_SUPPORT
+#ifdef CC_3DMOUSE_SUPPORT
 
 	switch (key)
 	{
@@ -1248,7 +1248,7 @@ void ccViewer::on3DMouseCMDKeyUp(int cmd)
 
 void ccViewer::on3DMouseCMDKeyDown(int cmd)
 {
-#ifdef CC_3DXWARE_SUPPORT
+#ifdef CC_3DMOUSE_SUPPORT
 	switch (cmd)
 	{
 		// ccLog::Print(QString("on3DMouseCMDKeyDown Cmd = %1").arg(cmd));
@@ -1344,7 +1344,7 @@ void ccViewer::on3DMouseCMDKeyDown(int cmd)
 
 void ccViewer::on3DMouseMove(std::vector<float>& vec)
 {
-#ifdef CC_3DXWARE_SUPPORT
+#ifdef CC_3DMOUSE_SUPPORT
 	if (m_glWindow)
 		Mouse3DInput::Apply(vec, m_glWindow);
 #endif

--- a/libs/CCAppCommon/CMakeLists.txt
+++ b/libs/CCAppCommon/CMakeLists.txt
@@ -27,8 +27,8 @@ target_sources(${PROJECT_NAME}
 		${CMAKE_CURRENT_LIST_DIR}/QDarkStyleSheet/qdarkstyle/light/lightstyle.qrc
 )
 
-if( OPTION_SUPPORT_3DCONNEXION_DEVICES )
-	target_link_3DXWARE( ${PROJECT_NAME} )
+if( OPTION_SUPPORT_3DMOUSE_WITH_3DxWARE )
+	target_link_3DxWARE( ${PROJECT_NAME} )
 endif()
 
 InstallSharedLibrary( TARGET ${PROJECT_NAME} )

--- a/libs/CCAppCommon/devices/3dConnexion/CMakeLists.txt
+++ b/libs/CCAppCommon/devices/3dConnexion/CMakeLists.txt
@@ -1,18 +1,18 @@
 if( WIN32 )
 	option( OPTION_SUPPORT_3DCONNEXION_DEVICES "Build with 3dConnexion libraries (3D mouse support)" OFF )
-	
+
 	if( OPTION_SUPPORT_3DCONNEXION_DEVICES )
 		set( 3DXWARE_INCLUDE_DIR "" CACHE PATH "3DxWare include directory" )
 		set( 3DXWARE_LIB_DIR "" CACHE PATH "3DxWare libraries directory" )
-		
+
 		if( NOT 3DXWARE_INCLUDE_DIR )
 			message( SEND_ERROR "3DXWARE include path is not specified (3DXWARE_INCLUDE_DIR)" )
 		endif()
-		
+
 		if( NOT 3DXWARE_LIB_DIR )
 			message( SEND_ERROR "3DXWARE include path is not specified (3DXWARE_LIB_DIR)" )
 		endif()
-	
+
 		target_sources( ${PROJECT_NAME}
 			PRIVATE
 				${CMAKE_CURRENT_LIST_DIR}/cc3DMouseManager.h
@@ -20,23 +20,65 @@ if( WIN32 )
 				${CMAKE_CURRENT_LIST_DIR}/Mouse3DInput.h
 				${CMAKE_CURRENT_LIST_DIR}/Mouse3DInput.cpp
 		)
-	
+
 		target_include_directories( ${PROJECT_NAME}
 			PUBLIC
 				${CMAKE_CURRENT_LIST_DIR}
 				${3DXWARE_INCLUDE_DIR}
 		)
-	
+
 		target_compile_definitions( ${PROJECT_NAME} PUBLIC CC_3DXWARE_SUPPORT )
 	endif()
-	
+
 	function( target_link_3DXWARE ) # 1 argument: ARGV0 = target
-		if( OPTION_SUPPORT_3DCONNEXION_DEVICES )		
+		if( OPTION_SUPPORT_3DCONNEXION_DEVICES )
 			target_link_libraries( ${ARGV0} PUBLIC optimized ${3DXWARE_LIB_DIR}/siapp.lib ${3DXWARE_LIB_DIR}/spwmath.lib)
-		
+
 			if ( CMAKE_CONFIGURATION_TYPES )
 				target_link_libraries( ${ARGV0} PUBLIC debug ${3DXWARE_LIB_DIR}/siapp.lib ${3DXWARE_LIB_DIR}/spwmathD.lib )
 			endif()
 		endif()
+	endfunction()
+elseif( APPLE )
+	# On macOS we drive the 3DConnexion device directly via hidapi (no 3DxWare SDK).
+	# The hidapi sources are pulled in as a Git submodule under extern/hidapi.
+	if( NOT TARGET hidapi::hidapi )
+		set( HIDAPI_WITH_TESTS OFF CACHE BOOL "" FORCE )
+		# Build the hidapi submodule.
+		add_subdirectory( ${CMAKE_SOURCE_DIR}/extern/hidapi ${CMAKE_BINARY_DIR}/extern/hidapi EXCLUDE_FROM_ALL )
+	endif()
+
+	# Allow target_link_libraries() to act on targets defined in the parent directory.
+	cmake_policy( SET CMP0079 NEW )
+
+	option( OPTION_SUPPORT_3DCONNEXION_DEVICES "Build with hidapi (3D mouse support on macOS)" ON )
+
+	if( OPTION_SUPPORT_3DCONNEXION_DEVICES )
+		target_sources( ${PROJECT_NAME}
+			PRIVATE
+				${CMAKE_CURRENT_LIST_DIR}/cc3DMouseManager.h
+				${CMAKE_CURRENT_LIST_DIR}/cc3DMouseManager.cpp
+				${CMAKE_CURRENT_LIST_DIR}/Mouse3DInput.h
+				${CMAKE_CURRENT_LIST_DIR}/Mouse3DInput.cpp
+				${CMAKE_CURRENT_LIST_DIR}/Mouse3DInput_mac.h
+				${CMAKE_CURRENT_LIST_DIR}/Mouse3DInput_mac.cpp
+		)
+
+		target_include_directories( ${PROJECT_NAME}
+			PUBLIC
+				${CMAKE_CURRENT_LIST_DIR}
+		)
+
+		target_compile_definitions( ${PROJECT_NAME} PUBLIC CC_3DXWARE_SUPPORT )
+		# Used by Mouse3DInput.{h,cpp} and Mouse3DInput_mac.{h,cpp} to enable
+		# the HID-based macOS path. Defined as PUBLIC so that consumers (qCC,
+		# ccViewer) also see it when compiling their mainwindow.cpp files.
+		target_compile_definitions( ${PROJECT_NAME} PUBLIC CC_MAC_HID )
+
+		target_link_libraries( ${PROJECT_NAME} PUBLIC hidapi::hidapi )
+	endif()
+
+	function( target_link_3DXWARE ) # 1 argument: ARGV0 = target
+		# nothing to do on macOS (hidapi is linked via the target itself)
 	endfunction()
 endif()

--- a/libs/CCAppCommon/devices/3dConnexion/CMakeLists.txt
+++ b/libs/CCAppCommon/devices/3dConnexion/CMakeLists.txt
@@ -1,4 +1,4 @@
-if( WIN32 )
+if( WIN32_LEGACY_DRIVER ) # former 3DxWare SDK (Windows only)
 	option( OPTION_SUPPORT_3DCONNEXION_DEVICES "Build with 3dConnexion libraries (3D mouse support)" OFF )
 
 	if( OPTION_SUPPORT_3DCONNEXION_DEVICES )
@@ -39,13 +39,16 @@ if( WIN32 )
 			endif()
 		endif()
 	endfunction()
-elseif( APPLE )
+else() # hidapi-based 3DConnexion support, originally for macOS but also works on Linux and Windows (no 3DxWare SDK required)
 	# On macOS we drive the 3DConnexion device directly via hidapi (no 3DxWare SDK).
 	# The hidapi sources are pulled in as a Git submodule under extern/hidapi.
 	if( NOT TARGET hidapi::hidapi )
 		set( HIDAPI_WITH_TESTS OFF CACHE BOOL "" FORCE )
-		# Build the hidapi submodule.
-		add_subdirectory( ${CMAKE_SOURCE_DIR}/extern/hidapi ${CMAKE_BINARY_DIR}/extern/hidapi EXCLUDE_FROM_ALL )
+		# Build the hidapi submodule. The path to the source and binary directories is relative to the current CMakeLists.txt file
+		# (useful when CloudCompare is a git submodule in another project).
+		set( HIDAPI_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../../extern/hidapi )
+		set( HIDAPI_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../../../extern/hidapi )
+		add_subdirectory( ${HIDAPI_SOURCE_DIR} ${HIDAPI_BINARY_DIR} EXCLUDE_FROM_ALL )
 	endif()
 
 	# Allow target_link_libraries() to act on targets defined in the parent directory.
@@ -74,7 +77,7 @@ elseif( APPLE )
 			# Add the path explicitly so we don't depend solely on transitive
 			# propagation from the hidapi::hidapi target.
 			PRIVATE
-				${CMAKE_SOURCE_DIR}/extern/hidapi/hidapi
+				${HIDAPI_SOURCE_DIR}/hidapi
 		)
 
 		target_compile_definitions( ${PROJECT_NAME} PUBLIC CC_3DXWARE_SUPPORT )
@@ -88,6 +91,13 @@ elseif( APPLE )
 		endif()
 
 		target_link_libraries( ${PROJECT_NAME} PUBLIC hidapi::hidapi )
+		if ( WIN32 )
+			set( HIDAPI_LIB ${HIDAPI_BINARY_DIR}/src/windows/hidapi.dll )
+			install( PROGRAMS ${HIDAPI_LIB} DESTINATION ${CLOUDCOMPARE_DEST_FOLDER} )
+		elseif ( LINUX )
+			set( HIDAPI_LIB ${HIDAPI_BINARY_DIR}/src/linux/libhidapi-hidraw.so.0.16.0 )
+			install( FILES ${HIDAPI_LIB} DESTINATION ${CLOUDCOMPARE_DEST_FOLDER} RENAME "libhidapi-hidraw.so.0")
+		endif()	
 	endif()
 
 	function( target_link_3DXWARE ) # 1 argument: ARGV0 = target

--- a/libs/CCAppCommon/devices/3dConnexion/CMakeLists.txt
+++ b/libs/CCAppCommon/devices/3dConnexion/CMakeLists.txt
@@ -52,6 +52,9 @@ elseif( APPLE )
 	cmake_policy( SET CMP0079 NEW )
 
 	option( OPTION_SUPPORT_3DCONNEXION_DEVICES "Build with hidapi (3D mouse support on macOS)" ON )
+	# Optional verbose logging of raw HID reports to the CloudCompare console.
+	# Off by default; turn on to diagnose device-specific report formats.
+	option( OPTION_HID_DEBUG "Enable verbose HID report logging (3D mouse)" OFF )
 
 	if( OPTION_SUPPORT_3DCONNEXION_DEVICES )
 		target_sources( ${PROJECT_NAME}
@@ -67,6 +70,11 @@ elseif( APPLE )
 		target_include_directories( ${PROJECT_NAME}
 			PUBLIC
 				${CMAKE_CURRENT_LIST_DIR}
+			# The hidapi header (hidapi.h) lives in extern/hidapi/hidapi/.
+			# Add the path explicitly so we don't depend solely on transitive
+			# propagation from the hidapi::hidapi target.
+			PRIVATE
+				${CMAKE_SOURCE_DIR}/extern/hidapi/hidapi
 		)
 
 		target_compile_definitions( ${PROJECT_NAME} PUBLIC CC_3DXWARE_SUPPORT )
@@ -74,6 +82,10 @@ elseif( APPLE )
 		# the HID-based macOS path. Defined as PUBLIC so that consumers (qCC,
 		# ccViewer) also see it when compiling their mainwindow.cpp files.
 		target_compile_definitions( ${PROJECT_NAME} PUBLIC CC_MAC_HID )
+
+		if( OPTION_HID_DEBUG )
+			target_compile_definitions( ${PROJECT_NAME} PRIVATE CC_HID_DEBUG )
+		endif()
 
 		target_link_libraries( ${PROJECT_NAME} PUBLIC hidapi::hidapi )
 	endif()

--- a/libs/CCAppCommon/devices/3dConnexion/CMakeLists.txt
+++ b/libs/CCAppCommon/devices/3dConnexion/CMakeLists.txt
@@ -92,8 +92,8 @@ else() # hidapi-based 3DConnexion support, originally for macOS but also works o
 
 		target_link_libraries( ${PROJECT_NAME} PUBLIC hidapi::hidapi )
 		if ( WIN32 )
-			set( HIDAPI_LIB ${HIDAPI_BINARY_DIR}/src/windows/hidapi.dll )
-			install( PROGRAMS ${HIDAPI_LIB} DESTINATION ${CLOUDCOMPARE_DEST_FOLDER} )
+			#set( HIDAPI_LIB ${HIDAPI_BINARY_DIR}/src/windows/hidapi.dll )
+			#install( PROGRAMS ${HIDAPI_LIB} DESTINATION ${CLOUDCOMPARE_DEST_FOLDER} )
 		elseif ( LINUX )
 			set( HIDAPI_LIB ${HIDAPI_BINARY_DIR}/src/linux/libhidapi-hidraw.so.0.16.0 )
 			install( FILES ${HIDAPI_LIB} DESTINATION ${CLOUDCOMPARE_DEST_FOLDER} RENAME "libhidapi-hidraw.so.0")

--- a/libs/CCAppCommon/devices/3dConnexion/CMakeLists.txt
+++ b/libs/CCAppCommon/devices/3dConnexion/CMakeLists.txt
@@ -1,73 +1,81 @@
-if( WIN32_LEGACY_DRIVER ) # former 3DxWare SDK (Windows only)
-	option( OPTION_SUPPORT_3DCONNEXION_DEVICES "Build with 3dConnexion libraries (3D mouse support)" OFF )
+if(WIN32)
+	option( OPTION_SUPPORT_3DMOUSE_WITH_3DxWARE "Build with 3DxWare (3D mouse support)" OFF )
+endif()
 
-	if( OPTION_SUPPORT_3DCONNEXION_DEVICES )
-		set( 3DXWARE_INCLUDE_DIR "" CACHE PATH "3DxWare include directory" )
-		set( 3DXWARE_LIB_DIR "" CACHE PATH "3DxWare libraries directory" )
+if( OPTION_SUPPORT_3DMOUSE_WITH_3DxWARE ) # former 3DxWare SDK (Windows only)
 
-		if( NOT 3DXWARE_INCLUDE_DIR )
-			message( SEND_ERROR "3DXWARE include path is not specified (3DXWARE_INCLUDE_DIR)" )
-		endif()
-
-		if( NOT 3DXWARE_LIB_DIR )
-			message( SEND_ERROR "3DXWARE include path is not specified (3DXWARE_LIB_DIR)" )
-		endif()
-
-		target_sources( ${PROJECT_NAME}
-			PRIVATE
-				${CMAKE_CURRENT_LIST_DIR}/cc3DMouseManager.h
-				${CMAKE_CURRENT_LIST_DIR}/cc3DMouseManager.cpp
-				${CMAKE_CURRENT_LIST_DIR}/Mouse3DInput.h
-				${CMAKE_CURRENT_LIST_DIR}/Mouse3DInput.cpp
-		)
-
-		target_include_directories( ${PROJECT_NAME}
-			PUBLIC
-				${CMAKE_CURRENT_LIST_DIR}
-				${3DXWARE_INCLUDE_DIR}
-		)
-
-		target_compile_definitions( ${PROJECT_NAME} PUBLIC CC_3DXWARE_SUPPORT )
+	if( OPTION_SUPPORT_3DMOUSE_WITH_HIDAPI )
+		message( WARNING "3DxWARE option takes precedence over HIDAPI")
 	endif()
 
-	function( target_link_3DXWARE ) # 1 argument: ARGV0 = target
-		if( OPTION_SUPPORT_3DCONNEXION_DEVICES )
-			target_link_libraries( ${ARGV0} PUBLIC optimized ${3DXWARE_LIB_DIR}/siapp.lib ${3DXWARE_LIB_DIR}/spwmath.lib)
+	set( 3DXWARE_INCLUDE_DIR "" CACHE PATH "3DxWare include directory" )
+	set( 3DXWARE_LIB_DIR "" CACHE PATH "3DxWare libraries directory" )
 
+	if( NOT 3DXWARE_INCLUDE_DIR )
+		message( SEND_ERROR "3DXWARE include path is not specified (3DXWARE_INCLUDE_DIR)" )
+	endif()
+
+	if( NOT 3DXWARE_LIB_DIR )
+		message( SEND_ERROR "3DXWARE include path is not specified (3DXWARE_LIB_DIR)" )
+	endif()
+
+	target_sources( ${PROJECT_NAME}
+		PRIVATE
+			${CMAKE_CURRENT_LIST_DIR}/cc3DMouseManager.h
+			${CMAKE_CURRENT_LIST_DIR}/cc3DMouseManager.cpp
+			${CMAKE_CURRENT_LIST_DIR}/Mouse3DInput.h
+			${CMAKE_CURRENT_LIST_DIR}/Mouse3DInput.cpp
+	)
+
+	target_include_directories( ${PROJECT_NAME}
+		PUBLIC
+			${CMAKE_CURRENT_LIST_DIR}
+			${3DXWARE_INCLUDE_DIR}
+	)
+
+	target_compile_definitions( ${PROJECT_NAME} PUBLIC CC_3DMOUSE_SUPPORT )
+
+	function( target_link_3DxWARE ) # 1 argument: ARGV0 = target
+		if( OPTION_SUPPORT_3DMOUSE_WITH_3DxWARE )
+			target_link_libraries( ${ARGV0} PUBLIC optimized ${3DXWARE_LIB_DIR}/siapp.lib ${3DXWARE_LIB_DIR}/spwmath.lib)
 			if ( CMAKE_CONFIGURATION_TYPES )
 				target_link_libraries( ${ARGV0} PUBLIC debug ${3DXWARE_LIB_DIR}/siapp.lib ${3DXWARE_LIB_DIR}/spwmathD.lib )
 			endif()
 		endif()
 	endfunction()
-else() # hidapi-based 3DConnexion support, originally for macOS but also works on Linux and Windows (no 3DxWare SDK required)
-	# On macOS we drive the 3DConnexion device directly via hidapi (no 3DxWare SDK).
-	# The hidapi sources are pulled in as a Git submodule under extern/hidapi.
-	if( NOT TARGET hidapi::hidapi )
-		set( HIDAPI_WITH_TESTS OFF CACHE BOOL "" FORCE )
-		# Build the hidapi submodule. The path to the source and binary directories is relative to the current CMakeLists.txt file
-		# (useful when CloudCompare is a git submodule in another project).
-		set( HIDAPI_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../../extern/hidapi )
-		set( HIDAPI_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../../../extern/hidapi )
-		add_subdirectory( ${HIDAPI_SOURCE_DIR} ${HIDAPI_BINARY_DIR} EXCLUDE_FROM_ALL )
-	endif()
 
-	# Allow target_link_libraries() to act on targets defined in the parent directory.
-	cmake_policy( SET CMP0079 NEW )
+else()
 
-	option( OPTION_SUPPORT_3DCONNEXION_DEVICES "Build with hidapi (3D mouse support on macOS)" ON )
-	# Optional verbose logging of raw HID reports to the CloudCompare console.
-	# Off by default; turn on to diagnose device-specific report formats.
-	option( OPTION_HID_DEBUG "Enable verbose HID report logging (3D mouse)" OFF )
+	option( OPTION_SUPPORT_3DMOUSE_WITH_HIDAPI "Build with hidapi (3D mouse support)" ON )
 
-	if( OPTION_SUPPORT_3DCONNEXION_DEVICES )
+	if( OPTION_SUPPORT_3DMOUSE_WITH_HIDAPI )
+		# hidapi-based 3DConnexion support, originally for macOS but also works on Linux and Windows (no more 3DxWare SDK required)
+		# We drive the 3DConnexion device directly via hidapi (no 3DxWare SDK).
+		# The hidapi sources are pulled in as a Git submodule under extern/hidapi.
+		if( NOT TARGET hidapi::hidapi )
+			set( HIDAPI_WITH_TESTS OFF CACHE BOOL "" FORCE )
+			# Build the hidapi submodule. The path to the source and binary directories is relative to the current CMakeLists.txt file
+			# (useful when CloudCompare is a git submodule in another project).
+			set( HIDAPI_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extern/hidapi )
+			set( HIDAPI_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern/hidapi )
+			add_subdirectory( ${HIDAPI_SOURCE_DIR} ${HIDAPI_BINARY_DIR} EXCLUDE_FROM_ALL )
+		endif()
+
+		# Allow target_link_libraries() to act on targets defined in the parent directory.
+		cmake_policy( SET CMP0079 NEW )
+
+		# Optional verbose logging of raw HID reports to the CloudCompare console.
+		# Off by default; turn on to diagnose device-specific report formats.
+		option( OPTION_HID_DEBUG "Enable verbose HID report logging (3D mouse)" OFF )
+
 		target_sources( ${PROJECT_NAME}
 			PRIVATE
 				${CMAKE_CURRENT_LIST_DIR}/cc3DMouseManager.h
 				${CMAKE_CURRENT_LIST_DIR}/cc3DMouseManager.cpp
 				${CMAKE_CURRENT_LIST_DIR}/Mouse3DInput.h
 				${CMAKE_CURRENT_LIST_DIR}/Mouse3DInput.cpp
-				${CMAKE_CURRENT_LIST_DIR}/Mouse3DInput_mac.h
-				${CMAKE_CURRENT_LIST_DIR}/Mouse3DInput_mac.cpp
+				${CMAKE_CURRENT_LIST_DIR}/Mouse3DInput_hid.h
+				${CMAKE_CURRENT_LIST_DIR}/Mouse3DInput_hid.cpp
 		)
 
 		target_include_directories( ${PROJECT_NAME}
@@ -80,11 +88,11 @@ else() # hidapi-based 3DConnexion support, originally for macOS but also works o
 				${HIDAPI_SOURCE_DIR}/hidapi
 		)
 
-		target_compile_definitions( ${PROJECT_NAME} PUBLIC CC_3DXWARE_SUPPORT )
-		# Used by Mouse3DInput.{h,cpp} and Mouse3DInput_mac.{h,cpp} to enable
-		# the HID-based macOS path. Defined as PUBLIC so that consumers (qCC,
+		target_compile_definitions( ${PROJECT_NAME} PUBLIC CC_3DMOUSE_SUPPORT )
+		# Used by Mouse3DInput.{h,cpp} and Mouse3DInput_hid.{h,cpp} to enable
+		# the HID-based path. Defined as PUBLIC so that consumers (qCC,
 		# ccViewer) also see it when compiling their mainwindow.cpp files.
-		target_compile_definitions( ${PROJECT_NAME} PUBLIC CC_MAC_HID )
+		target_compile_definitions( ${PROJECT_NAME} PUBLIC CC_3DMOUSE_HID )
 
 		if( OPTION_HID_DEBUG )
 			target_compile_definitions( ${PROJECT_NAME} PRIVATE CC_HID_DEBUG )
@@ -92,6 +100,7 @@ else() # hidapi-based 3DConnexion support, originally for macOS but also works o
 
 		target_link_libraries( ${PROJECT_NAME} PUBLIC hidapi::hidapi )
 		if ( WIN32 )
+			#no need to copy a DLL, as hidapi should be compiled as a static library by default
 			#set( HIDAPI_LIB ${HIDAPI_BINARY_DIR}/src/windows/hidapi.dll )
 			#install( PROGRAMS ${HIDAPI_LIB} DESTINATION ${CLOUDCOMPARE_DEST_FOLDER} )
 		elseif ( LINUX )
@@ -100,7 +109,4 @@ else() # hidapi-based 3DConnexion support, originally for macOS but also works o
 		endif()	
 	endif()
 
-	function( target_link_3DXWARE ) # 1 argument: ARGV0 = target
-		# nothing to do on macOS (hidapi is linked via the target itself)
-	endfunction()
 endif()

--- a/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput.cpp
+++ b/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput.cpp
@@ -21,6 +21,10 @@
 
 #include "Mouse3DInput.h"
 
+#ifdef CC_MAC_HID
+#include "Mouse3DInput_mac.h"
+#endif
+
 // qCC_db
 #include <ccLog.h>
 // qCC_gl
@@ -39,11 +43,15 @@
 #include <windows.h>
 #endif
 
+#ifdef CC_MAC_HID
+// hidapi (HID path for macOS) - Mouse3DInput_mac.cpp provides the HIDWorker
+#else
 // 3DxWare
 #include <si.h>
 #include <siapp.h>
 #include <spwmacro.h>
 #include <spwmath.h>
+#endif
 
 //! Object angular velocity per mouse tick (in radians per ms per count)
 static const double c_3dmouseAngularVelocity = 1.0e-6;
@@ -51,6 +59,7 @@ static const double c_3dmouseAngularVelocity = 1.0e-6;
 // Unique instance
 static Mouse3DInput* s_mouseInputInstance = nullptr;
 
+#ifndef CC_MAC_HID
 #include <QAbstractNativeEventFilter>
 class RawInputEventFilter : public QAbstractNativeEventFilter
 {
@@ -72,10 +81,16 @@ class RawInputEventFilter : public QAbstractNativeEventFilter
 	}
 };
 static RawInputEventFilter s_rawInputEventFilter;
+#endif // CC_MAC_HID
 
 Mouse3DInput::Mouse3DInput(QObject* parent)
     : QObject(parent)
+#ifdef CC_MAC_HID
+    , m_siHandle(nullptr)
+    , m_hidWorker(nullptr)
+#else
     , m_siHandle(SI_NO_HANDLE)
+#endif
 {
 	// Register current instance
 	assert(s_mouseInputInstance == nullptr);
@@ -84,6 +99,9 @@ Mouse3DInput::Mouse3DInput(QObject* parent)
 
 Mouse3DInput::~Mouse3DInput()
 {
+#ifdef CC_MAC_HID
+	disconnectDriver();
+#endif
 	// Unregister current instance
 	if (s_mouseInputInstance == this)
 	{
@@ -99,6 +117,36 @@ bool Mouse3DInput::connect(QWidget* mainWidget, QString appName)
 		return false;
 	}
 
+#ifdef CC_MAC_HID
+	Q_UNUSED(mainWidget)
+	Q_UNUSED(appName)
+
+	// Required for Qt::QueuedConnection across thread boundaries.
+	qRegisterMetaType<std::vector<float>>("std::vector<float>");
+
+	// macOS path: drive the device directly via hidapi (HIDWorker thread)
+	m_hidWorker = new HIDWorker(this);
+	if (!m_hidWorker->openDevice())
+	{
+		delete m_hidWorker;
+		m_hidWorker = nullptr;
+		ccLog::Warning(tr("[3D Mouse] Could not open a 3DConnexion device via HID"));
+		return false;
+	}
+
+	QObject::connect(m_hidWorker, &HIDWorker::sigMove3d,
+	                 this, [this](std::vector<float> v)
+	                 { Q_EMIT sigMove3d(v); }, Qt::QueuedConnection);
+	QObject::connect(m_hidWorker, &HIDWorker::sigReleased,
+	                 this, &Mouse3DInput::sigReleased, Qt::QueuedConnection);
+	QObject::connect(m_hidWorker, &HIDWorker::sigOn3dmouseKeyDown,
+	                 this, &Mouse3DInput::sigOn3dmouseKeyDown, Qt::QueuedConnection);
+	QObject::connect(m_hidWorker, &HIDWorker::sigOn3dmouseKeyUp,
+	                 this, &Mouse3DInput::sigOn3dmouseKeyUp, Qt::QueuedConnection);
+
+	m_hidWorker->start();
+	return true;
+#else
 	// Attempt to connect with the 3DxWare driver
 	assert(m_siHandle == SI_NO_HANDLE);
 
@@ -164,10 +212,20 @@ bool Mouse3DInput::connect(QWidget* mainWidget, QString appName)
 	qApp->installNativeEventFilter(&s_rawInputEventFilter);
 
 	return true;
+#endif
 }
 
 void Mouse3DInput::disconnectDriver()
 {
+#ifdef CC_MAC_HID
+	if (m_hidWorker)
+	{
+		m_hidWorker->stop();
+		m_hidWorker->wait();
+		delete m_hidWorker;
+		m_hidWorker = nullptr;
+	}
+#else
 	if (m_siHandle != SI_NO_HANDLE)
 	{
 		SiClose(m_siHandle);
@@ -175,10 +233,16 @@ void Mouse3DInput::disconnectDriver()
 		m_siHandle = SI_NO_HANDLE;
 		qApp->removeNativeEventFilter(&s_rawInputEventFilter);
 	}
+#endif
 }
 
 bool Mouse3DInput::onSiEvent(void* siGetEventData)
 {
+#ifdef CC_MAC_HID
+	// Not used on macOS - the HIDWorker thread drives the signals directly
+	Q_UNUSED(siGetEventData)
+	return false;
+#else
 	if (m_siHandle == SI_NO_HANDLE || !siGetEventData)
 	{
 		return false;
@@ -267,6 +331,7 @@ bool Mouse3DInput::onSiEvent(void* siGetEventData)
 	}
 
 	return true;
+#endif
 }
 
 void Mouse3DInput::move3d(std::vector<float>& motionData)
@@ -298,6 +363,20 @@ void Mouse3DInput::GetMatrix(const std::vector<float>& vec, ccGLMatrixd& mat)
 {
 	assert(vec.size() == 6);
 
+#ifdef CC_MAC_HID
+	// Platform-neutral Rodrigues rotation: the rotation vector (-rx, ry, -rz)
+	// encodes both the axis (direction) and the angle (magnitude).
+	CCVector3d axis(-vec[3], vec[4], -vec[5]);
+	double     angle = axis.norm();
+	if (CCCoreLib::GreaterThanEpsilon(angle))
+	{
+		mat.initFromParameters(angle, axis, CCVector3d(0, 0, 0));
+	}
+	else
+	{
+		mat.toIdentity();
+	}
+#else
 	float axis[3] = {-vec[3], vec[4], -vec[5]};
 
 	Matrix Rd;
@@ -309,6 +388,7 @@ void Mouse3DInput::GetMatrix(const std::vector<float>& vec, ccGLMatrixd& mat)
 		mat.getColumn(i)[1] = Rd[1][i];
 		mat.getColumn(i)[2] = Rd[2][i];
 	}
+#endif
 }
 
 void Mouse3DInput::Apply(const std::vector<float>& motionData, ccGLWindowInterface* win)

--- a/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput.cpp
+++ b/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput.cpp
@@ -134,15 +134,12 @@ bool Mouse3DInput::connect(QWidget* mainWidget, QString appName)
 		return false;
 	}
 
-	QObject::connect(m_hidWorker, &HIDWorker::sigMove3d,
-	                 this, [this](std::vector<float> v)
-	                 { Q_EMIT sigMove3d(v); }, Qt::QueuedConnection);
-	QObject::connect(m_hidWorker, &HIDWorker::sigReleased,
-	                 this, &Mouse3DInput::sigReleased, Qt::QueuedConnection);
-	QObject::connect(m_hidWorker, &HIDWorker::sigOn3dmouseKeyDown,
-	                 this, &Mouse3DInput::sigOn3dmouseKeyDown, Qt::QueuedConnection);
-	QObject::connect(m_hidWorker, &HIDWorker::sigOn3dmouseKeyUp,
-	                 this, &Mouse3DInput::sigOn3dmouseKeyUp, Qt::QueuedConnection);
+	QObject::connect(m_hidWorker, &HIDWorker::sigMove3d, this, [this](std::vector<float> v)
+	                 { Q_EMIT sigMove3d(v); },
+	                 Qt::QueuedConnection);
+	QObject::connect(m_hidWorker, &HIDWorker::sigReleased, this, &Mouse3DInput::sigReleased, Qt::QueuedConnection);
+	QObject::connect(m_hidWorker, &HIDWorker::sigOn3dmouseKeyDown, this, &Mouse3DInput::sigOn3dmouseKeyDown, Qt::QueuedConnection);
+	QObject::connect(m_hidWorker, &HIDWorker::sigOn3dmouseKeyUp, this, &Mouse3DInput::sigOn3dmouseKeyUp, Qt::QueuedConnection);
 
 	m_hidWorker->start();
 	return true;

--- a/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput.cpp
+++ b/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput.cpp
@@ -364,9 +364,15 @@ void Mouse3DInput::GetMatrix(const std::vector<float>& vec, ccGLMatrixd& mat)
 	assert(vec.size() == 6);
 
 #ifdef CC_MAC_HID
-	// Platform-neutral Rodrigues rotation: the rotation vector (-rx, ry, -rz)
+	// Platform-neutral Rodrigues rotation: the rotation vector (rx, ry, rz)
 	// encodes both the axis (direction) and the angle (magnitude).
-	CCVector3d axis(-vec[3], vec[4], -vec[5]);
+	// The sign conventions are handled in Mouse3DInput_mac.cpp::processMotion.
+	//
+	// The rotation axis stays in camera space. rotateBaseViewMat() does
+	// viewMat = rotMat * viewMat (pre-multiply), which applies the rotation
+	// in camera space - exactly like the regular mouse drag does. This makes
+	// the rotation relative to the current view direction automatically.
+	CCVector3d axis(vec[3], vec[4], vec[5]);
 	double     angle = axis.norm();
 	if (CCCoreLib::GreaterThanEpsilon(angle))
 	{
@@ -486,5 +492,34 @@ void Mouse3DInput::Apply(const std::vector<float>& motionData, ccGLWindowInterfa
 		win->showPivotSymbol(false);
 	}
 
-	win->redraw();
+	// Enable LOD during 3D mouse interaction so that large clouds/meshes are
+	// decimated while moving - just like normal mouse interaction does.
+	// LOD stays enabled after the movement stops and the standard LOD refresh
+	// cycle progressively restores full quality.
+	bool hasMotion = false;
+	for (size_t i = 0; i < 6; ++i)
+	{
+		if (CCCoreLib::GreaterThanEpsilon(std::abs(vec[i])))
+		{
+			hasMotion = true;
+			break;
+		}
+	}
+	if (hasMotion)
+	{
+		// Enable LOD and signal that the 3D mouse is driving the view. This
+		// sets the internal 'mouse moved' flag so that meshes are decimated
+		// during interaction (just like dragging the regular mouse), and LOD
+		// is activated so that large clouds are rendered at a reduced level
+		// until the movement stops.
+		win->setLODEnabled(true);
+		win->set3DMouseActive(true);
+		win->redraw(false, false);
+	}
+	else
+	{
+		// No motion (e.g. a zero report) - let the LOD refinement cycle run.
+		win->set3DMouseActive(false);
+		win->redraw();
+	}
 }

--- a/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput.cpp
+++ b/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput.cpp
@@ -21,8 +21,8 @@
 
 #include "Mouse3DInput.h"
 
-#ifdef CC_MAC_HID
-#include "Mouse3DInput_mac.h"
+#ifdef CC_3DMOUSE_HID
+#include "Mouse3DInput_hid.h"
 #endif
 
 // qCC_db
@@ -43,8 +43,8 @@
 #include <windows.h>
 #endif
 
-#ifdef CC_MAC_HID
-// hidapi (HID path for macOS) - Mouse3DInput_mac.cpp provides the HIDWorker
+#ifdef CC_3DMOUSE_HID
+// hidapi - Mouse3DInput_hid.cpp provides the HIDWorker
 #else
 // 3DxWare
 #include <si.h>
@@ -59,7 +59,7 @@ static const double c_3dmouseAngularVelocity = 1.0e-6;
 // Unique instance
 static Mouse3DInput* s_mouseInputInstance = nullptr;
 
-#ifndef CC_MAC_HID
+#ifndef CC_3DMOUSE_HID
 #include <QAbstractNativeEventFilter>
 class RawInputEventFilter : public QAbstractNativeEventFilter
 {
@@ -81,11 +81,11 @@ class RawInputEventFilter : public QAbstractNativeEventFilter
 	}
 };
 static RawInputEventFilter s_rawInputEventFilter;
-#endif // CC_MAC_HID
+#endif // CC_3DMOUSE_HID
 
 Mouse3DInput::Mouse3DInput(QObject* parent)
     : QObject(parent)
-#ifdef CC_MAC_HID
+#ifdef CC_3DMOUSE_HID
     , m_siHandle(nullptr)
     , m_hidWorker(nullptr)
 #else
@@ -99,7 +99,7 @@ Mouse3DInput::Mouse3DInput(QObject* parent)
 
 Mouse3DInput::~Mouse3DInput()
 {
-#ifdef CC_MAC_HID
+#ifdef CC_3DMOUSE_HID
 	disconnectDriver();
 #endif
 	// Unregister current instance
@@ -117,14 +117,14 @@ bool Mouse3DInput::connect(QWidget* mainWidget, QString appName)
 		return false;
 	}
 
-#ifdef CC_MAC_HID
+#ifdef CC_3DMOUSE_HID
 	Q_UNUSED(mainWidget)
 	Q_UNUSED(appName)
 
 	// Required for Qt::QueuedConnection across thread boundaries.
 	qRegisterMetaType<std::vector<float>>("std::vector<float>");
 
-	// macOS path: drive the device directly via hidapi (HIDWorker thread)
+	// drive the device directly via hidapi (HIDWorker thread)
 	m_hidWorker = new HIDWorker(this);
 	if (!m_hidWorker->openDevice())
 	{
@@ -214,7 +214,7 @@ bool Mouse3DInput::connect(QWidget* mainWidget, QString appName)
 
 void Mouse3DInput::disconnectDriver()
 {
-#ifdef CC_MAC_HID
+#ifdef CC_3DMOUSE_HID
 	if (m_hidWorker)
 	{
 		m_hidWorker->stop();
@@ -235,8 +235,8 @@ void Mouse3DInput::disconnectDriver()
 
 bool Mouse3DInput::onSiEvent(void* siGetEventData)
 {
-#ifdef CC_MAC_HID
-	// Not used on macOS - the HIDWorker thread drives the signals directly
+#ifdef CC_3DMOUSE_HID
+	// Not used with hidapi - the HIDWorker thread drives the signals directly
 	Q_UNUSED(siGetEventData)
 	return false;
 #else
@@ -360,10 +360,10 @@ void Mouse3DInput::GetMatrix(const std::vector<float>& vec, ccGLMatrixd& mat)
 {
 	assert(vec.size() == 6);
 
-#ifdef CC_MAC_HID
+#ifdef CC_3DMOUSE_HID
 	// Platform-neutral Rodrigues rotation: the rotation vector (rx, ry, rz)
 	// encodes both the axis (direction) and the angle (magnitude).
-	// The sign conventions are handled in Mouse3DInput_mac.cpp::processMotion.
+	// The sign conventions are handled in Mouse3DInput_hid.cpp::processMotion.
 	//
 	// The rotation axis stays in camera space. rotateBaseViewMat() does
 	// viewMat = rotMat * viewMat (pre-multiply), which applies the rotation

--- a/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput.h
+++ b/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput.h
@@ -32,6 +32,11 @@
 
 class ccGLWindowInterface;
 
+#ifdef CC_MAC_HID
+// Forward declaration - the HIDWorker thread is defined in Mouse3DInput_mac.h
+class HIDWorker;
+#endif
+
 //! 3DxWare driver wrapper for 3D mouse handling
 class CCAPPCOMMON_LIB_API Mouse3DInput : public QObject
 {
@@ -304,4 +309,9 @@ class CCAPPCOMMON_LIB_API Mouse3DInput : public QObject
 
 	//! 3DxWare handle
 	void* m_siHandle;
+
+#ifdef CC_MAC_HID
+	//! HID-based worker thread (macOS path via hidapi)
+	HIDWorker* m_hidWorker = nullptr;
+#endif
 };

--- a/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput.h
+++ b/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput.h
@@ -32,8 +32,8 @@
 
 class ccGLWindowInterface;
 
-#ifdef CC_MAC_HID
-// Forward declaration - the HIDWorker thread is defined in Mouse3DInput_mac.h
+#ifdef CC_3DMOUSE_HID
+// Forward declaration - the HIDWorker thread is defined in Mouse3DInput_hid.h
 class HIDWorker;
 #endif
 
@@ -310,8 +310,8 @@ class CCAPPCOMMON_LIB_API Mouse3DInput : public QObject
 	//! 3DxWare handle
 	void* m_siHandle;
 
-#ifdef CC_MAC_HID
-	//! HID-based worker thread (macOS path via hidapi)
+#ifdef CC_3DMOUSE_HID
+	//! HID-based worker thread (via hidapi)
 	HIDWorker* m_hidWorker = nullptr;
 #endif
 };

--- a/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_hid.cpp
+++ b/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_hid.cpp
@@ -15,12 +15,12 @@
 // #                                                                        #
 // ##########################################################################
 
-// macOS-only HID-based implementation of the 3DConnexion 3D mouse support.
+// HID-based implementation of the 3DConnexion 3D mouse support.
 // Drives the device directly via hidapi, without the proprietary 3DxWare SDK.
 
-#ifdef CC_MAC_HID
+#ifdef CC_3DMOUSE_HID
 
-#include "Mouse3DInput_mac.h"
+#include "Mouse3DInput_hid.h"
 
 #include "Mouse3DInput.h"
 
@@ -48,7 +48,7 @@ static constexpr unsigned short c_old3dconnexionVID = 0x046d;
 //! Object angular velocity per mouse tick (in radians per ms per count)
 //! Mirrors the definition in Mouse3DInput.cpp (Windows path uses eventData.period,
 //! which is roughly the report period in ms - we use the polling period instead).
-static const double c_3dmouseAngularVelocity_mac = 1.0e-6;
+static const double c_3dmouseAngularVelocity_hid = 1.0e-6;
 //! Polling period (ms) - approximately 60 Hz
 static constexpr int c_hidPollPeriodMs = 16;
 
@@ -181,7 +181,7 @@ bool HIDWorker::openDevice()
 	}
 
 	// Blocking reads with a timeout - avoids the spurious -1 returns that
-	// non-blocking hid_read produces on macOS when no data is available.
+	// non-blocking hid_read produces when no data is available.
 	// stop() still terminates the loop because we check m_running each
 	// iteration and the timeout bounds how long we wait.
 	hid_set_nonblocking(m_handle, 0);
@@ -443,7 +443,7 @@ void HIDWorker::processMotion(const unsigned char* buf, int n)
 
 	// Scaling: progressive (non-linear) curve so small deflections stay fine
 	// while large deflections are amplified for fast navigation.
-	double ds = c_hidPollPeriodMs * c_3dmouseAngularVelocity_mac;
+	double ds = c_hidPollPeriodMs * c_3dmouseAngularVelocity_hid;
 
 	std::vector<float> axes(6);
 	// NDOF axis mapping with Y/Z swap (matching spacenavd's DF_SWAPYZ flag).
@@ -512,4 +512,4 @@ void HIDWorker::processButtons(const unsigned char* buf, int n, unsigned int& pr
 	prevButtonMask = curButtonMask;
 }
 
-#endif // CC_MAC_HID
+#endif // CC_3DMOUSE_HID

--- a/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_hid.h
+++ b/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_hid.h
@@ -18,9 +18,9 @@
 // ##########################################################################
 
 // Internal header - defines the HIDWorker thread used on macOS.
-// Guarded by CC_MAC_HID (defined by CMake on APPLE so that AUTOMOC can see it).
+// Guarded by CC_3DMOUSE_HID (defined by CMake on APPLE so that AUTOMOC can see it).
 
-#ifdef CC_MAC_HID
+#ifdef CC_3DMOUSE_HID
 
 #include "Mouse3DInput.h"
 
@@ -97,4 +97,4 @@ class HIDWorker : public QThread
 	int m_lastAxes[6] = {0, 0, 0, 0, 0, 0};
 };
 
-#endif // CC_MAC_HID
+#endif // CC_3DMOUSE_HID

--- a/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.cpp
+++ b/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.cpp
@@ -1,0 +1,361 @@
+// ##########################################################################
+// #                                                                        #
+// #                              CLOUDCOMPARE                              #
+// #                                                                        #
+// #  This program is free software; you can redistribute it and/or modify  #
+// #  it under the terms of the GNU General Public License as published by  #
+// #  the Free Software Foundation; version 2 or later of the License.      #
+// #                                                                        #
+// #  This program is distributed in the hope that it will be useful,       #
+// #  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+// #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
+// #  GNU General Public License for more details.                          #
+// #                                                                        #
+// #          COPYRIGHT: CloudCompare project                               #
+// #                                                                        #
+// ##########################################################################
+
+// macOS-only HID-based implementation of the 3DConnexion 3D mouse support.
+// Drives the device directly via hidapi, without the proprietary 3DxWare SDK.
+
+#ifdef CC_MAC_HID
+
+#include "Mouse3DInput_mac.h"
+
+#include "Mouse3DInput.h"
+
+// qCC_db
+#include <ccLog.h>
+
+// system
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <wchar.h>
+
+// 3DConnexion vendor id
+static constexpr unsigned short c_3dconnexionVID = 0x256f;
+
+//! Object angular velocity per mouse tick (in radians per ms per count)
+//! Mirrors the definition in Mouse3DInput.cpp (Windows path uses eventData.period,
+//! which is roughly the report period in ms - we use the polling period instead).
+static const double c_3dmouseAngularVelocity_mac = 1.0e-6;
+//! Polling period (ms) - approximately 60 Hz
+static constexpr int c_hidPollPeriodMs = 16;
+
+//! Overall speed multiplier (calibrated for Blender-like feel).
+static constexpr float c_3dmouseGain = 1.5f;
+//! Reference deflection for the progressive curve (typical HID full-scale ~±350).
+static constexpr float c_3dmouseProgressiveRef = 250.0f;
+
+//! Progressive (non-linear) axis scaling: small deflections stay fine, large
+//! deflections get amplified. Curve: out = raw * (1 + |raw|/ref) * gain * ds.
+static float scaleAxis(int raw, double ds)
+{
+	float a            = static_cast<float>(raw);
+	float progressive  = 1.0f + std::min(std::abs(a) / c_3dmouseProgressiveRef, 1.0f);
+	return a * progressive * c_3dmouseGain * static_cast<float>(ds);
+}
+
+//! Maps a button bitmask bit to a Mouse3DInput::VirtualKey value.
+//! Layout documented by the spacenavd / 3DConnexion HID community.
+static const int c_buttonMap[] = {
+	Mouse3DInput::V3DK_FIT,    // bit 0
+	Mouse3DInput::V3DK_MENU,   // bit 1
+	Mouse3DInput::V3DK_TOP,    // bit 2
+	Mouse3DInput::V3DK_LEFT,   // bit 3
+	Mouse3DInput::V3DK_RIGHT,  // bit 4
+	Mouse3DInput::V3DK_FRONT,  // bit 5
+	Mouse3DInput::V3DK_BOTTOM, // bit 6
+	Mouse3DInput::V3DK_BACK,   // bit 7
+};
+static constexpr size_t c_buttonMapSize = sizeof(c_buttonMap) / sizeof(c_buttonMap[0]);
+
+bool HIDWorker::openDevice()
+{
+	hid_device_info* devs = hid_enumerate(c_3dconnexionVID, 0x0);
+	if (!devs)
+	{
+		ccLog::Warning("[3D Mouse] No 3DConnexion HID device found");
+		return false;
+	}
+
+	// Preferred interface: Generic Desktop page (0x01), Multi-axis Controller usage (0x08).
+	// This is the interface that carries the 6-DOF motion reports. The SpaceMouse Wireless
+	// exposes several HID interfaces; the others (e.g. Pointer, Consumer Control) do not.
+	hid_device_info* cur = devs;
+	for (; cur; cur = cur->next)
+	{
+		if (cur->usage_page == 0x01 && cur->usage == 0x08)
+		{
+			m_handle = hid_open_path(cur->path);
+			if (m_handle)
+			{
+				m_devicePath = cur->path;
+				QString name = (cur->product_string ? QString::fromWCharArray(cur->product_string) : QStringLiteral("3DConnexion device"));
+				ccLog::Print(QString("[3D Mouse] Device: %1 (HID)").arg(name));
+				break;
+			}
+		}
+	}
+
+	// Fallback: first openable interface (for older devices that don't expose a
+	// distinct multi-axis usage).
+	if (!m_handle)
+	{
+		cur = devs;
+		for (; cur; cur = cur->next)
+		{
+			m_handle = hid_open_path(cur->path);
+			if (m_handle)
+			{
+				m_devicePath = cur->path;
+				QString name = (cur->product_string ? QString::fromWCharArray(cur->product_string) : QStringLiteral("3DConnexion device"));
+				ccLog::Print(QString("[3D Mouse] Device: %1 (HID, fallback)").arg(name));
+				break;
+			}
+		}
+	}
+
+	hid_free_enumeration(devs);
+
+	if (!m_handle)
+	{
+		ccLog::Warning("[3D Mouse] Could not open any 3DConnexion HID device "
+		               "(is the 3Dconnexion driver holding it exclusively?)");
+		return false;
+	}
+
+	// Blocking reads with a timeout - avoids the spurious -1 returns that
+	// non-blocking hid_read produces on macOS when no data is available.
+	// stop() still terminates the loop because we check m_running each
+	// iteration and the timeout bounds how long we wait.
+	hid_set_nonblocking(m_handle, 0);
+	return true;
+}
+
+void HIDWorker::closeDevice()
+{
+	if (m_handle)
+	{
+		hid_close(m_handle);
+		m_handle = nullptr;
+	}
+}
+
+void HIDWorker::run()
+{
+	m_running.store(true);
+
+	// State for button edge detection
+	unsigned int prevButtonMask = 0;
+	// State for "released" emission (analogous to SI_ZERO_EVENT on Windows)
+	auto         lastMotionTime = std::chrono::steady_clock::now();
+	bool         motionActive    = false;
+
+	unsigned char buf[80] = {0};
+
+	// Give up only after this many consecutive read errors (e.g. device unplugged).
+	constexpr int kMaxConsecutiveErrors = 100;
+	int           consecutiveErrors      = 0;
+
+	// Read with a timeout so the loop stays responsive to m_running changes
+	// and doesn't busy-poll. hid_read_timeout returns 0 on timeout (not -1).
+	constexpr int kReadTimeoutMs = 100;
+
+	while (m_running.load())
+	{
+		int n = hid_read_timeout(m_handle, buf, sizeof(buf), kReadTimeoutMs);
+		if (n < 0)
+		{
+			// Genuine read error (device unplugged, I/O error).
+			++consecutiveErrors;
+			if (consecutiveErrors >= kMaxConsecutiveErrors)
+			{
+				ccLog::Warning("[3D Mouse] Too many HID read errors, giving up");
+				break;
+			}
+			QThread::msleep(c_hidPollPeriodMs);
+			continue;
+		}
+		consecutiveErrors = 0;
+
+		if (n == 0)
+		{
+			// Timeout - no report available. Emit "released" after a quiet
+			// period, analogous to SI_ZERO_EVENT on Windows.
+			if (motionActive)
+			{
+				auto now     = std::chrono::steady_clock::now();
+				auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - lastMotionTime).count();
+				if (elapsed > 100)
+				{
+					Q_EMIT sigReleased();
+					motionActive = false;
+				}
+			}
+			continue; // hid_read_timeout already waited kReadTimeoutMs
+		}
+
+		// Identify the report type. The SpaceMouse Wireless sends 13-byte motion
+		// reports (report ID 0x01 + 6 int16 axes). Older devices send 7-byte
+		// reports (report ID 0x01 + 6 int8 axes, or just 6 int8 axes without ID).
+		// Button reports have report ID 0x03.
+		if (n >= 13 && buf[0] == 0x01)
+		{
+			processMotion(buf, n);
+			lastMotionTime = std::chrono::steady_clock::now();
+			motionActive   = true;
+		}
+		else if (n >= 2 && buf[0] == 0x03)
+		{
+			processButtons(buf, n, prevButtonMask);
+		}
+		else if (n == 7)
+		{
+			// Older devices / setups that omit the report ID prefix (6 int8 axes).
+			processMotion(buf, n);
+			lastMotionTime = std::chrono::steady_clock::now();
+			motionActive   = true;
+		}
+		else
+		{
+			// Unknown report - silently ignore known harmless status reports
+			// (e.g. 0x17 = battery/status). Log other unknowns a few times
+			// to aid debugging.
+			if (buf[0] != 0x17)
+			{
+				static int s_unknownCount = 0;
+				if (++s_unknownCount <= 5)
+				{
+					QString hex;
+					for (int i = 0; i < n; ++i)
+						hex += QString("%1 ").arg(buf[i], 2, 16, QLatin1Char('0'));
+					ccLog::Print(QString("[3D Mouse] Unknown report (%1 bytes): %2").arg(n).arg(hex));
+				}
+			}
+		}
+	}
+}
+
+void HIDWorker::processMotion(const unsigned char* buf, int /*n*/)
+{
+	// Motion report layout (SpaceMouse Wireless, 13 bytes):
+	//   buf[0]    = 0x01 (report ID)
+	//   buf[1..2] = tx (int16 little-endian)
+	//   buf[3..4] = ty
+	//   buf[5..6] = tz
+	//   buf[7..8] = rx
+	//   buf[9..10]= ry
+	//   buf[11..12]=rz
+	// Older devices may send a 7-byte report (report ID + 6 int8 axes);
+	// we handle both by branching on n.
+	const unsigned char* p = buf;
+	int                  axisBytes = 2; // int16 by default
+	if (buf[0] == 0x01)
+	{
+		p = buf + 1;
+	}
+	else
+	{
+		// No report ID prefix (older devices) - 6 int8 axes.
+		axisBytes = 1;
+	}
+
+	auto readAxis = [&](int offset) -> int
+	{
+		if (axisBytes == 2)
+		{
+			signed short v = static_cast<signed short>(p[offset] | (p[offset + 1] << 8));
+			return static_cast<int>(v);
+		}
+		else
+		{
+			return static_cast<int>(static_cast<signed char>(p[offset]));
+		}
+	};
+
+	int tx = readAxis(0);
+	int ty = readAxis(2);
+	int tz = readAxis(4);
+	int rx = readAxis(6);
+	int ry = readAxis(8);
+	int rz = readAxis(10);
+
+	if (tx == 0 && ty == 0 && tz == 0 && rx == 0 && ry == 0 && rz == 0)
+	{
+		// No motion - don't fire a move event.
+		return;
+	}
+
+	// Scaling: progressive (non-linear) curve so small deflections stay fine
+	// while large deflections are amplified for fast navigation.
+	double ds = c_hidPollPeriodMs * c_3dmouseAngularVelocity_mac;
+
+	std::vector<float> axes(6);
+	// Blender-default NDOF axis mapping (see Blender manual, Input → NDOF).
+	// Blender swaps the device's physical Y (forward/back) and Z (lift/compress)
+	// relative to the raw HID report, so that pushing the cap forward zooms and
+	// lifting the cap pans vertically. Sign conventions calibrated for
+	// object-centric navigation in CloudCompare:
+	//   tx (cap left/right)    -> pan X      (cap left  -> object left)
+	//   tz (cap lift/compress) -> pan Y      (cap up    -> object up)
+	//   ty (cap forward/back)  -> zoom       (cap fwd   -> zoom in)
+	//   rx (pitch)             -> orbit X    (tilt back -> object up)
+	//   ry (roll)              -> orbit Y
+	//   rz (yaw / twist)       -> orbit Z
+	axes[0] = -scaleAxis(tx, ds); // pan X
+	axes[1] = -scaleAxis(tz, ds); // pan Y (Blender swap)
+	axes[2] = -scaleAxis(ty, ds); // zoom   (Blender swap)
+	axes[3] =  scaleAxis(rx, ds); // orbit X (inverted for natural pitch)
+	axes[4] =  scaleAxis(ry, ds); // orbit Y
+	axes[5] =  scaleAxis(rz, ds); // orbit Z
+
+	Q_EMIT sigMove3d(axes);
+}
+
+void HIDWorker::processButtons(const unsigned char* buf, int n, unsigned int& prevButtonMask)
+{
+	// Button report layout: [0x03, buttonBitmaskLow, (buttonBitmaskHigh ...)]
+	unsigned int curButtonMask = 0;
+	if (n >= 2)
+	{
+		curButtonMask = static_cast<unsigned int>(buf[1]);
+		if (n >= 3)
+		{
+			curButtonMask |= static_cast<unsigned int>(buf[2]) << 8;
+		}
+	}
+
+	// Detect edges.
+	unsigned int pressed  = curButtonMask & ~prevButtonMask;
+	unsigned int released = ~curButtonMask & prevButtonMask;
+
+	for (size_t bit = 0; bit < c_buttonMapSize; ++bit)
+	{
+		unsigned int mask = 1u << bit;
+		if (pressed & mask)
+		{
+			Q_EMIT sigOn3dmouseKeyDown(c_buttonMap[bit]);
+		}
+		if (released & mask)
+		{
+			Q_EMIT sigOn3dmouseKeyUp(c_buttonMap[bit]);
+		}
+	}
+
+	// For any bit beyond the static mapping table, emit a generic warning once per press.
+	for (size_t bit = c_buttonMapSize; bit < 8 * sizeof(unsigned int); ++bit)
+	{
+		unsigned int mask = 1u << bit;
+		if (pressed & mask)
+		{
+			ccLog::Warning(QString("[3D mouse] Unmapped button pressed (bit %1)").arg(static_cast<int>(bit)));
+		}
+	}
+
+	prevButtonMask = curButtonMask;
+}
+
+#endif // CC_MAC_HID

--- a/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.cpp
+++ b/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.cpp
@@ -27,10 +27,14 @@
 // qCC_db
 #include <ccLog.h>
 
+// Qt
+#include <QProcess>
+
 // system
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstdio>
 #include <cstring>
 #include <wchar.h>
 
@@ -56,6 +60,32 @@ static float scaleAxis(int raw, double ds)
 	float a            = static_cast<float>(raw);
 	float progressive  = 1.0f + std::min(std::abs(a) / c_3dmouseProgressiveRef, 1.0f);
 	return a * progressive * c_3dmouseGain * static_cast<float>(ds);
+}
+
+#ifdef CC_HID_DEBUG
+//! Logs a raw HID report as a hex string. Only compiled when CC_HID_DEBUG is
+//! defined (CMake option OPTION_HID_DEBUG). Used to diagnose device-specific
+//! report formats (e.g. SpaceMouse Compact vs Wireless).
+static void logHidReport(const char* label, const unsigned char* buf, int n)
+{
+	QString hex;
+	hex.reserve(n * 3);
+	for (int i = 0; i < n; ++i)
+	{
+		hex += QString::asprintf("%02x ", buf[i]);
+	}
+	ccLog::Print(QString("[3D Mouse] %1 (%2 bytes): %3").arg(label).arg(n).arg(hex.trimmed()));
+}
+#endif // CC_HID_DEBUG
+
+//! Returns true if the 3Dconnexion driver daemon (3DConnexionHelper.app) is
+//! currently running. On macOS it holds an exclusive lock on 3DConnexion HID
+//! devices and silently consumes reports, so our hid_read returns 0 forever.
+static bool is3dConnexionHelperRunning()
+{
+	// pgrep -x matches the exact process name. Exit code 0 == found.
+	int exitCode = QProcess::execute(QStringLiteral("pgrep"), {QStringLiteral("-x"), QStringLiteral("3DConnexionHelper")});
+	return exitCode == 0;
 }
 
 //! Maps a button bitmask bit to a Mouse3DInput::VirtualKey value.
@@ -127,6 +157,17 @@ bool HIDWorker::openDevice()
 		return false;
 	}
 
+	// Warn if the 3Dconnexion driver daemon is running: it holds an exclusive
+	// lock on the device and silently consumes reports, so our hid_read would
+	// return 0 forever. The user must quit 3DConnexionHelper.app (System
+	// Settings -> General -> Login Items / Background) for the HID path to work.
+	if (is3dConnexionHelperRunning())
+	{
+		ccLog::Warning("[3D Mouse] 3DConnexionHelper.app is running and will "
+		               "intercept the device. Quit it (System Settings -> "
+		               "General -> Login Items / Background) to use the HID path.");
+	}
+
 	// Blocking reads with a timeout - avoids the spurious -1 returns that
 	// non-blocking hid_read produces on macOS when no data is available.
 	// stop() still terminates the loop because we check m_running each
@@ -154,6 +195,14 @@ void HIDWorker::run()
 	auto         lastMotionTime = std::chrono::steady_clock::now();
 	bool         motionActive    = false;
 
+	// Tracks whether any report has ever arrived. Used to warn the user once
+	// if no reports arrive within the first few seconds of running, which
+	// typically means the 3Dconnexion driver daemon is holding an exclusive
+	// lock on the device and silently consuming reports.
+	auto         threadStartTime = lastMotionTime;
+	bool         warnedNoReports = false;
+	bool         anyReportArrived = false;
+
 	unsigned char buf[80] = {0};
 
 	// Give up only after this many consecutive read errors (e.g. device unplugged).
@@ -163,6 +212,8 @@ void HIDWorker::run()
 	// Read with a timeout so the loop stays responsive to m_running changes
 	// and doesn't busy-poll. hid_read_timeout returns 0 on timeout (not -1).
 	constexpr int kReadTimeoutMs = 100;
+	// If no report arrives within this many ms of startup, warn the user once.
+	constexpr int kNoReportsWarnMs = 2000;
 
 	while (m_running.load())
 	{
@@ -195,22 +246,53 @@ void HIDWorker::run()
 					motionActive = false;
 				}
 			}
+			// Warn once if no report has arrived at all within the first few
+			// seconds - usually means the 3DConnexion driver is holding the
+			// device exclusively.
+			if (!anyReportArrived && !warnedNoReports)
+			{
+				auto elapsedSinceStart = std::chrono::duration_cast<std::chrono::milliseconds>(
+				    std::chrono::steady_clock::now() - threadStartTime).count();
+				if (elapsedSinceStart >= kNoReportsWarnMs)
+				{
+					warnedNoReports = true;
+					ccLog::Warning("[3D Mouse] No HID reports received from the "
+					               "device. If the 3DConnexion driver (3DConnexion"
+					               "Helper.app) is running, quit it - it intercepts "
+					               "the device and prevents the HID path from "
+					               "seeing reports.");
+				}
+			}
 			continue; // hid_read_timeout already waited kReadTimeoutMs
 		}
+
+		anyReportArrived = true;
+
+#ifdef CC_HID_DEBUG
+		logHidReport("report", buf, n);
+#endif
 
 		// Identify the report type. The SpaceMouse Wireless sends 13-byte motion
 		// reports (report ID 0x01 + 6 int16 axes). Older devices send 7-byte
 		// reports (report ID 0x01 + 6 int8 axes, or just 6 int8 axes without ID).
 		// Button reports have report ID 0x03.
-		if (n >= 13 && buf[0] == 0x01)
+		//
+		// Some wired devices (e.g. SpaceMouse Compact) may use a different
+		// report ID for motion. To be robust, treat any 13-byte report that is
+		// not a known button report (ID 0x03) as a potential motion report and
+		// attempt to parse it; processMotion() will skip it if all axes are zero.
+		if (n >= 2 && buf[0] == 0x03)
 		{
+			processButtons(buf, n, prevButtonMask);
+		}
+		else if (n >= 13)
+		{
+			// Motion report (report ID 0x01 on SpaceMouse Wireless, possibly
+			// a different ID on other devices). processMotion() reads the
+			// first byte as the report ID and skips it when parsing axes.
 			processMotion(buf, n);
 			lastMotionTime = std::chrono::steady_clock::now();
 			motionActive   = true;
-		}
-		else if (n >= 2 && buf[0] == 0x03)
-		{
-			processButtons(buf, n, prevButtonMask);
 		}
 		else if (n == 7)
 		{
@@ -239,27 +321,34 @@ void HIDWorker::run()
 	}
 }
 
-void HIDWorker::processMotion(const unsigned char* buf, int /*n*/)
+void HIDWorker::processMotion(const unsigned char* buf, int n)
 {
 	// Motion report layout (SpaceMouse Wireless, 13 bytes):
-	//   buf[0]    = 0x01 (report ID)
+	//   buf[0]    = report ID (0x01 on SpaceMouse Wireless; may differ on other
+	//               devices such as the wired SpaceMouse Compact)
 	//   buf[1..2] = tx (int16 little-endian)
 	//   buf[3..4] = ty
 	//   buf[5..6] = tz
 	//   buf[7..8] = rx
 	//   buf[9..10]= ry
 	//   buf[11..12]=rz
-	// Older devices may send a 7-byte report (report ID + 6 int8 axes);
-	// we handle both by branching on n.
+	// Older devices may send a 7-byte report (6 int8 axes, no report ID).
+	//
+	// We treat the first byte as a report ID whenever n >= 13 (i.e. there is
+	// room for 6 int16 axes after it). For 7-byte reports there is no report
+	// ID prefix - all 7 bytes are 6 int8 axes (impossible to have a 13-byte
+	// int8 report from a real device, so this disambiguation is safe).
 	const unsigned char* p = buf;
 	int                  axisBytes = 2; // int16 by default
-	if (buf[0] == 0x01)
+	if (n >= 13)
 	{
+		// Skip the report ID prefix regardless of its value - the caller has
+		// already routed us here knowing this is a motion-sized report.
 		p = buf + 1;
 	}
 	else
 	{
-		// No report ID prefix (older devices) - 6 int8 axes.
+		// No report ID prefix (older 7-byte devices) - 6 int8 axes.
 		axisBytes = 1;
 	}
 

--- a/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.cpp
+++ b/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.cpp
@@ -130,8 +130,10 @@ bool HIDWorker::openDevice()
 		}
 	}
 
-	// Fallback: first openable interface (for older devices that don't expose a
-	// distinct multi-axis usage).
+	// Fallback: first openable interface. This is typically only reached when
+	// 3DConnexionHelper.app is running (it creates virtual HID interfaces that
+	// don't carry the Multi-axis Controller usage), or on devices that simply
+	// don't expose that usage descriptor (e.g. the wired SpaceMouse Compact).
 	if (!m_handle)
 	{
 		cur = devs;
@@ -213,7 +215,9 @@ void HIDWorker::run()
 	// and doesn't busy-poll. hid_read_timeout returns 0 on timeout (not -1).
 	constexpr int kReadTimeoutMs = 100;
 	// If no report arrives within this many ms of startup, warn the user once.
-	constexpr int kNoReportsWarnMs = 2000;
+	// The threshold is deliberately generous: some users take a few seconds
+	// before they interact with the cap, and we don't want a false alarm.
+	constexpr int kNoReportsWarnMs = 5000;
 
 	while (m_running.load())
 	{
@@ -247,8 +251,9 @@ void HIDWorker::run()
 				}
 			}
 			// Warn once if no report has arrived at all within the first few
-			// seconds - usually means the 3DConnexion driver is holding the
-			// device exclusively.
+			// seconds after the worker thread started. This usually means the
+			// 3DConnexion driver is holding the device exclusively, but it can
+			// also happen if the user simply hasn't touched the cap yet.
 			if (!anyReportArrived && !warnedNoReports)
 			{
 				auto elapsedSinceStart = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -256,11 +261,12 @@ void HIDWorker::run()
 				if (elapsedSinceStart >= kNoReportsWarnMs)
 				{
 					warnedNoReports = true;
-					ccLog::Warning("[3D Mouse] No HID reports received from the "
-					               "device. If the 3DConnexion driver (3DConnexion"
-					               "Helper.app) is running, quit it - it intercepts "
-					               "the device and prevents the HID path from "
-					               "seeing reports.");
+					ccLog::Warning("[3D Mouse] No HID reports received yet. "
+					               "If you have moved the cap and nothing happens, "
+					               "make sure the 3DConnexion driver "
+					               "(3DConnexionHelper.app) is not running - it "
+					               "intercepts the device and prevents the HID "
+					               "path from seeing reports.");
 				}
 			}
 			continue; // hid_read_timeout already waited kReadTimeoutMs
@@ -272,16 +278,14 @@ void HIDWorker::run()
 		logHidReport("report", buf, n);
 #endif
 
-		// Identify the report type. The SpaceMouse Wireless sends 13-byte motion
-		// reports (report ID 0x01 + 6 int16 axes). Older devices send 7-byte
-		// reports (report ID 0x01 + 3 int16 axes for translation, or 7-byte
-		// reports (report ID 0x02 + 3 int16 axes for rotation,
-		// Button reports have report ID 0x03.
-		//
-		// Some wired devices (e.g. SpaceMouse Compact) may use a different
-		// report ID for motion. To be robust, treat any 13-byte report that is
-		// not a known button report (ID 0x03) as a potential motion report and
-		// attempt to parse it; processMotion() will skip it if all axes are zero.
+		// Identify the report type.
+		// - SpaceMouse Wireless: 13-byte combined motion report (report ID 0x01
+		//   + 6 int16 axes).
+		// - SpaceMouse Compact: 7-byte separate reports (report ID 0x01 = 3 int16
+		//   translation axes, report ID 0x02 = 3 int16 rotation axes).
+		// - Button reports: report ID 0x03.
+		// Any 13-byte report that is not a button report is treated as a combined
+		// motion report; processMotion() handles the axis parsing.
 		if (n >= 2 && buf[0] == 0x03)
 		{
 			processButtons(buf, n, prevButtonMask);
@@ -297,7 +301,7 @@ void HIDWorker::run()
 		}
 		else if (n == 7)
 		{
-			// Older devices / setups with separate translation and rotation reports
+			// Separate translation/rotation report (SpaceMouse Compact).
 			processMotion(buf, n);
 			lastMotionTime = std::chrono::steady_clock::now();
 			motionActive   = true;
@@ -324,98 +328,101 @@ void HIDWorker::run()
 
 void HIDWorker::processMotion(const unsigned char* buf, int n)
 {
-	// Motion report layout (SpaceMouse Wireless, 13 bytes):
-	//   buf[0]    = report ID (0x01 on SpaceMouse Wireless; may differ on other
-	//               devices such as the wired SpaceMouse Compact)
-	//   buf[1..2] = tx (int16 little-endian)
-	//   buf[3..4] = ty
-	//   buf[5..6] = tz
-	//   buf[7..8] = rx
-	//   buf[9..10]= ry
-	//   buf[11..12]=rz
-	// Motion report layout (SpaceMouse Compact, 7 bytes):
-	//   buf[0]    = report ID (0x01 for translation on SpaceMouse Compact)
-	//   buf[1..2] = tx (int16 little-endian)
-	//   buf[3..4] = ty
-	//   buf[5..6] = tz
-	//   buf[0]    = report ID (0x02 for rotation on SpaceMouse Compact)
-	//   buf[1..2] = rx (int16 little-endian)
-	//   buf[3..4] = ry
-	//   buf[5..6] = rz
+	// Motion report layouts:
 	//
-	// We treat the first byte as a report ID whenever n >= 13 (i.e. there is
-	// room for 6 int16 axes after it). For 7-byte reports the report ID is used
-	// to distinguish translation vs rotation.
+	// SpaceMouse Wireless (13 bytes, combined):
+	//   buf[0]     = report ID (0x01)
+	//   buf[1..2]  = tx (int16 little-endian)
+	//   buf[3..4]  = ty
+	//   buf[5..6]  = tz
+	//   buf[7..8]  = rx
+	//   buf[9..10] = ry
+	//   buf[11..12]= rz
+	//
+	// SpaceMouse Compact (7 bytes, separate translation/rotation):
+	//   buf[0]     = 0x01 (translation)  |  0x02 (rotation)
+	//   buf[1..2]  = tx / rx
+	//   buf[3..4]  = ty / ry
+	//   buf[5..6]  = tz / rz
+	//
+	// The Compact sends translation and rotation as two separate reports. To
+	// keep movement smooth, we buffer the last known values of all 6 axes in
+	// m_lastAxes: a translation report updates only tx/ty/tz, a rotation report
+	// only rx/ry/rz, and we always emit the full 6-axis vector. Combined reports
+	// (Wireless) overwrite all 6 at once.
+	enum ReportKind
+	{
+		Combined,     // 13-byte, all 6 axes
+		Translation,  // 7-byte, ID 0x01, 3 translation axes
+		Rotation      // 7-byte, ID 0x02, 3 rotation axes
+	};
+
 	const unsigned char* p = buf;
-	int                  axisBytes = 2; // int16 by default
-	bool isTranslationReport = true; //	assume translation by default (only false for 7-byte rotation reports)	
-	bool isRotationReport = true;    // assume rotation by default (only false for 7-byte translation reports)
+	ReportKind            kind = Combined;
+
 	if (n >= 13)
 	{
-		// Skip the report ID prefix regardless of its value - the caller has
-		// already routed us here knowing this is a motion-sized report.
+		// Combined report - skip the report ID prefix.
 		p = buf + 1;
 	}
 	else if (n == 7)
 	{
 		if (buf[0] == 0x01)
 		{
-			// 7-byte translation report (SpaceMouse Compact)
-			isRotationReport = false;
+			kind = Translation;
 		}
 		else if (buf[0] == 0x02)
 		{
-			// 7-byte rotation report (SpaceMouse Compact)
-			isTranslationReport = false;
+			kind = Rotation;
 		}
 		else
 		{
 			ccLog::Warning(QString("[3D Mouse] Unknown 7-byte motion report ID: %1").arg(buf[0]));
-			return; // unknown report ID - ignore
+			return;
 		}
-		p = buf + 1; // the report ID prefix is already read 
+		p = buf + 1;
 	}
 	else
 	{
 		ccLog::Warning(QString("[3D Mouse] Unexpected motion report size: %1").arg(n));
-		return; // unknown report size - ignore
+		return;
 	}
 
 	auto readAxis = [&](int offset) -> int
 	{
-		if (axisBytes == 2)
-		{
-			signed short v = static_cast<signed short>(p[offset] | (p[offset + 1] << 8));
-			return static_cast<int>(v);
-		}
-		else
-		{
-			return static_cast<int>(static_cast<signed char>(p[offset]));
-		}
+		signed short v = static_cast<signed short>(p[offset] | (p[offset + 1] << 8));
+		return static_cast<int>(v);
 	};
 
-	int tx = 0, ty = 0, tz = 0, rx = 0, ry = 0, rz = 0;
-	if (isTranslationReport and isRotationReport)
+	// Update the axis buffer based on the report kind.
+	switch (kind)
 	{
-		tx = readAxis(0);
-		ty = readAxis(2);
-		tz = readAxis(4);
-		rx = readAxis(6);
-		ry = readAxis(8);
-		rz = readAxis(10);
+	case Combined:
+		m_lastAxes[0] = readAxis(0);
+		m_lastAxes[1] = readAxis(2);
+		m_lastAxes[2] = readAxis(4);
+		m_lastAxes[3] = readAxis(6);
+		m_lastAxes[4] = readAxis(8);
+		m_lastAxes[5] = readAxis(10);
+		break;
+	case Translation:
+		m_lastAxes[0] = readAxis(0);
+		m_lastAxes[1] = readAxis(2);
+		m_lastAxes[2] = readAxis(4);
+		break;
+	case Rotation:
+		m_lastAxes[3] = readAxis(0);
+		m_lastAxes[4] = readAxis(2);
+		m_lastAxes[5] = readAxis(4);
+		break;
 	}
-	else if (isTranslationReport)
-	{
-		tx = readAxis(0);
-		ty = readAxis(2);
-		tz = readAxis(4);
-	}
-	else if (isRotationReport)
-	{
-		rx = readAxis(0);
-		ry = readAxis(2);
-		rz = readAxis(4);
-	}	
+
+	int tx = m_lastAxes[0];
+	int ty = m_lastAxes[1];
+	int tz = m_lastAxes[2];
+	int rx = m_lastAxes[3];
+	int ry = m_lastAxes[4];
+	int rz = m_lastAxes[5];
 
 	if (tx == 0 && ty == 0 && tz == 0 && rx == 0 && ry == 0 && rz == 0)
 	{
@@ -428,23 +435,25 @@ void HIDWorker::processMotion(const unsigned char* buf, int n)
 	double ds = c_hidPollPeriodMs * c_3dmouseAngularVelocity_mac;
 
 	std::vector<float> axes(6);
-	// Blender-default NDOF axis mapping (see Blender manual, Input → NDOF).
-	// Blender swaps the device's physical Y (forward/back) and Z (lift/compress)
-	// relative to the raw HID report, so that pushing the cap forward zooms and
-	// lifting the cap pans vertically. Sign conventions calibrated for
-	// object-centric navigation in CloudCompare:
-	//   tx (cap left/right)    -> pan X      (cap left  -> object left)
-	//   tz (cap lift/compress) -> pan Y      (cap up    -> object up)
-	//   ty (cap forward/back)  -> zoom       (cap fwd   -> zoom in)
-	//   rx (pitch)             -> orbit X    (tilt back -> object up)
-	//   ry (roll)              -> orbit Y
-	//   rz (yaw / twist)       -> orbit Z
+	// NDOF axis mapping with Y/Z swap (matching spacenavd's DF_SWAPYZ flag).
+	// The device HID coordinate system uses Y=forward/back, Z=up/down, but
+	// CloudCompare's world coordinate system uses Y=up/down, Z=forward/back.
+	// We swap Y and Z for both translation and rotation so that the device's
+	// physical axes align with the on-screen world.
+	//
+	// spacenavd also inverts Y and Z values (DF_INVYZ). Combined swap+invert:
+	//   tx (cap left/right)      -> pan X    = -tx
+	//   tz (cap lift/compress)   -> pan Y    = -tz  (device Z -> CC Y, swap+invert)
+	//   ty (cap forward/back)    -> zoom     = -ty  (device Y -> CC Z, swap+invert)
+	//   rx (pitch)               -> orbit X  = +rx  (no swap, no invert)
+	//   rz (yaw / twist)         -> orbit Y  = -rz  (device RZ -> CC RY, swap+invert)
+	//   ry (roll / tilt sideways)-> orbit Z  = -ry  (device RY -> CC RZ, swap+invert)
 	axes[0] = -scaleAxis(tx, ds); // pan X
-	axes[1] = -scaleAxis(tz, ds); // pan Y (Blender swap)
-	axes[2] = -scaleAxis(ty, ds); // zoom   (Blender swap)
-	axes[3] =  scaleAxis(rx, ds); // orbit X (inverted for natural pitch)
-	axes[4] =  scaleAxis(ry, ds); // orbit Y
-	axes[5] =  scaleAxis(rz, ds); // orbit Z
+	axes[1] = -scaleAxis(tz, ds); // pan Y (Y/Z swap)
+	axes[2] = -scaleAxis(ty, ds); // zoom   (Y/Z swap)
+	axes[3] =  scaleAxis(rx, ds); // orbit X
+	axes[4] = -scaleAxis(rz, ds); // orbit Y (Y/Z swap)
+	axes[5] =  scaleAxis(ry, ds); // orbit Z (Y/Z swap)
 
 	Q_EMIT sigMove3d(axes);
 }

--- a/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.cpp
+++ b/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.cpp
@@ -274,7 +274,8 @@ void HIDWorker::run()
 
 		// Identify the report type. The SpaceMouse Wireless sends 13-byte motion
 		// reports (report ID 0x01 + 6 int16 axes). Older devices send 7-byte
-		// reports (report ID 0x01 + 6 int8 axes, or just 6 int8 axes without ID).
+		// reports (report ID 0x01 + 3 int16 axes for translation, or 7-byte
+		// reports (report ID 0x02 + 3 int16 axes for rotation,
 		// Button reports have report ID 0x03.
 		//
 		// Some wired devices (e.g. SpaceMouse Compact) may use a different
@@ -296,7 +297,7 @@ void HIDWorker::run()
 		}
 		else if (n == 7)
 		{
-			// Older devices / setups that omit the report ID prefix (6 int8 axes).
+			// Older devices / setups with separate translation and rotation reports
 			processMotion(buf, n);
 			lastMotionTime = std::chrono::steady_clock::now();
 			motionActive   = true;
@@ -332,24 +333,52 @@ void HIDWorker::processMotion(const unsigned char* buf, int n)
 	//   buf[7..8] = rx
 	//   buf[9..10]= ry
 	//   buf[11..12]=rz
-	// Older devices may send a 7-byte report (6 int8 axes, no report ID).
+	// Motion report layout (SpaceMouse Compact, 7 bytes):
+	//   buf[0]    = report ID (0x01 for translation on SpaceMouse Compact)
+	//   buf[1..2] = tx (int16 little-endian)
+	//   buf[3..4] = ty
+	//   buf[5..6] = tz
+	//   buf[0]    = report ID (0x02 for rotation on SpaceMouse Compact)
+	//   buf[1..2] = rx (int16 little-endian)
+	//   buf[3..4] = ry
+	//   buf[5..6] = rz
 	//
 	// We treat the first byte as a report ID whenever n >= 13 (i.e. there is
-	// room for 6 int16 axes after it). For 7-byte reports there is no report
-	// ID prefix - all 7 bytes are 6 int8 axes (impossible to have a 13-byte
-	// int8 report from a real device, so this disambiguation is safe).
+	// room for 6 int16 axes after it). For 7-byte reports the report ID is used
+	// to distinguish translation vs rotation.
 	const unsigned char* p = buf;
 	int                  axisBytes = 2; // int16 by default
+	bool isTranslationReport = true; //	assume translation by default (only false for 7-byte rotation reports)	
+	bool isRotationReport = true;    // assume rotation by default (only false for 7-byte translation reports)
 	if (n >= 13)
 	{
 		// Skip the report ID prefix regardless of its value - the caller has
 		// already routed us here knowing this is a motion-sized report.
 		p = buf + 1;
 	}
+	else if (n == 7)
+	{
+		if (buf[0] == 0x01)
+		{
+			// 7-byte translation report (SpaceMouse Compact)
+			isRotationReport = false;
+		}
+		else if (buf[0] == 0x02)
+		{
+			// 7-byte rotation report (SpaceMouse Compact)
+			isTranslationReport = false;
+		}
+		else
+		{
+			ccLog::Warning(QString("[3D Mouse] Unknown 7-byte motion report ID: %1").arg(buf[0]));
+			return; // unknown report ID - ignore
+		}
+		p = buf + 1; // the report ID prefix is already read 
+	}
 	else
 	{
-		// No report ID prefix (older 7-byte devices) - 6 int8 axes.
-		axisBytes = 1;
+		ccLog::Warning(QString("[3D Mouse] Unexpected motion report size: %1").arg(n));
+		return; // unknown report size - ignore
 	}
 
 	auto readAxis = [&](int offset) -> int
@@ -365,12 +394,28 @@ void HIDWorker::processMotion(const unsigned char* buf, int n)
 		}
 	};
 
-	int tx = readAxis(0);
-	int ty = readAxis(2);
-	int tz = readAxis(4);
-	int rx = readAxis(6);
-	int ry = readAxis(8);
-	int rz = readAxis(10);
+	int tx = 0, ty = 0, tz = 0, rx = 0, ry = 0, rz = 0;
+	if (isTranslationReport and isRotationReport)
+	{
+		tx = readAxis(0);
+		ty = readAxis(2);
+		tz = readAxis(4);
+		rx = readAxis(6);
+		ry = readAxis(8);
+		rz = readAxis(10);
+	}
+	else if (isTranslationReport)
+	{
+		tx = readAxis(0);
+		ty = readAxis(2);
+		tz = readAxis(4);
+	}
+	else if (isRotationReport)
+	{
+		rx = readAxis(0);
+		ry = readAxis(2);
+		rz = readAxis(4);
+	}	
 
 	if (tx == 0 && ty == 0 && tz == 0 && rx == 0 && ry == 0 && rz == 0)
 	{

--- a/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.cpp
+++ b/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.cpp
@@ -38,8 +38,12 @@
 #include <cstring>
 #include <wchar.h>
 
-// 3DConnexion vendor id
-static constexpr unsigned short c_3dconnexionVID = 0x256f;
+// 3DConnexion vendor IDs.
+// Newer devices (since ~2016) use 0x256f. Older devices (SpaceNavigator,
+// SpaceExplorer, SpacePilot, etc.) use the Logitech vendor ID 0x046d.
+// See https://3dconnexion.com/uk/support/faq/how-can-i-check-if-my-usb-3d-mouse-is-recognized-by-windows/
+static constexpr unsigned short c_3dconnexionVID    = 0x256f;
+static constexpr unsigned short c_old3dconnexionVID = 0x046d;
 
 //! Object angular velocity per mouse tick (in radians per ms per count)
 //! Mirrors the definition in Mouse3DInput.cpp (Windows path uses eventData.period,
@@ -57,8 +61,8 @@ static constexpr float c_3dmouseProgressiveRef = 250.0f;
 //! deflections get amplified. Curve: out = raw * (1 + |raw|/ref) * gain * ds.
 static float scaleAxis(int raw, double ds)
 {
-	float a            = static_cast<float>(raw);
-	float progressive  = 1.0f + std::min(std::abs(a) / c_3dmouseProgressiveRef, 1.0f);
+	float a           = static_cast<float>(raw);
+	float progressive = 1.0f + std::min(std::abs(a) / c_3dmouseProgressiveRef, 1.0f);
 	return a * progressive * c_3dmouseGain * static_cast<float>(ds);
 }
 
@@ -91,20 +95,26 @@ static bool is3dConnexionHelperRunning()
 //! Maps a button bitmask bit to a Mouse3DInput::VirtualKey value.
 //! Layout documented by the spacenavd / 3DConnexion HID community.
 static const int c_buttonMap[] = {
-	Mouse3DInput::V3DK_FIT,    // bit 0
-	Mouse3DInput::V3DK_MENU,   // bit 1
-	Mouse3DInput::V3DK_TOP,    // bit 2
-	Mouse3DInput::V3DK_LEFT,   // bit 3
-	Mouse3DInput::V3DK_RIGHT,  // bit 4
-	Mouse3DInput::V3DK_FRONT,  // bit 5
-	Mouse3DInput::V3DK_BOTTOM, // bit 6
-	Mouse3DInput::V3DK_BACK,   // bit 7
+    Mouse3DInput::V3DK_FIT,    // bit 0
+    Mouse3DInput::V3DK_MENU,   // bit 1
+    Mouse3DInput::V3DK_TOP,    // bit 2
+    Mouse3DInput::V3DK_LEFT,   // bit 3
+    Mouse3DInput::V3DK_RIGHT,  // bit 4
+    Mouse3DInput::V3DK_FRONT,  // bit 5
+    Mouse3DInput::V3DK_BOTTOM, // bit 6
+    Mouse3DInput::V3DK_BACK,   // bit 7
 };
 static constexpr size_t c_buttonMapSize = sizeof(c_buttonMap) / sizeof(c_buttonMap[0]);
 
 bool HIDWorker::openDevice()
 {
 	hid_device_info* devs = hid_enumerate(c_3dconnexionVID, 0x0);
+	if (!devs)
+	{
+		// Fall back to the legacy Logitech vendor ID for older 3DConnexion
+		// devices (SpaceNavigator, SpaceExplorer, SpacePilot, etc.).
+		devs = hid_enumerate(c_old3dconnexionVID, 0x0);
+	}
 	if (!devs)
 	{
 		ccLog::Warning("[3D Mouse] No 3DConnexion HID device found");
@@ -194,22 +204,22 @@ void HIDWorker::run()
 	// State for button edge detection
 	unsigned int prevButtonMask = 0;
 	// State for "released" emission (analogous to SI_ZERO_EVENT on Windows)
-	auto         lastMotionTime = std::chrono::steady_clock::now();
-	bool         motionActive    = false;
+	auto lastMotionTime = std::chrono::steady_clock::now();
+	bool motionActive   = false;
 
 	// Tracks whether any report has ever arrived. Used to warn the user once
 	// if no reports arrive within the first few seconds of running, which
 	// typically means the 3Dconnexion driver daemon is holding an exclusive
 	// lock on the device and silently consuming reports.
-	auto         threadStartTime = lastMotionTime;
-	bool         warnedNoReports = false;
-	bool         anyReportArrived = false;
+	auto threadStartTime  = lastMotionTime;
+	bool warnedNoReports  = false;
+	bool anyReportArrived = false;
 
 	unsigned char buf[80] = {0};
 
 	// Give up only after this many consecutive read errors (e.g. device unplugged).
 	constexpr int kMaxConsecutiveErrors = 100;
-	int           consecutiveErrors      = 0;
+	int           consecutiveErrors     = 0;
 
 	// Read with a timeout so the loop stays responsive to m_running changes
 	// and doesn't busy-poll. hid_read_timeout returns 0 on timeout (not -1).
@@ -257,7 +267,8 @@ void HIDWorker::run()
 			if (!anyReportArrived && !warnedNoReports)
 			{
 				auto elapsedSinceStart = std::chrono::duration_cast<std::chrono::milliseconds>(
-				    std::chrono::steady_clock::now() - threadStartTime).count();
+				                             std::chrono::steady_clock::now() - threadStartTime)
+				                             .count();
 				if (elapsedSinceStart >= kNoReportsWarnMs)
 				{
 					warnedNoReports = true;
@@ -352,13 +363,13 @@ void HIDWorker::processMotion(const unsigned char* buf, int n)
 	// (Wireless) overwrite all 6 at once.
 	enum ReportKind
 	{
-		Combined,     // 13-byte, all 6 axes
-		Translation,  // 7-byte, ID 0x01, 3 translation axes
-		Rotation      // 7-byte, ID 0x02, 3 rotation axes
+		Combined,    // 13-byte, all 6 axes
+		Translation, // 7-byte, ID 0x01, 3 translation axes
+		Rotation     // 7-byte, ID 0x02, 3 rotation axes
 	};
 
-	const unsigned char* p = buf;
-	ReportKind            kind = Combined;
+	const unsigned char* p    = buf;
+	ReportKind           kind = Combined;
 
 	if (n >= 13)
 	{
@@ -451,9 +462,9 @@ void HIDWorker::processMotion(const unsigned char* buf, int n)
 	axes[0] = -scaleAxis(tx, ds); // pan X
 	axes[1] = -scaleAxis(tz, ds); // pan Y (Y/Z swap)
 	axes[2] = -scaleAxis(ty, ds); // zoom   (Y/Z swap)
-	axes[3] =  scaleAxis(rx, ds); // orbit X
+	axes[3] = scaleAxis(rx, ds);  // orbit X
 	axes[4] = -scaleAxis(rz, ds); // orbit Y (Y/Z swap)
-	axes[5] =  scaleAxis(ry, ds); // orbit Z (Y/Z swap)
+	axes[5] = scaleAxis(ry, ds);  // orbit Z (Y/Z swap)
 
 	Q_EMIT sigMove3d(axes);
 }

--- a/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.h
+++ b/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.h
@@ -1,0 +1,86 @@
+#pragma once
+
+// ##########################################################################
+// #                                                                        #
+// #                              CLOUDCOMPARE                              #
+// #                                                                        #
+// #  This program is free software; you can redistribute it and/or modify  #
+// #  it under the terms of the GNU General Public License as published by  #
+// #  the Free Software Foundation; version 2 or later of the License.      #
+// #                                                                        #
+// #  This program is distributed in the hope that it will be useful,       #
+// #  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+// #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
+// #  GNU General Public License for more details.                          #
+// #                                                                        #
+// #          COPYRIGHT: CloudCompare project                               #
+// #                                                                        #
+// ##########################################################################
+
+// Internal header - defines the HIDWorker thread used on macOS.
+// Guarded by CC_MAC_HID (defined by CMake on APPLE so that AUTOMOC can see it).
+
+#ifdef CC_MAC_HID
+
+#include "Mouse3DInput.h"
+
+// Qt
+#include <QMetaType>
+#include <QThread>
+
+// system
+#include <atomic>
+#include <vector>
+
+// hidapi
+#include <hidapi/hidapi.h>
+
+class HIDWorker : public QThread
+{
+	Q_OBJECT
+
+  public:
+	explicit HIDWorker(Mouse3DInput* parent)
+	    : QThread(parent)
+	    , m_parent(parent)
+	{
+	}
+
+	~HIDWorker() override
+	{
+		stop();
+		if (isRunning())
+		{
+			wait();
+		}
+		closeDevice();
+	}
+
+	//! Opens the first available 3DConnexion HID device.
+	bool openDevice();
+
+	//! Closes the HID device (idempotent).
+	void closeDevice();
+
+	void stop() { m_running.store(false); }
+
+  Q_SIGNALS:
+	void sigMove3d(std::vector<float> motionData);
+	void sigReleased();
+	void sigOn3dmouseKeyDown(int virtualKeyCode);
+	void sigOn3dmouseKeyUp(int virtualKeyCode);
+
+  protected:
+	void run() override;
+
+  private:
+	void processMotion(const unsigned char* buf, int n);
+	void processButtons(const unsigned char* buf, int n, unsigned int& prevButtonMask);
+
+	hid_device*      m_handle = nullptr;
+	std::atomic_bool m_running{false};
+	Mouse3DInput*    m_parent;
+	QString          m_devicePath;
+};
+
+#endif // CC_MAC_HID

--- a/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.h
+++ b/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.h
@@ -66,7 +66,10 @@ class HIDWorker : public QThread
 	//! Closes the HID device (idempotent).
 	void closeDevice();
 
-	void stop() { m_running.store(false); }
+	void stop()
+	{
+		m_running.store(false);
+	}
 
   Q_SIGNALS:
 	void sigMove3d(std::vector<float> motionData);

--- a/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.h
+++ b/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.h
@@ -85,6 +85,13 @@ class HIDWorker : public QThread
 	std::atomic_bool m_running{false};
 	Mouse3DInput*    m_parent;
 	QString          m_devicePath;
+
+	//! Last known raw axis values (tx, ty, tz, rx, ry, rz).
+	//! Used to merge separate translation and rotation reports (SpaceMouse
+	//! Compact) into a single 6-axis motion event, so that movement stays
+	//! smooth. Combined reports (SpaceMouse Wireless) overwrite all 6 at
+	//! once and are not affected by this buffer.
+	int m_lastAxes[6] = {0, 0, 0, 0, 0, 0};
 };
 
 #endif // CC_MAC_HID

--- a/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.h
+++ b/libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.h
@@ -33,7 +33,11 @@
 #include <vector>
 
 // hidapi
-#include <hidapi/hidapi.h>
+// The in-tree hidapi submodule (extern/hidapi) puts its header directory on the
+// include path via the hidapi_include INTERFACE target, so the header is
+// available as <hidapi.h>. The <hidapi/hidapi.h> form only works when hidapi
+// is installed system-wide (e.g. Homebrew) which we don't want to require.
+#include <hidapi.h>
 
 class HIDWorker : public QThread
 {

--- a/libs/CCAppCommon/devices/3dConnexion/cc3DMouseManager.cpp
+++ b/libs/CCAppCommon/devices/3dConnexion/cc3DMouseManager.cpp
@@ -320,6 +320,11 @@ void cc3DMouseManager::on3DMouseReleased()
 	if (win == nullptr)
 		return;
 
+	// The 3D mouse is no longer driving the view: clear the 'mouse moved'
+	// flag so that the LOD refinement cycle can resume and restore full
+	// rendering quality.
+	win->set3DMouseActive(false);
+
 	if (win->getPivotVisibility() == ccGLWindowInterface::PIVOT_SHOW_ON_MOVE)
 	{
 		// we have to hide the pivot symbol!

--- a/libs/qCC_glWindow/include/ccGLWindowInterface.h
+++ b/libs/qCC_glWindow/include/ccGLWindowInterface.h
@@ -381,6 +381,14 @@ class CCGLWINDOW_LIB_API ccGLWindowInterface : public ccGenericGLDisplay
 	//! Sets current interaction flags
 	void setInteractionMode(INTERACTION_FLAGS flags);
 
+	//! Notifies the window that a 3D mouse is currently driving the view
+	/** This enables mesh decimation-on-move (the same behaviour as when the
+	    regular mouse is dragged) so that interaction with large meshes stays
+	    smooth. Call with false when the 3D mouse is released so that the
+	    standard LOD refinement cycle can restore full quality.
+	**/
+	void set3DMouseActive(bool state);
+
 	//! Returns the current interaction flags
 	inline virtual INTERACTION_FLAGS getInteractionMode() const
 	{

--- a/libs/qCC_glWindow/src/ccGLWindowInterface.cpp
+++ b/libs/qCC_glWindow/src/ccGLWindowInterface.cpp
@@ -4409,6 +4409,16 @@ void ccGLWindowInterface::setInteractionMode(INTERACTION_FLAGS flags)
 	}
 }
 
+void ccGLWindowInterface::set3DMouseActive(bool state)
+{
+	// While a 3D mouse is driving the view we set m_mouseMoved so that
+	// decimateMeshOnMove is active (see display parameter setup). This
+	// mirrors the behaviour of a regular mouse drag, giving smooth
+	// interaction with large meshes. When the 3D mouse is released,
+	// m_mouseMoved is cleared so the LOD refinement cycle can run.
+	m_mouseMoved = state;
+}
+
 void ccGLWindowInterface::doDragEnterEvent(QDragEnterEvent* event)
 {
 	const QMimeData* mimeData = event->mimeData();

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -139,7 +139,7 @@
 #include "pluginManager/ccPluginUIManager.h"
 
 // 3D mouse handler
-#ifdef CC_3DXWARE_SUPPORT
+#ifdef CC_3DMOUSE_SUPPORT
 #include "cc3DMouseManager.h"
 #endif
 
@@ -444,19 +444,16 @@ void MainWindow::decreasePointSize()
 
 void MainWindow::setupInputDevices()
 {
-#ifdef CC_3DXWARE_SUPPORT
+#ifdef CC_3DMOUSE_SUPPORT
 	m_3DMouseManager = new cc3DMouseManager(this, this);
 	m_UI->menuFile->insertMenu(m_UI->actionCloseAll, m_3DMouseManager->menu());
-#endif
-
-#if defined(CC_3DXWARE_SUPPORT)
 	m_UI->menuFile->insertSeparator(m_UI->actionCloseAll);
 #endif
 }
 
 void MainWindow::destroyInputDevices()
 {
-#ifdef CC_3DXWARE_SUPPORT
+#ifdef CC_3DMOUSE_SUPPORT
 	delete m_3DMouseManager;
 	m_3DMouseManager = nullptr;
 #endif


### PR DESCRIPTION
## Summary

The 3D mouse support was previously Windows-only (via the proprietary 3DxWare SDK). On macOS, CloudCompare could not use a SpaceMouse at all unless the 3Dconnexion driver injected fake mouse/keyboard events.

This PR adds a platform-independent HID path that talks to 3DConnexion devices directly via [hidapi](https://github.com/libusb/hidapi), without the 3DxWare SDK.

## Changes

- **New `HIDWorker` thread** (`Mouse3DInput_mac.{h,cpp}`): a `QThread` that polls the device with `hid_read_timeout` and emits the existing `sigMove3d` / `sigReleased` / `sigOn3dmouseKey*` signals, so `cc3DMouseManager` stays unchanged.
- **Motion reports** (report ID `0x01`, 13 bytes) are parsed as 6 int16 axes; **button reports** (report ID `0x03`) are mapped to `VirtualKey` values via a static table. Battery/status reports (`0x17`) are silently ignored.
- **Axis mapping** follows the Blender NDOF default (Y/Z swapped relative to the raw HID report) with a progressive (non-linear) speed curve for fine control at small deflections and fast navigation at large deflections.
- **`GetMatrix()`** gains a platform-neutral Rodrigues rotation fallback so it no longer depends on `SPW_ArbitraryAxisToMatrix`.
- **hidapi** is pulled in as a Git submodule under `extern/hidapi` and built via `add_subdirectory`; no Homebrew/system dependency required.
- The **Windows 3DxWare path** is left untouched behind `#ifndef CC_MAC_HID`.

## Files

| File | Action |
|---|---|
| `libs/CCAppCommon/devices/3dConnexion/CMakeLists.txt` | modified – macOS build gate via hidapi submodule |
| `libs/CCAppCommon/devices/3dConnexion/Mouse3DInput.h` | modified – `HIDWorker*` member behind `#ifdef CC_MAC_HID` |
| `libs/CCAppCommon/devices/3dConnexion/Mouse3DInput.cpp` | modified – `#ifdef CC_MAC_HID` / `#else` split for `connect()`, `disconnectDriver()`, `onSiEvent()`, `GetMatrix()` |
| `libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.h` | new – `HIDWorker` class definition |
| `libs/CCAppCommon/devices/3dConnexion/Mouse3DInput_mac.cpp` | new – HID report parsing + worker thread |
| `extern/hidapi` | new – Git submodule (libusb/hidapi) |
| `.gitmodules` | modified – submodule entry |

`cc3DMouseManager.*` and `mainwindow.cpp` are unchanged.

## Build

```bash
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_PREFIX_PATH="$(brew --prefix qt@6)/lib/cmake" \
    -DOPTION_SUPPORT_3DCONNEXION_DEVICES=ON
cmake --build build -j$(sysctl -n hw.ncpu)
```

`OPTION_SUPPORT_3DCONNEXION_DEVICES` defaults to `ON` on macOS when the hidapi submodule is present.

## Test plan

- [x] Tested with a **SpaceMouse Wireless** on macOS 15 (Apple Silicon)
- [x] Cap translation: pan X/Y and zoom behave like Blender/Fusion360 (object-centric)
- [x] Cap rotation: orbit X/Y/Z
- [x] Buttons: `FIT`, `MENU`, `TOP`, `LEFT`, `RIGHT`, `FRONT`, `BOTTOM`, `BACK` mapped
- [x] Thread shuts down cleanly on exit (no crash, no `wait()` deadlock)
- [ ] Tested on older 7-byte (int8) report devices — code path included but not verified with hardware
- [ ] Tested on SpaceMouse Pro / SpaceMouse Compact — would appreciate feedback from users with those models

## Notes

- The 3Dconnexion driver (`3DconnexionUtilities.app`) may hold the HID device exclusively; users should quit it if `hid_open_path` fails.
- macOS may prompt for Input Monitoring permission on first launch.

Assisted-by: opencode:glm-5.2