### PR TITLE
Load E57 timestamps as scalar fields, show scalar fields in the point picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,7 @@ Improvements:
 			preserving the image sensor definition
 		- CC will now properly handle the case when a reflective transformation has been applied to a cloud (see bug fixes)
 		- Empty scans will not trigger an error anymore (just a warning message)
+		- E57 timestamps are now loaded as scalar fields
 
 	- PLY files:
 		- loading dialog: new 'Add all' button to add all the unused standard properties to be loaded as scalar fields
@@ -279,6 +280,7 @@ Improvements:
 			- A: pick 3 points and display the (a)ngles
 			- R: draw a (r)ectangle with a subtitle
 			- S: (s)ave the current label
+		- All scalar fields of the picked point are now shown in the Console.
 
 	- Cross section tool
 		- the default bounding-box is now very slightly larger than the entities bounding-box so as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,7 +280,7 @@ Improvements:
 			- A: pick 3 points and display the (a)ngles
 			- R: draw a (r)ectangle with a subtitle
 			- S: (s)ave the current label
-		- All scalar fields of the picked point are now shown in the Console.
+		- All scalar fields of the picked point are now shown in the resulting Label properties dialog.
 
 	- Cross section tool
 		- the default bounding-box is now very slightly larger than the entities bounding-box so as

--- a/libs/qCC_db/include/cc2DLabel.h
+++ b/libs/qCC_db/include/cc2DLabel.h
@@ -252,6 +252,13 @@ class QCC_DB_LIB_API cc2DLabel : public ccHObject
 	                  double&                     nearestSquareDist) const;
 
   protected:
+	//! Value of a single scalar field at the picked point
+	struct SFValue
+	{
+		QString    name;
+		ScalarType value = 0;
+	};
+
 	//! One-point label info
 	struct LabelInfo1
 	{
@@ -262,6 +269,8 @@ class QCC_DB_LIB_API cc2DLabel : public ccHObject
 		bool          hasSF;
 		ScalarType    sfValue;
 		QString       sfName;
+		//! Values of all scalar fields at the picked point (not just the displayed one)
+		std::vector<SFValue> sfValues;
 		//! Default constructor
 		LabelInfo1()
 		    : hasNormal(false)

--- a/libs/qCC_db/src/cc2DLabel.cpp
+++ b/libs/qCC_db/src/cc2DLabel.cpp
@@ -207,7 +207,7 @@ QString cc2DLabel::getTitle(int precision) const
 
 		// If available, we display the point's currently selected SF value.
 		// A point cloud may have very many scalar fields (e.g. multi-spectral data),
-		// so we show ALL of them in the Console only, not in this popup.
+		// so we show ALL of them in the Label properties dialog only, not in this popup.
 		LabelInfo1 info;
 		getLabelInfo1(info);
 		if (info.hasSF)

--- a/libs/qCC_db/src/cc2DLabel.cpp
+++ b/libs/qCC_db/src/cc2DLabel.cpp
@@ -205,7 +205,9 @@ QString cc2DLabel::getTitle(int precision) const
 		title = m_name;
 		title.replace(POINT_INDEX_0, m_pickedPoints[0].itemTitle());
 
-		// if available, we display the point SF value
+		// If available, we display the point's currently selected SF value.
+		// A point cloud may have very many scalar fields (e.g. multi-spectral data),
+		// so we show ALL of them in the Console only, not in this popup.
 		LabelInfo1 info;
 		getLabelInfo1(info);
 		if (info.hasSF)
@@ -730,6 +732,23 @@ void cc2DLabel::getLabelInfo1(LabelInfo1& info) const
 					info.sfName  = "Scalar";
 				}
 			}
+
+			// all scalar fields (not just the displayed one)
+			if (pp._cloud->isA(CC_TYPES::POINT_CLOUD))
+			{
+				ccPointCloud* pc      = static_cast<ccPointCloud*>(pp._cloud);
+				unsigned      sfCount = pc->getNumberOfScalarFields();
+				for (unsigned i = 0; i < sfCount; ++i)
+				{
+					const CCCoreLib::ScalarField* sf = pc->getScalarField(static_cast<int>(i));
+					if (!sf)
+						continue;
+					SFValue sfVal;
+					sfVal.name  = QString::fromStdString(sf->getName());
+					sfVal.value = sf->getValue(pp.index);
+					info.sfValues.push_back(sfVal);
+				}
+			}
 		}
 		else if (pp._mesh)
 		{
@@ -795,6 +814,33 @@ void cc2DLabel::getLabelInfo1(LabelInfo1& info) const
 				else
 				{
 					info.sfName = "Scalar";
+				}
+
+				// all scalar fields (not just the displayed one), interpolated on the triangle
+				if (vertices->isA(CC_TYPES::POINT_CLOUD))
+				{
+					ccPointCloud* pc      = static_cast<ccPointCloud*>(vertices);
+					unsigned      sfCount = pc->getNumberOfScalarFields();
+					for (unsigned i = 0; i < sfCount; ++i)
+					{
+						const CCCoreLib::ScalarField* asf = pc->getScalarField(static_cast<int>(i));
+						if (!asf)
+							continue;
+						ScalarType v1 = asf->getValue(vi->i1);
+						ScalarType v2 = asf->getValue(vi->i2);
+						ScalarType v3 = asf->getValue(vi->i3);
+						SFValue    sfVal;
+						sfVal.name = QString::fromStdString(asf->getName());
+						if (ccScalarField::ValidValue(v1) && ccScalarField::ValidValue(v2) && ccScalarField::ValidValue(v3))
+						{
+							sfVal.value = static_cast<ScalarType>(v1 * w.u[0] + v2 * w.u[1] + v3 * w.u[2]);
+						}
+						else
+						{
+							sfVal.value = CCCoreLib::NAN_VALUE;
+						}
+						info.sfValues.push_back(sfVal);
+					}
 				}
 			}
 		}
@@ -883,8 +929,16 @@ QStringList cc2DLabel::getLabelContent(int precision) const
 			QString colorStr = QString("Color: (%1;%2;%3;%4)").arg(info.color.r).arg(info.color.g).arg(info.color.b).arg(info.color.a);
 			body << colorStr;
 		}
-		// scalar field
-		if (info.hasSF)
+		// scalar fields
+		if (!info.sfValues.empty())
+		{
+			for (const SFValue& sfVal : info.sfValues)
+			{
+				QString valStr = (ccScalarField::ValidValue(sfVal.value) ? QString::number(sfVal.value, 'f', precision) : QString("NaN"));
+				body << QString("%1 = %2").arg(sfVal.name, valStr);
+			}
+		}
+		else if (info.hasSF)
 		{
 			QString sfVal = GetSFValueAsString(info, precision);
 			QString sfStr = QString("%1 = %2").arg(info.sfName, sfVal);

--- a/plugins/core/IO/qE57IO/src/E57Filter.cpp
+++ b/plugins/core/IO/qE57IO/src/E57Filter.cpp
@@ -50,6 +50,7 @@ namespace
 {
 	constexpr char CC_E57_INTENSITY_FIELD_NAME[]    = "Intensity";
 	constexpr char CC_E57_RETURN_INDEX_FIELD_NAME[] = "Return index";
+	constexpr char CC_E57_TIME_STAMP_FIELD_NAME[]   = "Timestamp";
 	constexpr char s_e57PoseKey[]                   = "E57_pose";
 	constexpr char s_e57NodeInfoKey[]               = "E57_node_info";
 	constexpr char s_e57CameraInfoKey[]             = "E57_camera_representation";
@@ -83,6 +84,10 @@ namespace
 		// scalar field
 		std::vector<double> intData;
 		std::vector<int8_t> isInvalidIntData;
+
+		// timestamp field
+		std::vector<double> timeData;
+		std::vector<int8_t> isInvalidTimeData;
 
 		// scan index field
 		std::vector<int8_t> scanIndexData;
@@ -2076,6 +2081,30 @@ static LoadedScan LoadScan(const e57::Node& node, QString& guidStr, ccProgressDi
 		}
 	}
 
+	// timestamp
+	ccScalarField* timeStampSF = nullptr;
+	if (header.pointFields.timeStampField)
+	{
+		timeStampSF = new ccScalarField(CC_E57_TIME_STAMP_FIELD_NAME);
+		if (!timeStampSF->resizeSafe(static_cast<unsigned>(pointCount)))
+		{
+			ccLog::Error("[E57] Not enough memory!");
+			timeStampSF->release();
+			delete cloud;
+			return {};
+		}
+		cloud->addScalarField(timeStampSF);
+
+		arrays.timeData.resize(chunkSize);
+		dbufs.emplace_back(node.destImageFile(), "timeStamp", arrays.timeData.data(), chunkSize, true, (prototype.get("timeStamp").type() == e57::E57_SCALED_INTEGER));
+
+		if (header.pointFields.isTimeStampInvalidField)
+		{
+			arrays.isInvalidTimeData.resize(chunkSize);
+			dbufs.emplace_back(node.destImageFile(), "isTimeStampInvalid", arrays.isInvalidTimeData.data(), chunkSize, true, (prototype.get("isTimeStampInvalid").type() == e57::E57_SCALED_INTEGER));
+		}
+	}
+
 	// color buffers
 	double colorRedRange    = 1;
 	double colorRedOffset   = 0;
@@ -2283,6 +2312,20 @@ static LoadedScan LoadScan(const e57::Node& node, QString& guidStr, ccProgressDi
 				}
 			}
 
+			if (!arrays.timeData.empty())
+			{
+				assert(timeStampSF);
+				if (!header.pointFields.isTimeStampInvalidField || arrays.isInvalidTimeData[i] != INVALID_DATA)
+				{
+					const ScalarType timeStamp = static_cast<ScalarType>(arrays.timeData[i]);
+					timeStampSF->setValue(static_cast<unsigned>(realCount), timeStamp);
+				}
+				else
+				{
+					timeStampSF->flagValueAsInvalid(static_cast<unsigned>(realCount));
+				}
+			}
+
 			if (hasColors)
 			{
 				// Normalize color to 0 - 255
@@ -2359,6 +2402,18 @@ static LoadedScan LoadScan(const e57::Node& node, QString& guidStr, ccProgressDi
 			intensitySF->setColorScale(ccColorScalesManager::GetDefaultScale(ccColorScalesManager::GREY));
 		cloud->setCurrentDisplayedScalarField(cloud->getScalarFieldIndexByName(intensitySF->getName()));
 		cloud->showSF(true);
+	}
+
+	if (timeStampSF)
+	{
+		timeStampSF->computeMinAndMax();
+		timeStampSF->setColorScale(ccColorScalesManager::GetDefaultScale(ccColorScalesManager::GREY));
+		// Only display the timestamps if no other scalar field is already shown (e.g. intensity).
+		if (cloud->getCurrentDisplayedScalarFieldIndex() < 0)
+		{
+			cloud->setCurrentDisplayedScalarField(cloud->getScalarFieldIndexByName(timeStampSF->getName()));
+			cloud->showSF(true);
+		}
 	}
 
 	if (returnIndexSF)


### PR DESCRIPTION
CloudCompare can already show timetamps from LAS/LAZ files, but not E57.

This adds that, and also the ability to read them from the point picker tool (popup and Console).

Screenshots:

<img width="1075" height="576" alt="image" src="https://github.com/user-attachments/assets/e0da632b-364a-4397-a410-9e81abdccd75" />

<img width="1342" height="668" alt="image" src="https://github.com/user-attachments/assets/4d46a012-2199-4666-90ab-1a56e2d65e46" />

---

This work was sponsored by the company I co-founded, [benaco.com](https://benaco.com).