### PR TITLE
Fix failure to load symlink if it points to file without extension

### DIFF
--- a/libs/qCC_io/include/FileIOFilter.h
+++ b/libs/qCC_io/include/FileIOFilter.h
@@ -323,6 +323,16 @@ class FileIOFilter
 	//! Returns the real file/path in case the input filename points to a symbolic link, shortcut or alias
 	static QString GetRealFilename(QString filename);
 
+	//! Returns the extension to use to guess the file format for the given (potentially symlinked) filename
+	/** The file format is normally guessed from the file extension.
+	    However, a symbolic link may point (possibly through several levels)
+	    to a target that has no (usable) extension.
+	    This walks the symbolic link chain and returns the first extension
+	    it finds, starting from the original filename itself.
+	    Returns an empty string if no extension is found.
+	**/
+	static QString GetExtensionForFormatGuessing(const QString& originalFilename);
+
   protected:
 	static constexpr float DEFAULT_PRIORITY = 25.0f;
 

--- a/libs/qCC_io/include/FileIOFilter.h
+++ b/libs/qCC_io/include/FileIOFilter.h
@@ -320,7 +320,7 @@ class FileIOFilter
 	Q_DECLARE_FLAGS(FilterFeatures, FilterFeature)
 
   public: // helpers
-	//! Returns the real file/path in case the input filename points to a symbolic link, shortcut or alias
+	//! Returns the real file/path in case the input filename points to a symbolic link, Windows shortcut or macOS alias
 	static QString GetRealFilename(QString filename);
 
 	//! Returns the extension to use to guess the file format for the given (potentially symlinked) filename

--- a/libs/qCC_io/src/FileIOFilter.cpp
+++ b/libs/qCC_io/src/FileIOFilter.cpp
@@ -62,6 +62,10 @@ QString FileIOFilter::GetRealFilename(QString filename)
 	{
 		// Resolve the whole symbolic link chain (not just a single level).
 		// canonicalFilePath() returns an empty string on broken links.
+		// It also resolves through Windows shortcut and macOS alias files;
+		// that is undocumented in Qt and will likely change in the future,
+		// given that `isSymlink()` is already documented to likely change, see:
+		//     https://github.com/CloudCompare/CloudCompare/pull/2341#issuecomment-4947138037
 		QString target = fi.canonicalFilePath();
 		if (!target.isEmpty())
 		{
@@ -435,8 +439,8 @@ ccHObject* FileIOFilter::LoadFromFile(const QString&  inputFilename,
 {
 	Shared filter;
 
-	// special case for symbolic link, shortcut or alias files
-	QString filename = GetRealFilename(inputFilename);
+	// special case for symbolic link, Windows shortcut or macOS alias files
+	QString resolvedFilename = GetRealFilename(inputFilename);
 
 	// if the right filter is specified by the caller
 	if (!fileFilter.isEmpty())
@@ -471,7 +475,7 @@ ccHObject* FileIOFilter::LoadFromFile(const QString&  inputFilename,
 		}
 	}
 
-	return LoadFromFile(filename, loadParameters, filter, result);
+	return LoadFromFile(resolvedFilename, loadParameters, filter, result);
 }
 
 CC_FILE_ERROR FileIOFilter::SaveToFile(ccHObject*            entities,
@@ -485,11 +489,11 @@ CC_FILE_ERROR FileIOFilter::SaveToFile(ccHObject*            entities,
 	}
 
 	// special case for symbolic link, shortcut or alias files
-	QString filename = GetRealFilename(inputFilename);
+	QString resolvedFilename = GetRealFilename(inputFilename);
 
 	// if the file name has no extension, we had a default one!
-	QString completeFileName(filename);
-	if (QFileInfo(filename).suffix().isEmpty())
+	QString completeFileName(resolvedFilename);
+	if (QFileInfo(resolvedFilename).suffix().isEmpty())
 	{
 		completeFileName += QString(".%1").arg(filter->getDefaultExtension());
 	}
@@ -501,17 +505,17 @@ CC_FILE_ERROR FileIOFilter::SaveToFile(ccHObject*            entities,
 	}
 	catch (...)
 	{
-		ccLog::Warning(QString("[I/O] CC has caught an unhandled exception while saving file '%1'").arg(filename));
+		ccLog::Warning(QString("[I/O] CC has caught an unhandled exception while saving file '%1'").arg(resolvedFilename));
 		result = CC_FERR_CONSOLE_ERROR;
 	}
 
 	if (result == CC_FERR_NO_ERROR)
 	{
-		ccLog::Print(QString("[I/O] File '%1' saved successfully").arg(filename));
+		ccLog::Print(QString("[I/O] File '%1' saved successfully").arg(resolvedFilename));
 	}
 	else
 	{
-		DisplayErrorMessage(result, "saving", filename);
+		DisplayErrorMessage(result, "saving", resolvedFilename);
 	}
 
 	return result;

--- a/libs/qCC_io/src/FileIOFilter.cpp
+++ b/libs/qCC_io/src/FileIOFilter.cpp
@@ -60,10 +60,49 @@ QString FileIOFilter::GetRealFilename(QString filename)
 	QFileInfo fi(filename);
 	if (fi.isSymLink())
 	{
-		return fi.symLinkTarget();
+		// Resolve the whole symbolic link chain (not just a single level).
+		// canonicalFilePath() returns an empty string on broken links.
+		QString target = fi.canonicalFilePath();
+		if (!target.isEmpty())
+		{
+			return target;
+		}
 	}
 
 	return filename;
+}
+
+QString FileIOFilter::GetExtensionForFormatGuessing(const QString& originalFilename)
+{
+	// Walk the symlink link chain, return the first extension found.
+	QString currentPath = originalFilename;
+
+	constexpr int maxSymLinkLevels = 40; // default on Linux 3.5
+	for (int level = 0; level < maxSymLinkLevels; ++level)
+	{
+		QFileInfo fi(currentPath);
+
+		QString extension = fi.suffix();
+		if (!extension.isEmpty())
+		{
+			return extension;
+		}
+
+		if (!fi.isSymLink())
+		{
+			break;
+		}
+
+		QString nextPath = fi.symLinkTarget();
+		if (nextPath.isEmpty() || (nextPath == currentPath))
+		{
+			break;
+		}
+
+		currentPath = nextPath;
+	}
+
+	return QString();
 }
 
 FileIOFilter::FileIOFilter(const FilterInfo& info)
@@ -412,8 +451,7 @@ ccHObject* FileIOFilter::LoadFromFile(const QString&  inputFilename,
 	}
 	else // we need to guess the I/O filter based on the file format
 	{
-		// look for file extension (we trust Qt on this task)
-		QString extension = QFileInfo(filename).suffix();
+		QString extension = GetExtensionForFormatGuessing(inputFilename);
 		if (extension.isEmpty())
 		{
 			ccLog::Error("[Load] Can't guess file format: no file extension");


### PR DESCRIPTION
Until now, CloudCompare tried to open a symlink such as

    myfile.e57 -> someFileNotEndingInDotE57

it would fail with error

    [Load] Can't guess file format: no file extension

Such cases are common in content-addressed storage systems (where the underlying files have hashes as their file names).

This commit fixes it by taking the first file extension along the symlink chain.

---

This work was sponsored by the company I co-founded, [benaco.com](https://benaco.com/).