### PR TITLE
Add -MATCH_SCALES command line option (#1034)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ New features:
 		- distances between a point cloud and a disc can be computed with 'Tools > Distances > Cloud/primitive dist'
 
 	- New Command line options
+		- New command -MATCH_SCALES {BB_MAX_DIM|BB_VOLUME|PCA_MAX_DIM|ICP} [-REFERENCE {index}] [-RMS_DIFF {value}] [-OVERLAP {percent}]
+			- ports the 'Tools > Registration > Match scales' tool to the command line
+			- rescales all loaded clouds/meshes to match the scale of the reference entity (0-based index, 0 by default)
+			- -RMS_DIFF and -OVERLAP only apply to the ICP algorithm (defaults: 1e-5 and 100 respectively)
 		- New command -DISTANCES_FROM_SENSOR [-SQUARED]
 			- to compute the distances from every point of the cloud to the associated sensor origin (if any)
 		- New command -SCATTERING_ANGLES [-DEGREES]

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -88,6 +88,10 @@ constexpr char COMMAND_REMOVE_SENSORS[]                   = "REMOVE_SENSORS";
 constexpr char COMMAND_REMOVE_RGB[]                       = "REMOVE_RGB";
 constexpr char COMMAND_REMOVE_NORMALS[]                   = "REMOVE_NORMALS";
 constexpr char COMMAND_MATCH_BB_CENTERS[]                 = "MATCH_CENTERS";
+constexpr char COMMAND_MATCH_SCALES[]                     = "MATCH_SCALES";
+constexpr char COMMAND_MATCH_SCALES_REFERENCE[]           = "REFERENCE";
+constexpr char COMMAND_MATCH_SCALES_RMS_DIFF[]            = "RMS_DIFF";
+constexpr char COMMAND_MATCH_SCALES_OVERLAP[]             = "OVERLAP";
 constexpr char COMMAND_BEST_FIT_PLANE[]                   = "BEST_FIT_PLANE";
 constexpr char COMMAND_BEST_FIT_PLANE_MAKE_HORIZ[]        = "MAKE_HORIZ";
 constexpr char COMMAND_BEST_FIT_PLANE_KEEP_LOADED[]       = "KEEP_LOADED";
@@ -3744,6 +3748,119 @@ bool CommandMatchBBCenters::process(ccCommandLineInterface& cmd)
 		cmd.print(QObject::tr("Entity '%1' has been translated: (%2,%3,%4)").arg(ent->getName()).arg(T.x).arg(T.y).arg(T.z));
 		if (cmd.autoSaveMode())
 		{
+			QString errorStr = cmd.exportEntity(*entities[i]);
+			if (!errorStr.isEmpty())
+			{
+				return cmd.error(errorStr);
+			}
+		}
+	}
+
+	return true;
+}
+
+CommandMatchScales::CommandMatchScales()
+    : ccCommandLineInterface::Command(QObject::tr("Match scales"), COMMAND_MATCH_SCALES)
+{
+}
+
+bool CommandMatchScales::process(ccCommandLineInterface& cmd)
+{
+	cmd.print(QObject::tr("[MATCH SCALES]"));
+
+	ccArgumentParser parser(cmd.arguments());
+
+	// the scale matching algorithm is a mandatory first parameter
+	const auto maybeAlgo = parser.takeEnum<ccLibAlgorithms::ScaleMatchingAlgorithm>({{"BB_MAX_DIM", ccLibAlgorithms::BB_MAX_DIM},
+	                                                                                 {"BB_VOLUME", ccLibAlgorithms::BB_VOLUME},
+	                                                                                 {"PCA_MAX_DIM", ccLibAlgorithms::PCA_MAX_DIM},
+	                                                                                 {"ICP", ccLibAlgorithms::ICP_SCALE}},
+	                                                                                QObject::tr("scale matching algorithm"));
+	if (!maybeAlgo)
+	{
+		return false;
+	}
+	const ccLibAlgorithms::ScaleMatchingAlgorithm algo = *maybeAlgo;
+
+	// optional parameters (defaults match the GUI dialog, see MainWindow::doActionMatchScales)
+	unsigned referenceIndex  = 0;
+	double   icpRmsDiff      = 1.0e-5;
+	int      icpFinalOverlap = 100;
+
+	while (!parser.isEmpty())
+	{
+		if (parser.tryConsumeOption(COMMAND_MATCH_SCALES_REFERENCE))
+		{
+			const auto maybeIndex = parser.takeUInt(QObject::tr("reference index"));
+			if (!maybeIndex)
+				return false;
+			referenceIndex = *maybeIndex;
+		}
+		else if (parser.tryConsumeOption(COMMAND_MATCH_SCALES_RMS_DIFF))
+		{
+			const auto maybeRmsDiff = parser.takeDouble(QObject::tr("RMS difference"), std::numeric_limits<double>::min());
+			if (!maybeRmsDiff)
+				return false;
+			icpRmsDiff = *maybeRmsDiff;
+		}
+		else if (parser.tryConsumeOption(COMMAND_MATCH_SCALES_OVERLAP))
+		{
+			const auto maybeOverlap = parser.takeUInt(QObject::tr("overlap"), 10, 100);
+			if (!maybeOverlap)
+				return false;
+			icpFinalOverlap = static_cast<int>(*maybeOverlap);
+		}
+		else
+		{
+			break;
+		}
+	}
+
+	// gather the loaded entities (clouds and meshes)
+	std::vector<CLEntityDesc*> entities;
+	for (auto& cloud : cmd.clouds())
+	{
+		entities.push_back(&cloud);
+	}
+	for (auto& mesh : cmd.meshes())
+	{
+		entities.push_back(&mesh);
+	}
+
+	if (entities.size() < 2)
+	{
+		return cmd.error(QObject::tr("Not enough loaded entities (2 or more clouds/meshes are expected)"));
+	}
+	if (referenceIndex >= entities.size())
+	{
+		return cmd.error(QObject::tr("Invalid reference index (%1): only %2 entities are loaded").arg(referenceIndex).arg(entities.size()));
+	}
+
+	// build the container expected by the algorithm
+	ccHObject::Container entityContainer;
+	entityContainer.reserve(entities.size());
+	for (CLEntityDesc* desc : entities)
+	{
+		entityContainer.push_back(desc->getEntity());
+	}
+
+	if (!ccLibAlgorithms::ApplyScaleMatchingAlgorithm(algo,
+	                                                  entityContainer,
+	                                                  icpRmsDiff,
+	                                                  icpFinalOverlap,
+	                                                  referenceIndex,
+	                                                  cmd.widgetParent()))
+	{
+		return cmd.error(QObject::tr("Failed to match scales"));
+	}
+
+	// save output if needed (the reference entity is left unchanged)
+	if (cmd.autoSaveMode())
+	{
+		for (size_t i = 0; i < entities.size(); ++i)
+		{
+			if (i == referenceIndex)
+				continue;
 			QString errorStr = cmd.exportEntity(*entities[i]);
 			if (!errorStr.isEmpty())
 			{

--- a/qCC/ccCommandLineCommands.h
+++ b/qCC/ccCommandLineCommands.h
@@ -266,6 +266,13 @@ struct CommandMatchBBCenters : public ccCommandLineInterface::Command
 	bool process(ccCommandLineInterface& cmd) override;
 };
 
+struct CommandMatchScales : public ccCommandLineInterface::Command
+{
+	CommandMatchScales();
+
+	bool process(ccCommandLineInterface& cmd) override;
+};
+
 struct CommandMatchBestFitPlane : public ccCommandLineInterface::Command
 {
 	CommandMatchBestFitPlane();

--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -883,6 +883,7 @@ void ccCommandLineParser::registerBuiltInCommands()
 	registerCommand(Command::Shared(new CommandRemoveScanGrids));
 	registerCommand(Command::Shared(new CommandRemoveSensors));
 	registerCommand(Command::Shared(new CommandMatchBBCenters));
+	registerCommand(Command::Shared(new CommandMatchScales));
 	registerCommand(Command::Shared(new CommandMatchBestFitPlane));
 	registerCommand(Command::Shared(new CommandOrientNormalsMST));
 	registerCommand(Command::Shared(new CommandSORFilter));

--- a/qCC/ccLibAlgorithms.cpp
+++ b/qCC/ccLibAlgorithms.cpp
@@ -635,12 +635,19 @@ namespace ccLibAlgorithms
 		unsigned count = static_cast<unsigned>(entities.size());
 
 		// now compute the scales
-		ccProgressDialog pDlg(true, parent);
-		pDlg.setMethodTitle(QObject::tr("Computing entities scales"));
-		pDlg.setInfo(QObject::tr("Entities: %1").arg(count));
-		CCCoreLib::NormalizedProgress nProgress(&pDlg, 2 * count - 1);
-		pDlg.start();
-		QApplication::processEvents();
+		QScopedPointer<ccProgressDialog> pDlg(nullptr);
+		if (parent)
+		{
+			pDlg.reset(new ccProgressDialog(true, parent));
+			pDlg->setMethodTitle(QObject::tr("Computing entities scales"));
+			pDlg->setInfo(QObject::tr("Entities: %1").arg(count));
+		}
+		CCCoreLib::NormalizedProgress nProgress(pDlg.data(), 2 * count - 1);
+		if (pDlg)
+		{
+			pDlg->start();
+			QApplication::processEvents();
+		}
 
 		for (unsigned i = 0; i < count; ++i)
 		{
@@ -773,7 +780,8 @@ namespace ccLibAlgorithms
 		ccLog::Print(QString("[Scale Matching] Reference entity scale: %1").arg(scales[refEntityIndex]));
 
 		// now we can rescale
-		pDlg.setMethodTitle(QObject::tr("Rescaling entities"));
+		if (pDlg)
+			pDlg->setMethodTitle(QObject::tr("Rescaling entities"));
 		{
 			for (unsigned i = 0; i < count; ++i)
 			{


### PR DESCRIPTION
## Summary

This ports the "Tools > Registration > Match scales" tool to the command line, requested in #1034. The tool exists in the GUI but was never exposed to the CLI.

New command:

```
-MATCH_SCALES {BB_MAX_DIM|BB_VOLUME|PCA_MAX_DIM|ICP} [-REFERENCE {index}] [-RMS_DIFF {value}] [-OVERLAP {percent}]
```

It rescales every loaded cloud/mesh to match the scale of a reference entity, wrapping the existing `ccLibAlgorithms::ApplyScaleMatchingAlgorithm` (the same function `MainWindow::doActionMatchScales` calls). `-REFERENCE` picks the reference entity by 0-based index into the loaded clouds-then-meshes list (default 0). `-RMS_DIFF` and `-OVERLAP` only affect the ICP algorithm and default to the GUI dialog's values (1e-5 and 100).

## Progress dialog change in ApplyScaleMatchingAlgorithm

`ApplyScaleMatchingAlgorithm` created a `ccProgressDialog` and called `start()` unconditionally, and `start()` always calls `show()`. Called from the CLI, that pops a dialog even under `-SILENT`. The other CLI-reachable algorithms in the same file create the dialog only when `parent` is non-null; `ComputeGeomCharacteristic` is one example. I made `ApplyScaleMatchingAlgorithm` follow the same pattern: the dialog is created only when `parent` is non-null, and `NormalizedProgress` already accepts a null callback. The GUI path always passes a non-null parent, so its behavior does not change.

## Scope

This covers the "match scales" CLI command only. The second request in #1034, specifying ICP axis rotation and translation on the command line, is a separate and larger change that I left out.

## Testing

I built this locally on Linux (Ubuntu 24.04, GCC 13, Qt 6.4) in a core configuration with plugins and ccViewer turned off. The full CloudCompare target compiles and links cleanly, including the three changed files. I have not exercised the command against sample data yet, so its runtime behavior rests on code review and on how closely it follows the existing commands (it mirrors `CommandMatchBBCenters` for gathering entities and `CommandICP` for parsing options). CI will build on Windows and macOS.

Addresses #1034.
