### PR TITLE
Sphere detection bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -386,6 +386,7 @@ Bug fixes:
 	- Despite what the tooltip was saying, using 0 as max edge length in the contour extraction option of the Cross Section tool would not lead to the
 		extraction of the convex hull.
 	- When using some tools and changing the selection was CloudCompare was still working, the tool could be applied to the newly selected entities
+	- The sphere detection feature of the point-pair-based-alignment tool could lead to a crash (2.14.alpha and 2.14.beta only)
 
 Unresolved anomalies:
 	- 'LAS.vlrs' meta-data items saved in BIN files with any version prior to 2.14.beta cannot be restored anymore due to Qt 6

--- a/qCC/ccPointPairRegistrationDlg.cpp
+++ b/qCC/ccPointPairRegistrationDlg.cpp
@@ -528,10 +528,11 @@ bool ccPointPairRegistrationDlg::convertToSphereCenter(CCVector3d& P, ccHObject*
 					box.clear();
 					box.add(C - CCVector3(1, 1, 1) * radius * static_cast<PointCoordinateType>(1.05)); // add 5%
 					box.add(C + CCVector3(1, 1, 1) * radius * static_cast<PointCoordinateType>(1.05)); // add 5%
+
+					delete part;
 					part = cloud->crop(box, true);
 
 					// replace the old subset by a slightly larger one
-					delete part;
 					if (part && part->size() > 16)
 					{
 						CCCoreLib::GeometricalAnalysisTools::DetectSphereRobust(part, 0.5, C, radius, rms, false, &pDlg, 0.99);


### PR DESCRIPTION
The sphere detection feature of the point-pair-based-alignment tool could lead to a crash (2.14.alpha and 2.14.beta only)