### PR TITLE
cc3DFin is a submodule

### DIFF
--- a/plugins/core/Standard/CMakeLists.txt
+++ b/plugins/core/Standard/CMakeLists.txt
@@ -15,10 +15,10 @@ add_subdirectory( qPoissonRecon )
 add_subdirectory( qRANSAC_SD )
 add_subdirectory( qSRA )
 add_subdirectory( qMeshBoolean )
-add_subdirectory( cc3DFin )
 
 #plugins integrated as submodules
 set( submod_plugins
+		${CMAKE_CURRENT_SOURCE_DIR}/cc3DFin
 		${CMAKE_CURRENT_SOURCE_DIR}/q3DMASC
 		${CMAKE_CURRENT_SOURCE_DIR}/qColorimetricSegmenter
 		${CMAKE_CURRENT_SOURCE_DIR}/qG3Point


### PR DESCRIPTION
So it needs to be declared as a submodule directory in the standard's plugins CMakeLists in order to allow people that only clone the submodule they care about to build

Needed for https://github.com/tmontaigu/CloudCompare-PythonRuntime/pull/179