### PR TITLE
Change 3D Mouse CI option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,7 +238,7 @@ jobs:
           -DPLUGIN_STANDARD_QCLOUDLAYERS=ON
           -DPLUGIN_STANDARD_QVOXFALL=ON
           -DBUILD_TESTING=ON
-          -DOPTION_SUPPORT_3DCONNEXION_DEVICES=ON
+          -DOPTION_SUPPORT_3DMOUSE_WITH_HIDAPI=ON
 
       - name: Build
         run: cmake --build build --parallel


### PR DESCRIPTION
3DCONNEXION_DEVICES option no longer exists since PR #2339 but it wrongly added it to the ci build.
So now use the correct option