### PR TITLE
Move ccArgumentParser to CCPLuginAPI

### DIFF
--- a/libs/CCPluginAPI/include/CMakeLists.txt
+++ b/libs/CCPluginAPI/include/CMakeLists.txt
@@ -2,6 +2,7 @@
 target_sources( ${PROJECT_NAME}
 	PRIVATE
 		${CMAKE_CURRENT_LIST_DIR}/CCPluginAPI.h
+		${CMAKE_CURRENT_LIST_DIR}/ccArgumentParser.h
 		${CMAKE_CURRENT_LIST_DIR}/ccColorScaleSelector.h
 		${CMAKE_CURRENT_LIST_DIR}/ccColorScaleEditorDlg.h
 		${CMAKE_CURRENT_LIST_DIR}/ccColorScaleEditorWidget.h

--- a/libs/CCPluginAPI/include/ccArgumentParser.h
+++ b/libs/CCPluginAPI/include/ccArgumentParser.h
@@ -16,6 +16,8 @@
 // #                                                                        #
 // ##########################################################################
 
+#include "CCPluginAPI.h"
+
 #include <ccLog.h>
 
 // Qt
@@ -31,7 +33,7 @@
 /** Meant to simplify parsing.
     Functions will log errors when necessary
 **/
-class ccArgumentParser
+class CCPLUGIN_LIB_API ccArgumentParser
 {
   public:
 	explicit ccArgumentParser(QStringList& arguments);
@@ -111,9 +113,12 @@ class ccArgumentParser
 	}
 
 	//! Parses a float from a string
-	/** Logs an error on failure
+	/** Logs an error on failure:
+	 * - if arg is not a number
+	 * - if arg is < min
+	 * - if arg is > max
 	 **/
-	static std::optional<float> ParseFloat(const QString& arg, const QString& name);
+	static std::optional<float> ParseFloat(const QString& arg, const QString& name, float min = std::numeric_limits<float>::lowest(), float max = std::numeric_limits<float>::max());
 
 	//! Parses a double from a string
 	/** Logs an error on failure:

--- a/libs/CCPluginAPI/include/ccCommandLineInterface.h
+++ b/libs/CCPluginAPI/include/ccCommandLineInterface.h
@@ -31,8 +31,10 @@
 #include <QString>
 
 // System
+#include <optional>
 #include <vector>
 
+class ccArgumentParser;
 class ccGenericMesh;
 class ccProgressDialog;
 
@@ -354,6 +356,12 @@ class CCPLUGIN_LIB_API ccCommandLineInterface
 	/** \warning This method assumes the 'COMMAND_OPEN_SHIFT_ON_LOAD' argument has already been removed from the argument stack
 	 **/
 	bool processGlobalShiftCommand(GlobalShiftOptions& options);
+
+	//! Parses global shift options from an argument parser.
+	/** Reads either AUTO, FIRST, or three coordinates (X Y Z) from the parser.
+	    \return parsed options, or std::nullopt on parse/validation error (error logged)
+	**/
+	static std::optional<GlobalShiftOptions> ParseGlobalShiftOptions(ccArgumentParser& parser);
 
   protected: // members
 	//! Currently opened AND SELECTED point clouds and their respective filename

--- a/libs/CCPluginAPI/src/CMakeLists.txt
+++ b/libs/CCPluginAPI/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 target_sources( ${PROJECT_NAME}
 	PRIVATE
+		${CMAKE_CURRENT_LIST_DIR}/ccArgumentParser.cpp
 		${CMAKE_CURRENT_LIST_DIR}/ccColorScaleEditorDlg.cpp
 		${CMAKE_CURRENT_LIST_DIR}/ccColorScaleEditorWidget.cpp
 		${CMAKE_CURRENT_LIST_DIR}/ccColorScaleSelector.cpp

--- a/libs/CCPluginAPI/src/ccArgumentParser.cpp
+++ b/libs/CCPluginAPI/src/ccArgumentParser.cpp
@@ -19,6 +19,83 @@
 #include <cassert>
 #include <ccLog.h>
 
+namespace
+{
+	//! Helper trait to allow some code factorization
+	template <typename T>
+	struct QStringParseTraits
+	{
+		static T Parse(const QString& arg, bool* ok)
+		{
+			static_assert(sizeof(T) == 0, "QStringParseTraits not specialized for this type");
+		}
+	};
+
+	template <>
+	struct QStringParseTraits<double>
+	{
+		static double Parse(const QString& arg, bool* ok)
+		{
+			return arg.toDouble(ok);
+		}
+	};
+
+	template <>
+	struct QStringParseTraits<float>
+	{
+		static float Parse(const QString& arg, bool* ok)
+		{
+			return arg.toFloat(ok);
+		}
+	};
+
+	template <>
+	struct QStringParseTraits<int>
+	{
+		static int Parse(const QString& arg, bool* ok)
+		{
+			return arg.toInt(ok);
+		}
+	};
+
+	template <>
+	struct QStringParseTraits<unsigned int>
+	{
+		static unsigned int Parse(const QString& arg, bool* ok)
+		{
+			return arg.toUInt(ok);
+		}
+	};
+
+	//! Parses the arg to the type `T` and check its within [min, max]
+	template <typename T>
+	std::optional<T> ParseString(const QString& arg, const QString& name, const T min, const T max)
+	{
+		bool    ok    = false;
+		const T value = QStringParseTraits<T>::Parse(arg, &ok);
+
+		if (!ok)
+		{
+			ccLog::Error(QObject::tr("Invalid number '%1' for %2").arg(arg, name));
+			return std::nullopt;
+		}
+
+		if (value < min)
+		{
+			ccLog::Error(QObject::tr("%1 (=%2) must be >= %3").arg(name, arg, QString::number(min)));
+			return std::nullopt;
+		}
+
+		if (value > max)
+		{
+			ccLog::Error(QObject::tr("%1 (=%2) must be <= %3").arg(name, arg, QString::number(max)));
+			return std::nullopt;
+		}
+
+		return value;
+	}
+} // namespace
+
 ccArgumentParser::ccArgumentParser(QStringList& arguments)
     : m_arguments(arguments)
 {
@@ -122,90 +199,22 @@ bool ccArgumentParser::tryConsumeOption(const QString& option)
 	return false;
 }
 
-std::optional<float> ccArgumentParser::ParseFloat(const QString& arg, const QString& name)
+std::optional<float> ccArgumentParser::ParseFloat(const QString& arg, const QString& name, float min, float max)
 {
-	bool        ok;
-	const float value = arg.toFloat(&ok);
-	if (!ok)
-	{
-		ccLog::Error(QObject::tr("Invalid float value '%1' for %2").arg(arg, name));
-		return std::nullopt;
-	}
-
-	return value;
+	return ParseString<float>(arg, name, min, max);
 }
 
 std::optional<double> ccArgumentParser::ParseDouble(const QString& arg, const QString& name, double min, double max)
 {
-	bool         ok;
-	const double value = arg.toDouble(&ok);
-	if (!ok)
-	{
-		ccLog::Error(QObject::tr("Invalid double value '%1' for %2").arg(arg, name));
-		return std::nullopt;
-	}
-
-	if (value < min)
-	{
-		ccLog::Error(QObject::tr("%1 (=%2) must be >= %3").arg(name, arg, QString::number(min)));
-		return std::nullopt;
-	}
-
-	if (value > max)
-	{
-		ccLog::Error(QObject::tr("%1 (=%2) must be <= %3").arg(name, arg, QString::number(max)));
-		return std::nullopt;
-	}
-
-	return value;
+	return ParseString<double>(arg, name, min, max);
 }
 
 std::optional<int> ccArgumentParser::ParseInt(const QString& arg, const QString& name, int min, int max)
 {
-	bool      ok;
-	const int value = arg.toInt(&ok);
-	if (!ok)
-	{
-		ccLog::Error(QObject::tr("Invalid int value '%1' for %2").arg(arg, name));
-		return std::nullopt;
-	}
-
-	if (value < min)
-	{
-		ccLog::Error(QObject::tr("%1 (=%2) must be >= %3").arg(name, arg, QString::number(min)));
-		return std::nullopt;
-	}
-
-	if (value > max)
-	{
-		ccLog::Error(QObject::tr("%1 (=%2) must be <= %3").arg(name, arg, QString::number(max)));
-		return std::nullopt;
-	}
-
-	return value;
+	return ParseString<int>(arg, name, min, max);
 }
 
 std::optional<unsigned> ccArgumentParser::ParseUInt(const QString& arg, const QString& name, unsigned min, unsigned max)
 {
-	bool           ok;
-	const unsigned value = arg.toUInt(&ok);
-	if (!ok)
-	{
-		ccLog::Error(QObject::tr("Invalid unsigned int value '%1' for %2").arg(arg, name));
-		return std::nullopt;
-	}
-
-	if (value < min)
-	{
-		ccLog::Error(QObject::tr("%1 (=%2) must be >= %3").arg(name, arg, QString::number(min)));
-		return std::nullopt;
-	}
-
-	if (value > max)
-	{
-		ccLog::Error(QObject::tr("%1 (=%2) must be <= %3").arg(name, arg, QString::number(max)));
-		return std::nullopt;
-	}
-
-	return value;
+	return ParseString<unsigned>(arg, name, min, max);
 }

--- a/libs/CCPluginAPI/src/ccCommandLineInterface.cpp
+++ b/libs/CCPluginAPI/src/ccCommandLineInterface.cpp
@@ -17,6 +17,7 @@
 
 #include "ccCommandLineInterface.h"
 
+#include "ccArgumentParser.h"
 #include "ccGenericMesh.h"
 
 #include <QDir>
@@ -253,50 +254,69 @@ bool ccCommandLineInterface::nextCommandIsGlobalShift() const
 	return !arguments().empty() && IsCommand(arguments().front(), COMMAND_OPEN_SHIFT_ON_LOAD);
 }
 
+std::optional<ccCommandLineInterface::GlobalShiftOptions>
+ccCommandLineInterface::ParseGlobalShiftOptions(ccArgumentParser& parser)
+{
+	GlobalShiftOptions options; // defaults: NO_GLOBAL_SHIFT, (0,0,0)
+
+	if (parser.isEmpty())
+	{
+		ccLog::Error(QObject::tr("Missing parameter: global shift vector or %1 or %2 after '%3'")
+		                 .arg(COMMAND_OPEN_SHIFT_ON_LOAD_AUTO, COMMAND_OPEN_SHIFT_ON_LOAD_FIRST, COMMAND_OPEN_SHIFT_ON_LOAD));
+		return std::nullopt;
+	}
+
+	const QString firstParam = parser.takeNext();
+	const QString firstUpper = firstParam.toUpper();
+
+	if (firstUpper == COMMAND_OPEN_SHIFT_ON_LOAD_AUTO)
+	{
+		options.mode = GlobalShiftOptions::AUTO_GLOBAL_SHIFT;
+		return options;
+	}
+	if (firstUpper == COMMAND_OPEN_SHIFT_ON_LOAD_FIRST)
+	{
+		options.mode = GlobalShiftOptions::FIRST_GLOBAL_SHIFT;
+		return options;
+	}
+
+	// firstParam is the X coordinate of a custom shift vector — we need Y and Z too
+	if (parser.size() < 2)
+	{
+		ccLog::Error(QObject::tr("Missing parameter: global shift vector after '%1' (3 values expected)").arg(COMMAND_OPEN_SHIFT_ON_LOAD));
+		return std::nullopt;
+	}
+
+	const auto x = ccArgumentParser::ParseDouble(firstParam, QObject::tr("X coordinate of the global shift vector"));
+	if (!x)
+		return std::nullopt;
+
+	const auto y = parser.takeDouble(QObject::tr("Y coordinate of the global shift vector"));
+	if (!y)
+		return std::nullopt;
+
+	const auto z = parser.takeDouble(QObject::tr("Z coordinate of the global shift vector"));
+	if (!z)
+		return std::nullopt;
+
+	options.mode              = GlobalShiftOptions::CUSTOM_GLOBAL_SHIFT;
+	options.customGlobalShift = CCVector3d(*x, *y, *z);
+	return options;
+}
+
 bool ccCommandLineInterface::processGlobalShiftCommand(GlobalShiftOptions& options)
 {
-	// set default parameters in case of an early exit
+	// defaults in case of an early exit (preserved for API compatibility)
 	options.mode              = GlobalShiftOptions::NO_GLOBAL_SHIFT;
 	options.customGlobalShift = CCVector3d(0, 0, 0);
 
-	if (arguments().empty())
+	ccArgumentParser parser(arguments());
+	auto             result = ParseGlobalShiftOptions(parser);
+	if (!result)
 	{
-		return error(QObject::tr("Missing parameter: global shift vector or %1 or %2 after '%3'")
-		                 .arg(COMMAND_OPEN_SHIFT_ON_LOAD_AUTO, COMMAND_OPEN_SHIFT_ON_LOAD_FIRST, COMMAND_OPEN_SHIFT_ON_LOAD));
+		return false; // error already logged
 	}
-
-	QString firstParam = arguments().takeFirst();
-
-	if (firstParam.toUpper() == COMMAND_OPEN_SHIFT_ON_LOAD_AUTO)
-	{
-		options.mode = GlobalShiftOptions::AUTO_GLOBAL_SHIFT;
-	}
-	else if (firstParam.toUpper() == COMMAND_OPEN_SHIFT_ON_LOAD_FIRST)
-	{
-		options.mode = GlobalShiftOptions::FIRST_GLOBAL_SHIFT;
-	}
-	else if (arguments().size() < 2)
-	{
-		return error(QObject::tr("Missing parameter: global shift vector after '%1' (3 values expected)").arg(COMMAND_OPEN_SHIFT_ON_LOAD));
-	}
-	else
-	{
-		bool       ok = true;
-		CCVector3d shiftOnLoadVec;
-		shiftOnLoadVec.x = firstParam.toDouble(&ok);
-		if (!ok)
-			return error(QObject::tr("Invalid parameter: X coordinate of the global shift vector after '%1'").arg(COMMAND_OPEN_SHIFT_ON_LOAD));
-		shiftOnLoadVec.y = arguments().takeFirst().toDouble(&ok);
-		if (!ok)
-			return error(QObject::tr("Invalid parameter: Y coordinate of the global shift vector after '%1'").arg(COMMAND_OPEN_SHIFT_ON_LOAD));
-		shiftOnLoadVec.z = arguments().takeFirst().toDouble(&ok);
-		if (!ok)
-			return error(QObject::tr("Invalid parameter: Z coordinate of the global shift vector after '%1'").arg(COMMAND_OPEN_SHIFT_ON_LOAD));
-
-		options.mode              = GlobalShiftOptions::CUSTOM_GLOBAL_SHIFT;
-		options.customGlobalShift = shiftOnLoadVec;
-	}
-
+	options = *result;
 	return true;
 }
 

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -639,59 +639,42 @@ CommandLoad::CommandLoad()
 {
 }
 
+constexpr char COMMAND_OPEN_SHIFT_ON_LOAD[] = "GLOBAL_SHIFT"; //!< Global shift
+
 bool CommandLoad::process(ccCommandLineInterface& cmd)
 {
-	if (cmd.arguments().empty())
-	{
-		return cmd.error(QObject::tr("Missing parameter: filename after \"-%1\"").arg(COMMAND_OPEN));
-	}
+
+	ccArgumentParser parser(cmd.arguments());
 
 	// optional parameters
 	int                                        skipLines = 0;
 	ccCommandLineInterface::GlobalShiftOptions globalShiftOptions;
 	bool                                       doNotCreateLabels = false;
 
-	while (!cmd.arguments().empty())
+	while (!parser.isEmpty())
 	{
 		QString argument = cmd.arguments().front();
-		if (ccCommandLineInterface::IsCommand(argument, COMMAND_OPEN_NO_LABEL))
+		if (parser.tryConsumeOption(COMMAND_OPEN_NO_LABEL))
 		{
-			// local option confirmed, we can move on
-			cmd.arguments().pop_front();
-
 			cmd.print(QObject::tr("Will not load labels"));
 
 			doNotCreateLabels = true;
 		}
-		if (ccCommandLineInterface::IsCommand(argument, COMMAND_OPEN_SKIP_LINES))
+		if (parser.tryConsumeOption(COMMAND_OPEN_SKIP_LINES))
 		{
-			// local option confirmed, we can move on
-			cmd.arguments().pop_front();
 
-			if (cmd.arguments().empty())
-			{
-				return cmd.error(QObject::tr("Missing parameter: number of lines after '%1'").arg(COMMAND_OPEN_SKIP_LINES));
-			}
-
-			bool ok;
-			skipLines = cmd.arguments().takeFirst().toInt(&ok);
-			if (!ok)
-			{
-				return cmd.error(QObject::tr("Invalid parameter: number of lines after '%1'").arg(COMMAND_OPEN_SKIP_LINES));
-			}
-
+			const auto maybeSkipLines = parser.takeInt(QObject::tr("number of lines"));
+			if (!maybeSkipLines)
+				return false;
+			skipLines = *maybeSkipLines;
 			cmd.print(QObject::tr("Will skip %1 lines").arg(skipLines));
 		}
-		else if (cmd.nextCommandIsGlobalShift())
+		else if (parser.tryConsumeOption(COMMAND_OPEN_SHIFT_ON_LOAD))
 		{
-			// local option confirmed, we can move on
-			cmd.arguments().pop_front();
-
-			if (!cmd.processGlobalShiftCommand(globalShiftOptions))
-			{
-				// error message already issued
+			const auto maybeGlobalShiftOptions = ccCommandLineInterface::ParseGlobalShiftOptions(parser);
+			if (!maybeGlobalShiftOptions)
 				return false;
-			}
+			globalShiftOptions = *maybeGlobalShiftOptions;
 		}
 		else
 		{
@@ -3256,9 +3239,14 @@ bool CommandSetGlobalShift::process(ccCommandLineInterface& cmd)
 		return cmd.error(QObject::tr("No loaded entity! (be sure to open one with \"-%1 [filename]\" before \"-%2\")").arg(COMMAND_OPEN, COMMAND_SET_GLOBAL_SHIFT));
 	}
 
+	ccArgumentParser parser(cmd.arguments());
+
+	const auto maybeGlobalShift = ccCommandLineInterface::ParseGlobalShiftOptions(parser);
+	if (!maybeGlobalShift)
+		return false;
+
 	// process globalshift options first
-	ccCommandLineInterface::GlobalShiftOptions globalShiftOptions;
-	cmd.processGlobalShiftCommand(globalShiftOptions);
+	ccCommandLineInterface::GlobalShiftOptions globalShiftOptions = *maybeGlobalShift;
 	// if it is not a valid global shift then an error msg already issued.
 	if (globalShiftOptions.mode != ccCommandLineInterface::GlobalShiftOptions::Mode::CUSTOM_GLOBAL_SHIFT)
 	{
@@ -3266,23 +3254,11 @@ bool CommandSetGlobalShift::process(ccCommandLineInterface& cmd)
 	}
 	CCVector3d newShift = globalShiftOptions.customGlobalShift;
 
-	// look for additional parameters
 	bool keepOrigFixed = false;
-	while (!cmd.arguments().empty())
+	if (parser.tryConsumeOption(COMMAND_SET_GLOBAL_SHIFT_KEEP_ORIG_FIXED))
 	{
-		QString argument = cmd.arguments().front();
-		if (ccCommandLineInterface::IsCommand(argument, COMMAND_SET_GLOBAL_SHIFT_KEEP_ORIG_FIXED))
-		{
-			// local option confirmed, pop that from front
-			cmd.arguments().pop_front();
-
-			keepOrigFixed = true;
-			cmd.print(QObject::tr("[%1] Option detected").arg(COMMAND_SET_GLOBAL_SHIFT_KEEP_ORIG_FIXED));
-		}
-		else
-		{
-			break;
-		}
+		keepOrigFixed = true;
+		cmd.print(QObject::tr("[%1] Option detected").arg(COMMAND_SET_GLOBAL_SHIFT_KEEP_ORIG_FIXED));
 	}
 
 	// create an entity vector
@@ -4775,10 +4751,8 @@ CommandCoordToSF::CommandCoordToSF()
 
 bool CommandCoordToSF::process(ccCommandLineInterface& cmd)
 {
-	if (cmd.arguments().empty())
-	{
-		return cmd.error(QObject::tr("Missing parameter after \"-%1\" (DIMENSION)").arg(COMMAND_COORD_TO_SF));
-	}
+	ccArgumentParser parser(cmd.arguments());
+
 	if (cmd.clouds().empty())
 	{
 		return cmd.error(QObject::tr("No point cloud available. Be sure to open or generate one first!"));
@@ -4953,64 +4927,41 @@ bool CommandCrop2D::process(ccCommandLineInterface& cmd)
 	ccPolyline   poly(&vertices);
 
 	// orthogonal dimension
-	unsigned char orthoDim     = 2;
-	bool          orderFlipped = false;
+	unsigned char    orthoDim     = 2;
+	bool             orderFlipped = false;
+	ccArgumentParser parser(cmd.arguments());
 	{
-		QString orthoDimStr = cmd.arguments().takeFirst().toUpper();
+		QString orthoDimStr = parser.takeNext().toUpper();
 		if (orthoDimStr.endsWith("FLIP"))
 		{
 			orderFlipped = true;
 			orthoDimStr  = orthoDimStr.left(orthoDimStr.size() - 4);
 		}
 
-		if (orthoDimStr == "X")
-		{
-			orthoDim = 0;
-		}
-		else if (orthoDimStr == "Y")
-		{
-			orthoDim = 1;
-		}
-		else if (orthoDimStr == "Z")
-		{
-			orthoDim = 2;
-		}
-		else
-		{
-			return cmd.error(QObject::tr("Invalid parameter: orthogonal dimension after \"-%1\" (expected: X, Y or Z)").arg(COMMAND_CROP_2D));
-		}
+		const auto maybeDim = ccArgumentParser::ParseEnum<unsigned>(orthoDimStr, {{"X", 0}, {"Y", 1}, {"Z", 2}}, QObject::tr("orthogonal dimension"));
+		if (!maybeDim)
+			return false;
+		orthoDim = *maybeDim;
 	}
 
 	ccCommandLineInterface::GlobalShiftOptions globalShiftOptions;
 	globalShiftOptions.mode = ccCommandLineInterface::GlobalShiftOptions::NO_GLOBAL_SHIFT;
-
-	if (cmd.arguments().size() >= 4)
+	if (parser.tryConsumeOption(COMMAND_OPEN_SHIFT_ON_LOAD))
 	{
-		if (cmd.nextCommandIsGlobalShift())
-		{
-			// local option confirmed, we can move on
-			cmd.arguments().pop_front();
-
-			if (!cmd.processGlobalShiftCommand(globalShiftOptions))
-			{
-				// error message already issued
-				return false;
-			}
-
-			cmd.setGlobalShiftOptions(globalShiftOptions);
-		}
+		const auto maybeGlobalShift = ccCommandLineInterface::ParseGlobalShiftOptions(parser);
+		if (!maybeGlobalShift)
+			return false;
+		globalShiftOptions = *maybeGlobalShift;
+		cmd.setGlobalShiftOptions(globalShiftOptions);
 	}
 
 	// number of vertices
-	bool     ok = true;
-	unsigned N  = 0;
+	unsigned N = 0;
 	{
-		QString countStr = cmd.arguments().takeFirst();
-		N                = countStr.toUInt(&ok);
-		if (!ok)
-		{
-			return cmd.error(QObject::tr("Invalid parameter: number of vertices for the 2D polyline after \"-%1\"").arg(COMMAND_CROP_2D));
-		}
+		const auto maybeCount = parser.takeUInt(QObject::tr("number of vertices"));
+		if (!maybeCount)
+			return false;
+		N = *maybeCount;
 	}
 
 	// now read the vertices
@@ -5041,18 +4992,14 @@ bool CommandCrop2D::process(ccCommandLineInterface& cmd)
 
 			CCVector3d Pd(0, 0, 0);
 
-			QString coordStr = cmd.arguments().takeFirst();
-			Pd.u[Xread]      = coordStr.toDouble(&ok);
-			if (!ok)
-			{
-				return cmd.error(QObject::tr("Invalid parameter: X-coordinate of vertex #%1").arg(i + 1));
-			}
-			/*QString */ coordStr = cmd.arguments().takeFirst();
-			Pd.u[Yread]           = coordStr.toDouble(&ok);
-			if (!ok)
-			{
-				return cmd.error(QObject::tr("Invalid parameter: Y-coordinate of vertex #%1").arg(i + 1));
-			}
+			const auto maybeX = parser.takeDouble(QObject::tr("Invalid parameter: X-coordinate of vertex #%1").arg(i + 1));
+			const auto maybeY = parser.takeDouble(QObject::tr("Invalid parameter: Y-coordinate of vertex #%1").arg(i + 1));
+
+			if (!maybeX || !maybeY)
+				return false;
+
+			Pd.u[Xread] = *maybeX;
+			Pd.u[Yread] = *maybeY;
 
 			if (i == 0)
 			{

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -653,7 +653,6 @@ bool CommandLoad::process(ccCommandLineInterface& cmd)
 
 	while (!parser.isEmpty())
 	{
-		QString argument = cmd.arguments().front();
 		if (parser.tryConsumeOption(COMMAND_OPEN_NO_LABEL))
 		{
 			cmd.print(QObject::tr("Will not load labels"));
@@ -689,7 +688,11 @@ bool CommandLoad::process(ccCommandLineInterface& cmd)
 	AsciiFilter::SetNoLabelCreated(doNotCreateLabels);
 
 	// open specified file
-	QString filename(cmd.arguments().takeFirst());
+	if (parser.isEmpty())
+	{
+		return cmd.error(QObject::tr("Missing parameter: filename after \"-%1\"").arg(COMMAND_OPEN));
+	}
+	QString filename(parser.takeNext());
 	if (!cmd.importFile(filename, globalShiftOptions))
 	{
 		return false;
@@ -4759,7 +4762,11 @@ bool CommandCoordToSF::process(ccCommandLineInterface& cmd)
 	}
 
 	// dimension
-	QString dimStr = cmd.arguments().takeFirst().toUpper();
+	if (parser.isEmpty())
+	{
+		return cmd.error(QObject::tr("Missing parameter after \"-%1\" (DIMENSION)").arg(COMMAND_COORD_TO_SF));
+	}
+	QString dimStr = parser.takeNext().toUpper();
 	bool    exportDims[3]{dimStr == "X", dimStr == "Y", dimStr == "Z"};
 	if (!exportDims[0] && !exportDims[1] && !exportDims[2])
 	{
@@ -4913,7 +4920,9 @@ CommandCrop2D::CommandCrop2D()
 
 bool CommandCrop2D::process(ccCommandLineInterface& cmd)
 {
-	if (cmd.arguments().size() < 6)
+	ccArgumentParser parser(cmd.arguments());
+
+	if (parser.size() < 6)
 	{
 		return cmd.error(QObject::tr("Missing parameter(s) after \"-%1\" (ORTHO_DIM N X1 Y1 X2 Y2 ... XN YN)").arg(COMMAND_CROP_2D));
 	}
@@ -4927,9 +4936,8 @@ bool CommandCrop2D::process(ccCommandLineInterface& cmd)
 	ccPolyline   poly(&vertices);
 
 	// orthogonal dimension
-	unsigned char    orthoDim     = 2;
-	bool             orderFlipped = false;
-	ccArgumentParser parser(cmd.arguments());
+	unsigned char orthoDim     = 2;
+	bool          orderFlipped = false;
 	{
 		QString orthoDimStr = parser.takeNext().toUpper();
 		if (orthoDimStr.endsWith("FLIP"))
@@ -4985,7 +4993,7 @@ bool CommandCrop2D::process(ccCommandLineInterface& cmd)
 		CCVector3d PShift(0, 0, 0);
 		for (unsigned i = 0; i < N; ++i)
 		{
-			if (cmd.arguments().size() < 2)
+			if (parser.size() < 2)
 			{
 				return cmd.error(QObject::tr("Missing parameter(s): vertex #%1 data and following").arg(i + 1));
 			}
@@ -5029,19 +5037,9 @@ bool CommandCrop2D::process(ccCommandLineInterface& cmd)
 
 	// optional parameters
 	bool inside = true;
-	while (!cmd.arguments().empty())
+	if (parser.tryConsumeOption(COMMAND_CROP_OUTSIDE))
 	{
-		QString argument = cmd.arguments().front();
-		if (ccCommandLineInterface::IsCommand(argument, COMMAND_CROP_OUTSIDE))
-		{
-			// local option confirmed, we can move on
-			cmd.arguments().pop_front();
-			inside = false;
-		}
-		else
-		{
-			break;
-		}
+		inside = false;
 	}
 
 	// now we can crop the loaded cloud(s)

--- a/qCC/test/CMakeLists.txt
+++ b/qCC/test/CMakeLists.txt
@@ -2,14 +2,11 @@ find_package(Qt6 REQUIRED COMPONENTS Test)
 
 add_executable(TestArgumentParser
     TestArgumentParser.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../ccArgumentParser.cpp
 )
-
-target_include_directories(TestArgumentParser PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 target_link_libraries(TestArgumentParser
     PRIVATE
-        QCC_DB_LIB
+        CCPluginAPI
         Qt6::Test
 )
 


### PR DESCRIPTION
* It can be used by plugins
* And it was needed to be able to rewrite the global shift arg parse using the argument parser
* Added new function to parse global shift option, but kepts the previous one as backward compatibility