### PR TITLE
Add -PLY_NO_SF_PREFIX command line option (#2043)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ New features:
 			- ports the 'Tools > Registration > Match scales' tool to the command line
 			- rescales all loaded clouds/meshes to match the scale of the reference entity (0-based index, 0 by default)
 			- -RMS_DIFF and -OVERLAP only apply to the ICP algorithm (defaults: 1e-5 and 100 respectively)
+		- New command -PLY_NO_SF_PREFIX
+			- tells the PLY filter not to add the 'scalar_' prefix to the scalar field names when saving
+			- scalar fields coming from an input PLY file already keep their original name
 		- New command -DISTANCES_FROM_SENSOR [-SQUARED]
 			- to compute the distances from every point of the cloud to the associated sensor origin (if any)
 		- New command -SCATTERING_ANGLES [-DEGREES]

--- a/libs/qCC_io/include/PlyFilter.h
+++ b/libs/qCC_io/include/PlyFilter.h
@@ -75,6 +75,8 @@ class QCC_IO_LIB_API PlyFilter : public FileIOFilter
 
 	// static accessors
 	static void SetDefaultOutputFormat(e_ply_storage_mode format);
+	//! Sets whether the 'scalar_' prefix should be added to the scalar field names at saving time (true by default)
+	static void SetAddSFPrefix(bool state);
 
 	// inherited from FileIOFilter
 	CC_FILE_ERROR loadFile(const QString& filename, ccHObject& container, LoadParameters& parameters) override;

--- a/libs/qCC_io/src/PlyFilter.cpp
+++ b/libs/qCC_io/src/PlyFilter.cpp
@@ -80,6 +80,7 @@ bool PlyFilter::canSave(CC_CLASS_ENUM type, bool& multiple, bool& exclusive) con
 }
 
 static e_ply_storage_mode s_defaultOutputFormat = PLY_DEFAULT;
+static bool               s_addSFPrefix         = true;
 
 static void errorCallback(p_ply _ply, const char* message)
 {
@@ -89,6 +90,11 @@ static void errorCallback(p_ply _ply, const char* message)
 void PlyFilter::SetDefaultOutputFormat(e_ply_storage_mode format)
 {
 	s_defaultOutputFormat = format;
+}
+
+void PlyFilter::SetAddSFPrefix(bool state)
+{
+	s_addSFPrefix = state;
 }
 
 CC_FILE_ERROR PlyFilter::saveToFile(ccHObject* entity, const QString& filename, const SaveParameters& parameters)
@@ -367,7 +373,8 @@ CC_FILE_ERROR PlyFilter::saveToFile(ccHObject* entity, QString filename, e_ply_s
 					else
 					{
 						// append the SF name with 'scalar' for easier detection at loading time
-						propName = QString("scalar_%1").arg(sfName);
+						// (unless the user explicitly asked to keep the original name)
+						propName = s_addSFPrefix ? QString("scalar_%1").arg(sfName) : sfName;
 						propName.replace(' ', '_');
 					}
 				}

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -164,6 +164,7 @@ constexpr char COMMAND_ICP_SKIP_TY[]                      = "SKIP_TY";
 constexpr char COMMAND_ICP_SKIP_TZ[]                      = "SKIP_TZ";
 constexpr char COMMAND_ICP_C2M_DIST[]                     = "USE_C2M_DIST";
 constexpr char COMMAND_PLY_EXPORT_FORMAT[]                = "PLY_EXPORT_FMT";
+constexpr char COMMAND_PLY_NO_SF_PREFIX[]                 = "PLY_NO_SF_PREFIX";
 constexpr char COMMAND_COMPUTE_GRIDDED_NORMALS[]          = "COMPUTE_NORMALS";
 constexpr char COMMAND_INVERT_NORMALS[]                   = "INVERT_NORMALS";
 constexpr char COMMAND_COMPUTE_OCTREE_NORMALS[]           = "OCTREE_NORMALS";
@@ -7339,6 +7340,19 @@ bool CommandChangePLYExportFormat::process(ccCommandLineInterface& cmd)
 	{
 		return cmd.error(QObject::tr("Invalid PLY format! ('%1')").arg(plyFormat));
 	}
+
+	return true;
+}
+
+CommandPLYNoSFPrefix::CommandPLYNoSFPrefix()
+    : ccCommandLineInterface::Command(QObject::tr("Don't add the 'scalar_' prefix to PLY scalar fields"), COMMAND_PLY_NO_SF_PREFIX)
+{
+}
+
+bool CommandPLYNoSFPrefix::process(ccCommandLineInterface& cmd)
+{
+	PlyFilter::SetAddSFPrefix(false);
+	cmd.print(QObject::tr("[PLY] Scalar field names will be saved without the 'scalar_' prefix"));
 
 	return true;
 }

--- a/qCC/ccCommandLineCommands.h
+++ b/qCC/ccCommandLineCommands.h
@@ -516,6 +516,13 @@ struct CommandChangePLYExportFormat : public ccCommandLineInterface::Command
 	bool process(ccCommandLineInterface& cmd) override;
 };
 
+struct CommandPLYNoSFPrefix : public ccCommandLineInterface::Command
+{
+	CommandPLYNoSFPrefix();
+
+	bool process(ccCommandLineInterface& cmd) override;
+};
+
 struct CommandForceNormalsComputation : public ccCommandLineInterface::Command
 {
 	CommandForceNormalsComputation();

--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -921,6 +921,7 @@ void ccCommandLineParser::registerBuiltInCommands()
 	registerCommand(Command::Shared(new CommandChangeMeshOutputFormat));
 	registerCommand(Command::Shared(new CommandChangeHierarchyOutputFormat));
 	registerCommand(Command::Shared(new CommandChangePLYExportFormat));
+	registerCommand(Command::Shared(new CommandPLYNoSFPrefix));
 	registerCommand(Command::Shared(new CommandForceNormalsComputation));
 	registerCommand(Command::Shared(new CommandSaveClouds));
 	registerCommand(Command::Shared(new CommandSaveMeshes));


### PR DESCRIPTION
Addresses #2043.

Master already keeps the original names of scalar fields that came from the input PLY file (06837ba8), so the round-trip case in the original report works today. What is left is the case you said you would welcome a patch for: a cloud that did not come from a PLY file, for example one loaded from LAS or E57, or one whose scalar fields were computed inside CC. Those still get `scalar_` prepended at save time, with no way to turn it off.

`-PLY_NO_SF_PREFIX` makes the PLY filter write the scalar field names without that prefix.

It follows the existing `PlyFilter::SetDefaultOutputFormat` accessor and the `-PLY_EXPORT_FMT` command that sets it.

Notes:
- Default behaviour is unchanged. The prefix is still added unless the option is passed.
- Fields already present in the source PLY keep their original names either way. That path is untouched.
- Spaces are still replaced with underscores when the prefix is skipped, since PLY property names cannot contain whitespace.
- The setter would also make a GUI checkbox easy to add. I left that out because I have no way to test the dialog.

Verified on Ubuntu 24.04 with GCC and Qt6 (core build, plugins off): no new warnings, and the existing ctest suite still passes. For the behaviour itself I used a 4 column ASCII cloud, so nothing that came from a PLY file. The default run writes `property float scalar_Scalar_field`. With `-PLY_NO_SF_PREFIX` the same cloud writes `property float Scalar_field`. That field is named "Scalar field" internally, so the second case also shows the space being replaced. I have not built this on Windows or macOS.
