### PR TITLE
Add -OUTPUT_MATRIX_FILE and -OUTPUT_INFO_FILE command line options (#2020)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ New features:
 		- New command -PLY_NO_SF_PREFIX
 			- tells the PLY filter not to add the 'scalar_' prefix to the scalar field names when saving
 			- scalar fields coming from an input PLY file already keep their original name
+		- New option -OUTPUT_MATRIX_FILE {filename} for the -ICP command
+			- saves the registration matrix to this file instead of the automatically generated '{cloud path}/{cloud name}_REGISTRATION_MATRIX.txt'
+			- the filename is used as is: no timestamp and no '.txt' extension are appended
+		- New option -OUTPUT_INFO_FILE {filename} for the -BEST_FIT_PLANE command
+			- saves the plane information file to this file instead of the automatically generated '{cloud path}/{cloud name}_BEST_FIT_PLANE_INFO.txt'
+			- the filename is used as is: no timestamp and no '.txt' extension are appended
+			- as this command writes one information file per loaded cloud, this option requires that a single cloud is loaded
 		- New command -DISTANCES_FROM_SENSOR [-SQUARED]
 			- to compute the distances from every point of the cloud to the associated sensor origin (if any)
 		- New command -SCATTERING_ANGLES [-DEGREES]

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -95,6 +95,7 @@ constexpr char COMMAND_MATCH_SCALES_OVERLAP[]             = "OVERLAP";
 constexpr char COMMAND_BEST_FIT_PLANE[]                   = "BEST_FIT_PLANE";
 constexpr char COMMAND_BEST_FIT_PLANE_MAKE_HORIZ[]        = "MAKE_HORIZ";
 constexpr char COMMAND_BEST_FIT_PLANE_KEEP_LOADED[]       = "KEEP_LOADED";
+constexpr char COMMAND_BEST_FIT_PLANE_OUTPUT_INFO_FILE[]  = "OUTPUT_INFO_FILE";
 constexpr char COMMAND_ORIENT_NORMALS[]                   = "ORIENT_NORMS_MST";
 constexpr char COMMAND_SOR_FILTER[]                       = "SOR";
 constexpr char COMMAND_NOISE_FILTER[]                     = "NOISE";
@@ -163,6 +164,7 @@ constexpr char COMMAND_ICP_SKIP_TX[]                      = "SKIP_TX";
 constexpr char COMMAND_ICP_SKIP_TY[]                      = "SKIP_TY";
 constexpr char COMMAND_ICP_SKIP_TZ[]                      = "SKIP_TZ";
 constexpr char COMMAND_ICP_C2M_DIST[]                     = "USE_C2M_DIST";
+constexpr char COMMAND_ICP_OUTPUT_MATRIX_FILE[]           = "OUTPUT_MATRIX_FILE";
 constexpr char COMMAND_PLY_EXPORT_FORMAT[]                = "PLY_EXPORT_FMT";
 constexpr char COMMAND_PLY_NO_SF_PREFIX[]                 = "PLY_NO_SF_PREFIX";
 constexpr char COMMAND_COMPUTE_GRIDDED_NORMALS[]          = "COMPUTE_NORMALS";
@@ -3860,8 +3862,9 @@ CommandMatchBestFitPlane::CommandMatchBestFitPlane()
 bool CommandMatchBestFitPlane::process(ccCommandLineInterface& cmd)
 {
 	// look for local options
-	bool makeCloudsHoriz = false;
-	bool keepLoaded      = false;
+	bool    makeCloudsHoriz = false;
+	bool    keepLoaded      = false;
+	QString outputInfoFile;
 
 	while (!cmd.arguments().empty())
 	{
@@ -3880,6 +3883,22 @@ bool CommandMatchBestFitPlane::process(ccCommandLineInterface& cmd)
 
 			keepLoaded = true;
 		}
+		else if (ccCommandLineInterface::IsCommand(argument, COMMAND_BEST_FIT_PLANE_OUTPUT_INFO_FILE))
+		{
+			// local option confirmed, we can move on
+			cmd.arguments().pop_front();
+
+			if (!cmd.arguments().empty())
+			{
+				outputInfoFile = cmd.arguments().front();
+				cmd.arguments().pop_front();
+				cmd.print(QObject::tr("Plane info file: %1").arg(outputInfoFile));
+			}
+			else
+			{
+				return cmd.error(QObject::tr("Missing argument: filename after '%1'").arg(COMMAND_BEST_FIT_PLANE_OUTPUT_INFO_FILE));
+			}
+		}
 		else
 		{
 			break; // as soon as we encounter an unrecognized argument, we break the local loop to go back to the main one!
@@ -3889,6 +3908,12 @@ bool CommandMatchBestFitPlane::process(ccCommandLineInterface& cmd)
 	if (cmd.clouds().empty())
 	{
 		return cmd.error(QObject::tr("No cloud available. Be sure to open one first!"));
+	}
+
+	// one info file is generated per cloud, so a forced output path can only describe a single one
+	if (!outputInfoFile.isEmpty() && cmd.clouds().size() > 1)
+	{
+		return cmd.error(QObject::tr("Option '%1' requires a single loaded cloud (%2 are loaded)").arg(COMMAND_BEST_FIT_PLANE_OUTPUT_INFO_FILE).arg(cmd.clouds().size()));
 	}
 
 	for (CLCloudDesc& desc : cmd.clouds())
@@ -3924,13 +3949,18 @@ bool CommandMatchBestFitPlane::process(ccCommandLineInterface& cmd)
 
 			// open text file to save plane related information
 			{
-				QString txtFilename = QObject::tr("%1/%2_BEST_FIT_PLANE_INFO").arg(desc.path, desc.basename);
-				if (cmd.addTimestamp())
+				// the user can force the output path, in which case it is used as is
+				QString txtFilename = outputInfoFile;
+				if (txtFilename.isEmpty())
 				{
-					QString timestamp = QDateTime::currentDateTime().toString("yyyy-MM-dd_hh'h'mm_ss_zzz");
-					txtFilename += QObject::tr("_%1").arg(timestamp);
+					txtFilename = QObject::tr("%1/%2_BEST_FIT_PLANE_INFO").arg(desc.path, desc.basename);
+					if (cmd.addTimestamp())
+					{
+						QString timestamp = QDateTime::currentDateTime().toString("yyyy-MM-dd_hh'h'mm_ss_zzz");
+						txtFilename += QObject::tr("_%1").arg(timestamp);
+					}
+					txtFilename += QObject::tr(".txt");
 				}
-				txtFilename += QObject::tr(".txt");
 				QFile txtFile(txtFilename);
 				if (txtFile.open(QIODevice::WriteOnly | QIODevice::Text))
 				{
@@ -6929,6 +6959,7 @@ bool CommandICP::process(ccCommandLineInterface& cmd)
 	bool                                              useC2MDistances       = false;
 	bool                                              robustC2MDistances    = true;
 	CCCoreLib::ICPRegistrationTools::NORMALS_MATCHING normalsMatching       = CCCoreLib::ICPRegistrationTools::NO_NORMAL;
+	QString                                           outputMatrixFile;
 
 	ccArgumentParser parser(cmd.arguments());
 
@@ -7007,6 +7038,16 @@ bool CommandICP::process(ccCommandLineInterface& cmd)
 			if (!maybemaxThreadCount)
 				return false;
 			maxThreadCount = *maybemaxThreadCount;
+		}
+		else if (parser.tryConsumeOption(COMMAND_ICP_OUTPUT_MATRIX_FILE))
+		{
+			if (parser.isEmpty())
+			{
+				return cmd.error(QObject::tr("Missing parameter: filename after \"-%1\"").arg(COMMAND_ICP_OUTPUT_MATRIX_FILE));
+			}
+
+			outputMatrixFile = parser.takeNext();
+			cmd.print(QObject::tr("[ICP] Registration matrix file: %1").arg(outputMatrixFile));
 		}
 		else if (parser.tryConsumeOption(COMMAND_ICP_ROT))
 		{
@@ -7213,13 +7254,18 @@ bool CommandICP::process(ccCommandLineInterface& cmd)
 
 		// save matrix in a separate text file
 		{
-			QString txtFilename = QObject::tr("%1/%2_REGISTRATION_MATRIX").arg(dataAndModel[0]->path, dataAndModel[0]->basename);
-			if (cmd.addTimestamp())
+			// the user can force the output path, in which case it is used as is
+			QString txtFilename = outputMatrixFile;
+			if (txtFilename.isEmpty())
 			{
-				QString timestamp = QDateTime::currentDateTime().toString("yyyy-MM-dd_hh'h'mm_ss_zzz");
-				txtFilename += QString("_%1").arg(timestamp);
+				txtFilename = QObject::tr("%1/%2_REGISTRATION_MATRIX").arg(dataAndModel[0]->path, dataAndModel[0]->basename);
+				if (cmd.addTimestamp())
+				{
+					QString timestamp = QDateTime::currentDateTime().toString("yyyy-MM-dd_hh'h'mm_ss_zzz");
+					txtFilename += QString("_%1").arg(timestamp);
+				}
+				txtFilename += ".txt";
 			}
-			txtFilename += ".txt";
 			QFile txtFile(txtFilename);
 			if (txtFile.open(QIODevice::WriteOnly | QIODevice::Text))
 			{


### PR DESCRIPTION
Addresses #2020.

The `-ICP` command always writes its registration matrix next to the input cloud, as `{path}/{basename}_REGISTRATION_MATRIX[_timestamp].txt`. If the registered cloud is exported somewhere else, the matrix stays behind, and it gets hard to tell which autogenerated file came from which run.

In the issue thread you grouped this with a second file:

> Ah yes, there was a similar request a few days ago regarding the fit plane description file... I'll add this to the TODO list (if not already there)

So this PR covers both sites.

### `-ICP ... -OUTPUT_MATRIX_FILE {filename}`

Writes the registration matrix to `{filename}` instead of the autogenerated path.

### `-BEST_FIT_PLANE ... -OUTPUT_INFO_FILE {filename}`

Writes the plane information file to `{filename}` instead of the autogenerated path.

In both cases the filename is used exactly as given: no timestamp and no `.txt` extension is appended. When the option is absent, the existing naming is untouched.

The two commands are not symmetric, which shapes the second option. `-ICP` writes exactly one matrix file per run, but `-BEST_FIT_PLANE` loops over every loaded cloud and writes one info file per cloud. One explicit path cannot describe N files, so `-OUTPUT_INFO_FILE` refuses to run when more than one cloud is loaded:

```
Option 'OUTPUT_INFO_FILE' requires a single loaded cloud (2 are loaded)
```

I made that an error rather than a warning, since the alternative is each cloud silently overwriting the previous one. If you would rather it accept several clouds, a directory argument or a per-cloud naming scheme would both work and I am happy to switch.

Each command keeps its own existing option-parsing idiom, so neither parser loop is restructured: `-ICP` uses `ccArgumentParser` (same shape as `-ROT`), and `-BEST_FIT_PLANE` uses the raw argument deque (same shape as `-VOLUME -TO_FILE`). At both write sites the original default-path code is unchanged, just moved inside an `isEmpty()` branch.

### Verified

Ubuntu 24.04, Qt 6.4, Release: 398/398 targets built, no new compiler warnings (the 4 remaining are pre-existing, in `shapelib` and `icons.qrc`). `ctest` 2/2 passed. `clang-format 18 --dry-run --Werror` and `git diff --check` both exit 0.

Run against the built binary:

| Case | Result |
|---|---|
| `-ICP`, no option | still writes `data_REGISTRATION_MATRIX.txt` next to the input cloud |
| `-ICP -OUTPUT_MATRIX_FILE out/my_matrix.txt` | writes exactly that file, no autogenerated file, no timestamp or `.txt` appended |
| `-BEST_FIT_PLANE` 1 cloud, no option | still writes `plane_BEST_FIT_PLANE_INFO.txt` |
| `-BEST_FIT_PLANE -OUTPUT_INFO_FILE out/my_plane.txt` | writes exactly that file |
| same, with 2 clouds loaded | exits non-zero, and a pre-existing file at that path is left untouched |
| `-BEST_FIT_PLANE` 2 clouds, no option | still writes 2 info files, one per cloud |
| either option with no value after it | errors out, no crash |

The matrix produced through `-OUTPUT_MATRIX_FILE` is identical to the one produced at the default path, and on a synthetic pair offset by a known rigid transform (2 degrees about Z, translation 0.08/0.05/0.03) it recovers the inverse transform to six decimal places.

I have not built this on Windows or macOS locally, so those platforms rest on CI.
