### PR TITLE
Add -STAT_FIT command line option (#1885)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ New features:
 		- New command -PLY_NO_SF_PREFIX
 			- tells the PLY filter not to add the 'scalar_' prefix to the scalar field names when saving
 			- scalar fields coming from an input PLY file already keep their original name
+		- New command -STAT_FIT {GAUSS|WEIBULL}
+			- ports the 'Compute stat. params' tool (distribution fitting) to the command line
+			- fits the distribution on the active scalar field of each loaded cloud (see -SET_ACTIVE_SF)
+			- the fitted parameters are printed to the console, and therefore to the -LOG_FILE file if one is set
 		- New command -DISTANCES_FROM_SENSOR [-SQUARED]
 			- to compute the distances from every point of the cloud to the associated sensor origin (if any)
 		- New command -SCATTERING_ANGLES [-DEGREES]

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -124,6 +124,7 @@ constexpr char COMMAND_C2C_LOCAL_MODEL[]                  = "MODEL";
 constexpr char COMMAND_C2X_MAX_DISTANCE[]                 = "MAX_DIST";
 constexpr char COMMAND_C2X_OCTREE_LEVEL[]                 = "OCTREE_LEVEL";
 constexpr char COMMAND_STAT_TEST[]                        = "STAT_TEST";
+constexpr char COMMAND_STAT_FIT[]                         = "STAT_FIT";
 constexpr char COMMAND_DELAUNAY[]                         = "DELAUNAY";
 constexpr char COMMAND_DELAUNAY_AA[]                      = "AA";
 constexpr char COMMAND_DELAUNAY_BF[]                      = "BEST_FIT";
@@ -5912,6 +5913,90 @@ bool CommandStatTest::process(ccCommandLineInterface& cmd)
 	{
 		progressDialog->close();
 		QCoreApplication::processEvents();
+	}
+
+	return true;
+}
+
+CommandStatFit::CommandStatFit()
+    : ccCommandLineInterface::Command(QObject::tr("Statistical model fitting"), COMMAND_STAT_FIT)
+{
+}
+
+bool CommandStatFit::process(ccCommandLineInterface& cmd)
+{
+	// distribution
+	if (cmd.arguments().empty())
+	{
+		return cmd.error(QObject::tr("Missing parameter: distribution type after \"-%1\" (GAUSS/WEIBULL)").arg(COMMAND_STAT_FIT));
+	}
+
+	QString distribStr = cmd.arguments().takeFirst().toUpper();
+	if (distribStr != "GAUSS" && distribStr != "WEIBULL")
+	{
+		return cmd.error(QObject::tr("Invalid parameter: unknown distribution '%1' after \"-%2\" (GAUSS/WEIBULL)").arg(distribStr, COMMAND_STAT_FIT));
+	}
+
+	if (cmd.clouds().empty())
+	{
+		return cmd.error(QObject::tr("No cloud available. Be sure to open one first!"));
+	}
+
+	int precision = cmd.numericalPrecision();
+
+	for (CLCloudDesc& desc : cmd.clouds())
+	{
+		// we apply the method on the currently 'output' SF (the one '-SET_ACTIVE_SF' sets)
+		CCCoreLib::ScalarField* sf = desc.pc->getCurrentOutScalarField();
+		if (!sf)
+		{
+			cmd.warning(QObject::tr("Cloud '%1' has no active scalar field. Set one with '-%2'").arg(desc.pc->getName(), COMMAND_SET_ACTIVE_SF));
+			continue;
+		}
+
+		if (sf->countValidValues() == 0)
+		{
+			cmd.warning(QObject::tr("Scalar field '%1' of cloud '%2' has no valid values").arg(QString::fromStdString(sf->getName()), desc.pc->getName()));
+			continue;
+		}
+
+		QScopedPointer<CCCoreLib::GenericDistribution> distrib;
+		if (distribStr == "GAUSS")
+		{
+			distrib.reset(new CCCoreLib::NormalDistribution());
+		}
+		else
+		{
+			distrib.reset(new CCCoreLib::WeibullDistribution());
+		}
+
+		if (!distrib->computeParameters(CCCoreLib::GenericDistribution::SFAsScalarContainer(*sf)))
+		{
+			cmd.warning(QObject::tr("Failed to compute the %1 distribution parameters for cloud '%2'").arg(distrib->getName(), desc.pc->getName()));
+			continue;
+		}
+
+		QString description;
+		if (distribStr == "GAUSS")
+		{
+			const CCCoreLib::NormalDistribution* normal = static_cast<const CCCoreLib::NormalDistribution*>(distrib.data());
+			description                                 = QObject::tr("mean = %1 / std.dev. = %2").arg(normal->getMu(), 0, 'f', precision).arg(sqrt(normal->getSigma2()), 0, 'f', precision);
+		}
+		else
+		{
+			const CCCoreLib::WeibullDistribution* weibull = static_cast<const CCCoreLib::WeibullDistribution*>(distrib.data());
+			ScalarType                            a       = 0;
+			ScalarType                            b       = 0;
+			weibull->getParameters(a, b);
+			description = QString("a = %1 / b = %2 / shift = %3").arg(a, 0, 'f', precision).arg(b, 0, 'f', precision).arg(weibull->getValueShift(), 0, 'f', precision);
+			cmd.print(QObject::tr("[Distribution fitting] Additional Weibull distrib. parameters: mode = %1 / skewness = %2").arg(weibull->computeMode()).arg(weibull->computeSkewness()));
+		}
+
+		cmd.print(QObject::tr("[Distribution fitting] Cloud '%1' (SF '%2') - %3: %4")
+		              .arg(desc.pc->getName())
+		              .arg(QString::fromStdString(sf->getName()))
+		              .arg(distrib->getName())
+		              .arg(description));
 	}
 
 	return true;

--- a/qCC/ccCommandLineCommands.h
+++ b/qCC/ccCommandLineCommands.h
@@ -425,6 +425,13 @@ struct CommandStatTest : public ccCommandLineInterface::Command
 	bool process(ccCommandLineInterface& cmd) override;
 };
 
+struct CommandStatFit : public ccCommandLineInterface::Command
+{
+	CommandStatFit();
+
+	bool process(ccCommandLineInterface& cmd) override;
+};
+
 struct CommandDelaunayTri : public ccCommandLineInterface::Command
 {
 	CommandDelaunayTri();

--- a/qCC/ccCommandLineParser.cpp
+++ b/qCC/ccCommandLineParser.cpp
@@ -905,6 +905,7 @@ void ccCommandLineParser::registerBuiltInCommands()
 	registerCommand(Command::Shared(new CommandC2CDist));
 	registerCommand(Command::Shared(new CommandCPS));
 	registerCommand(Command::Shared(new CommandStatTest));
+	registerCommand(Command::Shared(new CommandStatFit));
 	registerCommand(Command::Shared(new CommandDelaunayTri));
 	registerCommand(Command::Shared(new CommandSFArithmetic));
 	registerCommand(Command::Shared(new CommandSFOperation));


### PR DESCRIPTION
Addresses #1885.

This adds `-STAT_FIT {GAUSS|WEIBULL}`, which fits a distribution to the active scalar field of each loaded cloud and prints the fitted parameters. It ports the GUI's 'Compute stat. params' to the command line.

`-STAT_TEST` already exists, but it is the complement of this: it takes the distribution parameters as input and runs a Chi2 test against them. The request in this issue was for the fitting itself, and the thread explicitly ruled out the Local Statistical Test.

You asked in the thread what the output should be:

> it's not clear what the output should be (a text file?)

I went with console output only, formatting the parameters exactly as the GUI does (the line also names the cloud and its scalar field), because the existing `-LOG_FILE` option already writes the console to a file. I tested that: with `-LOG_FILE run.log`, the fitted parameters appear in `run.log`. That covers the "whole data log into a file" the thread asked for without adding a new surface. If you would rather have a dedicated argument, say `-STAT_FIT GAUSS -OUTPUT_FILE {filename}`, that is a small follow-up.

I did not add the RMSE mentioned later in the thread. The GUI's fitting function does not compute one, so producing it here would invent a statistic CloudCompare does not report anywhere else. Worth noting for whoever needs it: for a Gaussian fit the reported std.dev. is the RMS of the residuals about the mean, and the figure that looked inconsistent in the thread was an ICP alignment RMS, which is a different quantity.

On the implementation: the command does not call `ccEntityAction::computeStatParams`. That function builds a modal `ccPickOneElementDlg` as its first statement and reads the chosen distribution back from it, so it cannot run headless without changing a shared GUI signature. `-STAT_FIT` instead mirrors `CommandStatTest`, which sits in the same file and already constructs `NormalDistribution` / `WeibullDistribution` directly. The diff is purely additive: 97 lines added across 4 files, no existing line modified or deleted.

### Verified

Ubuntu 24.04, Qt 6, Release: builds and links with 0 errors, and the files this PR touches compile with no warnings. `ctest` 2/2 passed. `clang-format 18 --dry-run --Werror` and `git diff --check` both exit 0 on all three source files.

The GAUSS path is checked against statistics computed outside CloudCompare. I generated a 20000 point cloud whose scalar field is drawn from a normal distribution, then computed the sample statistics directly: mean 4.994374, std.dev 1.983565. `-STAT_FIT GAUSS` reports:

```
[Distribution fitting] Cloud 'gauss - Cloud' (SF 'TestSF') - Gauss: mean = 4.994374413813 / std.dev. = 1.983565150657
```

Other cases, all run against the built binary:

| Case | Result |
|---|---|
| `-STAT_FIT WEIBULL` | reports `a`, `b`, `shift` plus the extra mode/skewness line, matching the GUI |
| lower-case `-STAT_FIT gauss` | accepted, same result as `GAUSS` |
| cloud with no active scalar field | warns and continues, exit 0, no crash |
| `-STAT_FIT` with no argument | errors |
| `-STAT_FIT BOGUS` | errors, naming the rejected value |
| no cloud loaded | errors |
| `-LOG_FILE run.log` | the fitted parameters appear in `run.log` |
| existing `-STAT_TEST` | unchanged, still prints its Chi2 result |

I have not built this on Windows or macOS locally, so those platforms rest on CI.
