### PR TITLE
Add -MIN_SCALE and -MAX_SCALE options to -MATCH_SCALES (#1034)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,11 @@ New features:
 		- distances between a point cloud and a disc can be computed with 'Tools > Distances > Cloud/primitive dist'
 
 	- New Command line options
-		- New command -MATCH_SCALES {BB_MAX_DIM|BB_VOLUME|PCA_MAX_DIM|ICP} [-REFERENCE {index}] [-RMS_DIFF {value}] [-OVERLAP {percent}]
+		- New command -MATCH_SCALES {BB_MAX_DIM|BB_VOLUME|PCA_MAX_DIM|ICP} [-REFERENCE {index}] [-RMS_DIFF {value}] [-OVERLAP {percent}] [-MIN_SCALE {value}] [-MAX_SCALE {value}]
 			- ports the 'Tools > Registration > Match scales' tool to the command line
 			- rescales all loaded clouds/meshes to match the scale of the reference entity (0-based index, 0 by default)
 			- -RMS_DIFF and -OVERLAP only apply to the ICP algorithm (defaults: 1e-5 and 100 respectively)
+			- -MIN_SCALE and -MAX_SCALE constrain the scale factor: a factor falling outside the range is clamped to the nearest bound and a warning is issued (both are optional, and no limit is applied by default)
 		- New command -PLY_NO_SF_PREFIX
 			- tells the PLY filter not to add the 'scalar_' prefix to the scalar field names when saving
 			- scalar fields coming from an input PLY file already keep their original name

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -3771,9 +3771,9 @@ bool CommandMatchScales::process(ccCommandLineInterface& cmd)
 	unsigned referenceIndex  = 0;
 	double   icpRmsDiff      = 1.0e-5;
 	int      icpFinalOverlap = 100;
-	// a negative bound means 'no limit'
-	double minScale = -1.0;
-	double maxScale = -1.0;
+	// a NaN value means 'no limit'
+	double minScale = std::numeric_limits<double>::quiet_NaN();
+	double maxScale = std::numeric_limits<double>::quiet_NaN();
 
 	while (!parser.isEmpty())
 	{
@@ -3818,7 +3818,7 @@ bool CommandMatchScales::process(ccCommandLineInterface& cmd)
 		}
 	}
 
-	if (minScale > 0 && maxScale > 0 && minScale > maxScale)
+	if (std::isfinite(minScale) && std::isfinite(maxScale) && minScale > maxScale)
 	{
 		return cmd.error(QObject::tr("Invalid parameters: '-%1' value must not exceed '-%2' value").arg(COMMAND_MATCH_SCALES_MIN_SCALE, COMMAND_MATCH_SCALES_MAX_SCALE));
 	}

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -92,6 +92,8 @@ constexpr char COMMAND_MATCH_SCALES[]                     = "MATCH_SCALES";
 constexpr char COMMAND_MATCH_SCALES_REFERENCE[]           = "REFERENCE";
 constexpr char COMMAND_MATCH_SCALES_RMS_DIFF[]            = "RMS_DIFF";
 constexpr char COMMAND_MATCH_SCALES_OVERLAP[]             = "OVERLAP";
+constexpr char COMMAND_MATCH_SCALES_MIN_SCALE[]           = "MIN_SCALE";
+constexpr char COMMAND_MATCH_SCALES_MAX_SCALE[]           = "MAX_SCALE";
 constexpr char COMMAND_BEST_FIT_PLANE[]                   = "BEST_FIT_PLANE";
 constexpr char COMMAND_BEST_FIT_PLANE_MAKE_HORIZ[]        = "MAKE_HORIZ";
 constexpr char COMMAND_BEST_FIT_PLANE_KEEP_LOADED[]       = "KEEP_LOADED";
@@ -3769,6 +3771,9 @@ bool CommandMatchScales::process(ccCommandLineInterface& cmd)
 	unsigned referenceIndex  = 0;
 	double   icpRmsDiff      = 1.0e-5;
 	int      icpFinalOverlap = 100;
+	// a negative bound means 'no limit'
+	double minScale = -1.0;
+	double maxScale = -1.0;
 
 	while (!parser.isEmpty())
 	{
@@ -3793,10 +3798,29 @@ bool CommandMatchScales::process(ccCommandLineInterface& cmd)
 				return false;
 			icpFinalOverlap = static_cast<int>(*maybeOverlap);
 		}
+		else if (parser.tryConsumeOption(COMMAND_MATCH_SCALES_MIN_SCALE))
+		{
+			const auto maybeMinScale = parser.takeDouble(QObject::tr("minimum scale"), std::numeric_limits<double>::min());
+			if (!maybeMinScale)
+				return false;
+			minScale = *maybeMinScale;
+		}
+		else if (parser.tryConsumeOption(COMMAND_MATCH_SCALES_MAX_SCALE))
+		{
+			const auto maybeMaxScale = parser.takeDouble(QObject::tr("maximum scale"), std::numeric_limits<double>::min());
+			if (!maybeMaxScale)
+				return false;
+			maxScale = *maybeMaxScale;
+		}
 		else
 		{
 			break;
 		}
+	}
+
+	if (minScale > 0 && maxScale > 0 && minScale > maxScale)
+	{
+		return cmd.error(QObject::tr("Invalid parameters: '-%1' value must not exceed '-%2' value").arg(COMMAND_MATCH_SCALES_MIN_SCALE, COMMAND_MATCH_SCALES_MAX_SCALE));
 	}
 
 	// gather the loaded entities (clouds and meshes)
@@ -3832,7 +3856,9 @@ bool CommandMatchScales::process(ccCommandLineInterface& cmd)
 	                                                  icpRmsDiff,
 	                                                  icpFinalOverlap,
 	                                                  referenceIndex,
-	                                                  cmd.widgetParent()))
+	                                                  cmd.widgetParent(),
+	                                                  minScale,
+	                                                  maxScale))
 	{
 		return cmd.error(QObject::tr("Failed to match scales"));
 	}

--- a/qCC/ccLibAlgorithms.cpp
+++ b/qCC/ccLibAlgorithms.cpp
@@ -609,7 +609,9 @@ namespace ccLibAlgorithms
 	                                 double                 icpRmsDiff,
 	                                 int                    icpFinalOverlap,
 	                                 unsigned               refEntityIndex /*=0*/,
-	                                 QWidget*               parent /*=nullptr*/)
+	                                 QWidget*               parent /*=nullptr*/,
+	                                 double                 minScale /*=-1.0*/,
+	                                 double                 maxScale /*=-1.0*/)
 	{
 		if (entities.size() < 2
 		    || refEntityIndex >= entities.size())
@@ -813,6 +815,18 @@ namespace ccLibAlgorithms
 				}
 
 				double scaled = algo == ICP_SCALE ? scales[i] : scales[refEntityIndex] / scales[i];
+
+				// the caller can restrict the scale factor that may be applied (a negative bound means 'no limit')
+				if (minScale > 0 && scaled < minScale)
+				{
+					ccLog::Warning(QString("[Scale Matching] Entity '%1' scale factor (%2) was clamped to the minimum allowed value (%3)").arg(entities[i]->getName()).arg(scaled).arg(minScale));
+					scaled = minScale;
+				}
+				else if (maxScale > 0 && scaled > maxScale)
+				{
+					ccLog::Warning(QString("[Scale Matching] Entity '%1' scale factor (%2) was clamped to the maximum allowed value (%3)").arg(entities[i]->getName()).arg(scaled).arg(maxScale));
+					scaled = maxScale;
+				}
 
 				PointCoordinateType scale_pc = static_cast<PointCoordinateType>(scaled);
 

--- a/qCC/ccLibAlgorithms.cpp
+++ b/qCC/ccLibAlgorithms.cpp
@@ -610,13 +610,30 @@ namespace ccLibAlgorithms
 	                                 int                    icpFinalOverlap,
 	                                 unsigned               refEntityIndex /*=0*/,
 	                                 QWidget*               parent /*=nullptr*/,
-	                                 double                 minScale /*=-1.0*/,
-	                                 double                 maxScale /*=-1.0*/)
+	                                 double                 minScale /*=std::numeric_limits<double>::quiet_NaN()*/,
+	                                 double                 maxScale /*=std::numeric_limits<double>::quiet_NaN()*/)
 	{
 		if (entities.size() < 2
 		    || refEntityIndex >= entities.size())
 		{
 			ccLog::Error("[ApplyScaleMatchingAlgorithm] Invalid input parameter(s)");
+			return false;
+		}
+
+		if (std::isfinite(minScale) && minScale < 0.0)
+		{
+			ccLog::Warning("Minimum scale should not be negative");
+			minScale = 0.0;
+		}
+		if (std::isfinite(maxScale) && maxScale < 0.0)
+		{
+			ccLog::Warning("Maximum scale should not be negative");
+			maxScale = 0.0;
+		}
+
+		if (std::isfinite(minScale) && std::isfinite(maxScale) && minScale > maxScale)
+		{
+			ccLog::Error("Maximum scale should not be smaller than minimum scale");
 			return false;
 		}
 
@@ -683,9 +700,13 @@ namespace ccLibAlgorithms
 				{
 					ccBBox box = ent->getOwnBB();
 					if (box.isValid())
+					{
 						scales[i] = algo == BB_MAX_DIM ? box.getMaxBoxDim() : box.computeVolume();
+					}
 					else
+					{
 						ccLog::Warning(QString("[Scale Matching] Entity '%1' has an invalid bounding-box!").arg(ent->getName()));
+					}
 				}
 				break;
 
@@ -742,6 +763,8 @@ namespace ccLibAlgorithms
 						parameters.useC2MSignedDistances    = false;
 						parameters.robustC2MSignedDistances = true;
 						parameters.normalsMatching          = CCCoreLib::ICPRegistrationTools::NO_NORMAL;
+						parameters.minScale                 = minScale;
+						parameters.maxScale                 = maxScale;
 					}
 
 					if (ccRegistrationTools::ICP(
@@ -789,78 +812,95 @@ namespace ccLibAlgorithms
 
 		// now we can rescale
 		if (pDlg)
-			pDlg->setMethodTitle(QObject::tr("Rescaling entities"));
 		{
-			for (unsigned i = 0; i < count; ++i)
+			pDlg->setMethodTitle(QObject::tr("Rescaling entities"));
+		}
+
+		for (unsigned i = 0; i < count; ++i)
+		{
+			if (i == refEntityIndex)
 			{
-				if (i == refEntityIndex)
-					continue;
-				if (scales[i] < 0)
-					continue;
+				continue;
+			}
+			if (scales[i] < 0)
+			{
+				continue;
+			}
 
-				ccLog::Print(QString("[Scale Matching] Entity '%1' scale: %2").arg(entities[i]->getName()).arg(scales[i]));
-				if (scales[i] <= CCCoreLib::ZERO_TOLERANCE_D)
-				{
-					ccLog::Warning("[Scale Matching] Entity scale is too small!");
-					continue;
-				}
+			ccLog::Print(QString("[Scale Matching] Entity '%1' scale: %2").arg(entities[i]->getName()).arg(scales[i]));
+			if (scales[i] <= CCCoreLib::ZERO_TOLERANCE_D)
+			{
+				ccLog::Warning("[Scale Matching] Entity scale is too small!");
+				continue;
+			}
 
-				ccHObject* ent = entities[i];
+			ccHObject* ent = entities[i];
 
-				bool                 lockedVertices = false;
-				ccGenericPointCloud* cloud          = ccHObjectCaster::ToGenericPointCloud(ent, &lockedVertices);
-				if (nullptr == cloud || lockedVertices)
-				{
-					continue;
-				}
+			bool                 lockedVertices = false;
+			ccGenericPointCloud* cloud          = ccHObjectCaster::ToGenericPointCloud(ent, &lockedVertices);
+			if (nullptr == cloud || lockedVertices)
+			{
+				continue;
+			}
 
-				double scaled = algo == ICP_SCALE ? scales[i] : scales[refEntityIndex] / scales[i];
+			double scaled = 1.0;
+			if (algo == ICP_SCALE)
+			{
+				scaled = scales[i]; // already clamped normally
+				assert(!std::isfinite(minScale) || scaled >= minScale);
+				assert(!std::isfinite(maxScale) || scaled <= maxScale);
+			}
+			else
+			{
+				scaled = scales[refEntityIndex] / scales[i];
 
-				// the caller can restrict the scale factor that may be applied (a negative bound means 'no limit')
-				if (minScale > 0 && scaled < minScale)
+				// the caller can restrict the scale factor that may be applied
+				if (std::isfinite(minScale) && scaled < minScale)
 				{
 					ccLog::Warning(QString("[Scale Matching] Entity '%1' scale factor (%2) was clamped to the minimum allowed value (%3)").arg(entities[i]->getName()).arg(scaled).arg(minScale));
 					scaled = minScale;
 				}
-				else if (maxScale > 0 && scaled > maxScale)
+				else if (std::isfinite(maxScale) && scaled > maxScale)
 				{
 					ccLog::Warning(QString("[Scale Matching] Entity '%1' scale factor (%2) was clamped to the maximum allowed value (%3)").arg(entities[i]->getName()).arg(scaled).arg(maxScale));
 					scaled = maxScale;
 				}
-
-				PointCoordinateType scale_pc = static_cast<PointCoordinateType>(scaled);
-
-				// we temporarily detach entity, as it may undergo
-				//"severe" modifications (octree deletion, etc.) --> see ccPointCloud::scale
-				MainWindow*                  instance = dynamic_cast<MainWindow*>(parent);
-				MainWindow::ccHObjectContext objContext;
-				if (instance)
-				{
-					objContext = instance->removeObjectTemporarilyFromDBTree(cloud);
-				}
-
-				CCVector3 C = cloud->getOwnBB().getCenter();
-
-				cloud->scale(scale_pc,
-				             scale_pc,
-				             scale_pc,
-				             C);
-
-				if (instance)
-					instance->putObjectBackIntoDBTree(cloud, objContext);
-				cloud->prepareDisplayForRefresh_recursive();
-
-				// don't forget the 'global shift'!
-				const CCVector3d& shift = cloud->getGlobalShift();
-				cloud->setGlobalShift(shift * scaled);
-				// DGM: nope! Not the global scale!
 			}
 
-			if (!nProgress.oneStep())
+			PointCoordinateType scale_pc = static_cast<PointCoordinateType>(scaled);
+
+			// we temporarily detach entity, as it may undergo
+			//"severe" modifications (octree deletion, etc.) --> see ccPointCloud::scale
+			MainWindow*                  instance = dynamic_cast<MainWindow*>(parent);
+			MainWindow::ccHObjectContext objContext;
+			if (instance)
 			{
-				// process cancelled by user
-				return false;
+				objContext = instance->removeObjectTemporarilyFromDBTree(cloud);
 			}
+
+			CCVector3 C = cloud->getOwnBB().getCenter();
+
+			cloud->scale(scale_pc,
+			             scale_pc,
+			             scale_pc,
+			             C);
+
+			if (instance)
+			{
+				instance->putObjectBackIntoDBTree(cloud, objContext);
+			}
+			cloud->prepareDisplayForRefresh_recursive();
+
+			// don't forget the 'global shift'!
+			const CCVector3d& shift = cloud->getGlobalShift();
+			cloud->setGlobalShift(shift * scaled);
+			// DGM: nope! Not the global scale!
+		}
+
+		if (!nProgress.oneStep())
+		{
+			// process cancelled by user
+			return false;
 		}
 
 		return true;

--- a/qCC/ccLibAlgorithms.h
+++ b/qCC/ccLibAlgorithms.h
@@ -96,8 +96,8 @@ namespace ccLibAlgorithms
 	                                 int                    icpFinalOverlap,
 	                                 unsigned               refEntityIndex = 0,
 	                                 QWidget*               parent         = nullptr,
-	                                 double                 minScale       = -1.0,
-	                                 double                 maxScale       = -1.0);
+	                                 double                 minScale       = std::numeric_limits<double>::quiet_NaN(),
+	                                 double                 maxScale       = std::numeric_limits<double>::quiet_NaN());
 } // namespace ccLibAlgorithms
 
 #endif

--- a/qCC/ccLibAlgorithms.h
+++ b/qCC/ccLibAlgorithms.h
@@ -95,7 +95,9 @@ namespace ccLibAlgorithms
 	                                 double                 icpRmsDiff,
 	                                 int                    icpFinalOverlap,
 	                                 unsigned               refEntityIndex = 0,
-	                                 QWidget*               parent         = nullptr);
+	                                 QWidget*               parent         = nullptr,
+	                                 double                 minScale       = -1.0,
+	                                 double                 maxScale       = -1.0);
 } // namespace ccLibAlgorithms
 
 #endif


### PR DESCRIPTION
Addresses #1034.

This adds `-MIN_SCALE {value}` and `-MAX_SCALE {value}` to `-MATCH_SCALES`, constraining the scale factor the tool is allowed to apply. Both are optional and there is no limit by default, so existing command lines behave as before.

You described the semantics in the thread:

> I think the idea was to constrain the scales and clamp the values indeed.

So a factor below `-MIN_SCALE` is clamped up to it, a factor above `-MAX_SCALE` is clamped down to it, and either case logs a warning naming both the original factor and the bound applied. Passing `-MIN_SCALE` greater than `-MAX_SCALE` is rejected before any entity is touched.

On the CCCoreLib question from the same comment: no CCCoreLib change is needed for this. All four algorithms end up as a plain `double` in `ApplyScaleMatchingAlgorithm`, and the factor actually applied is computed in that function:

```cpp
double scaled = algo == ICP_SCALE ? scales[i] : scales[refEntityIndex] / scales[i];
```

The clamp sits immediately after that line, so one guard covers BB_MAX_DIM, BB_VOLUME, PCA_MAX_DIM and ICP. It mirrors the existing `scales[i] <= ZERO_TOLERANCE_D` guard a few lines above it.

One limit worth stating plainly: this bounds the factor that gets applied, it does not constrain the scale search inside ICP. `ICPRegistrationTools::Parameters` has no scale bounds, so steering ICP away from the small-patch local minimum reported in the issue would be a separate change in CCCoreLib.

`minScale` and `maxScale` are defaulted parameters on `ApplyScaleMatchingAlgorithm`, so the `mainwindow.cpp` caller is unchanged and the dialog work stays with you, as you offered.

### Verified

Ubuntu 24.04, Qt 6, Release: builds and links with 0 errors, and no warning names a file this PR touches. `ctest` 2/2 passed. `clang-format 18.1.8 --dry-run --Werror` exits 0 on all three source files.

Behaviour, run against the built binary with a reference cube of span 1 and a second cube of span 3, so the natural factor is 1/3:

| Case | Result |
|---|---|
| no bounds | span 3 rescaled to 1, reference untouched, no warning |
| `-MIN_SCALE 0.5` | 0.333 clamped up to 0.5, span becomes 1.5, warning names the minimum |
| `-MAX_SCALE 0.2` | 0.333 clamped down to 0.2, span becomes 0.6, warning names the maximum |
| `-MIN_SCALE 0.1 -MAX_SCALE 0.5` | factor in range, span becomes 1, no warning |
| `-MAX_SCALE 0.9` | bound above the factor, span becomes 1, no warning |
| `-MIN_SCALE 5 -MAX_SCALE 1` | rejected before any rescaling, non-zero exit |
| `-MIN_SCALE` with no value | errors |
| zero, negative or non-numeric value | rejected at parse time, non-zero exit |
| `-REFERENCE 0 -MIN_SCALE 0.1 -MAX_SCALE 0.5` | existing sub-options still parse |

28 assertions, all passing. I have not built this on Windows or macOS locally, so those platforms rest on CI.
