### PR TITLE
Warn the user when an ASCII file has too many columns (#2178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -364,6 +364,8 @@ Improvements:
 		- CloudCompare is now built upon Qt 6.
 		- Removed Gamepad support (QGamepad is no longer part of Qt starting from Qt6).
 		- point picking now works on mesh displayed with wireframe
+		- the ASCII loading dialog now warns the user when a file has more columns than it can handle
+			(only the first 512 columns are loaded, the other ones were previously ignored silently)
 
 Bug fixes:
 	- the weights derived from normals comparison during ICP registration of 2 clouds could be wrong (the wrong normals were compared)

--- a/libs/qCC_io/src/AsciiOpenDlg.cpp
+++ b/libs/qCC_io/src/AsciiOpenDlg.cpp
@@ -597,7 +597,7 @@ void AsciiOpenDlg::updateTable()
 	// warn the user if some columns can't be handled (and would be silently ignored otherwise)
 	if (maxPartsCount > MAX_COLUMNS)
 	{
-		QString warning = QString("This file has %1 columns, but only the first %2 can be loaded. The remaining %3 column(s) will be ignored.")
+		QString warning = tr("This file has %1 columns, but only the first %2 can be loaded. The remaining %3 column(s) will be ignored.")
 		                      .arg(maxPartsCount)
 		                      .arg(MAX_COLUMNS)
 		                      .arg(maxPartsCount - MAX_COLUMNS);

--- a/libs/qCC_io/src/AsciiOpenDlg.cpp
+++ b/libs/qCC_io/src/AsciiOpenDlg.cpp
@@ -23,6 +23,7 @@
 #include "FileIOFilter.h"
 
 // qCC_db
+#include <ccLog.h>
 #include <ccPointCloud.h>
 
 // Qt
@@ -371,6 +372,7 @@ void AsciiOpenDlg::updateTable()
 	bool hadValidHeader = !m_headerLine.isEmpty();
 	m_headerLine.clear();
 	m_ui->headerLabel->setVisible(false);
+	m_ui->columnsTruncatedLabel->setVisible(false);
 
 	if (m_filename.isEmpty() && m_stream == nullptr)
 	{
@@ -428,10 +430,11 @@ void AsciiOpenDlg::updateTable()
 	}
 	m_ui->tableWidget->setRowCount(DISPLAYED_LINES + 1); //+1 for first line shifting
 
-	unsigned lineCount    = 0; // number of lines read
-	unsigned totalChars   = 0; // total read characters (for stats)
-	unsigned columnsCount = 0; // max columns count per line
-	unsigned commentLines = 0; // number of comments line skipped
+	unsigned lineCount     = 0; // number of lines read
+	unsigned totalChars    = 0; // total read characters (for stats)
+	unsigned columnsCount  = 0; // max columns count per line
+	unsigned commentLines  = 0; // number of comments line skipped
+	unsigned maxPartsCount = 0; // max columns count per line, before it's clamped to MAX_COLUMNS
 
 	std::vector<bool> valueIsNumber;   // identifies columns with numbers only [mandatory]
 	std::vector<bool> valueIsBelowOne; // identifies columns with values between -1 and 1 only
@@ -461,7 +464,13 @@ void AsciiOpenDlg::updateTable()
 			QStringList parts = currentLine.simplified().split(m_separator);
 			if (lineCount < DISPLAYED_LINES)
 			{
-				unsigned partsCount              = std::min(MAX_COLUMNS, static_cast<unsigned>(parts.size()));
+				unsigned rawPartsCount = static_cast<unsigned>(parts.size());
+				if (rawPartsCount > maxPartsCount)
+				{
+					maxPartsCount = rawPartsCount;
+				}
+
+				unsigned partsCount              = std::min(MAX_COLUMNS, rawPartsCount);
 				bool     columnCountHasIncreased = (partsCount > columnsCount);
 
 				// do we need to add one or several new columns?
@@ -583,6 +592,20 @@ void AsciiOpenDlg::updateTable()
 	{
 		m_ui->commentLinesSkippedLabel->setText(QString("+ %1 comment line(s) skipped").arg(commentLines));
 		m_ui->commentLinesSkippedLabel->setVisible(true);
+	}
+
+	// warn the user if some columns can't be handled (and would be silently ignored otherwise)
+	if (maxPartsCount > MAX_COLUMNS)
+	{
+		QString warning = QString("This file has %1 columns, but only the first %2 can be loaded. The remaining %3 column(s) will be ignored.")
+		                      .arg(maxPartsCount)
+		                      .arg(MAX_COLUMNS)
+		                      .arg(maxPartsCount - MAX_COLUMNS);
+
+		m_ui->columnsTruncatedLabel->setText(warning);
+		m_ui->columnsTruncatedLabel->setVisible(true);
+
+		ccLog::Warning(QString("[AsciiOpenDlg] ") + warning);
 	}
 
 	if (lineCount == 0 || columnsCount == 0)

--- a/libs/qCC_io/ui/openAsciiFileDlg.ui
+++ b/libs/qCC_io/ui/openAsciiFileDlg.ui
@@ -115,6 +115,19 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="columnsTruncatedLabel">
+     <property name="styleSheet">
+      <string notr="true">color: red;</string>
+     </property>
+     <property name="text">
+      <string>Too many columns</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QScrollArea" name="scrollArea">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>


### PR DESCRIPTION
Addresses #2178.

The ASCII loading dialog stops at 512 columns (`MAX_COLUMNS`). `updateTable()` clamps the per-line column count to that with a `std::min`, and the extra columns are dropped without any message, so a wide file opens looking perfectly normal while some of its fields are simply missing. In the issue that was a `verticality 10m` column that disappeared with nothing to suggest anything had been left out.

You already said the dialog is not really meant to go beyond this:

> 512 columns! Indeed, you are pushing this dialog to its limits 😅

so this does not touch the limit, it only makes the truncation visible. The dialog now keeps track of how many columns the file actually has, and when that is more than `MAX_COLUMNS` it reports how many are being ignored, both in a label above the preview table and in the console. For the file attached to the issue:

> This file has 600 columns, but only the first 512 can be loaded. The remaining 88 column(s) will be ignored.

Notes:
- Default behaviour is unchanged. Files with 512 columns or fewer never show the label and log nothing.
- The label is hidden again at the start of every `updateTable()`, so it clears when the separator or the number of skipped lines changes.
- `MAX_COLUMNS` is untouched, and so is the set of columns that actually get loaded. This only reports the truncation, it does not change it.

Built on Ubuntu 24.04 with GCC 15.3 and Qt 6.9.3 (core build, most plugins off): the tree compiles with no new warnings. I then drove the dialog the way `AsciiFilter::loadStream` does and checked files with 3, 511, 512, 513 and 600 columns — the label only appears above 512, 512 itself stays quiet, and the counts in the message are correct. I have not built this on Windows or macOS.

<img width="1473" height="600" alt="dialog_warning" src="https://github.com/user-attachments/assets/01df701e-a1a6-4a3f-875e-a1db406a05eb" />
