### PR TITLE
Fix reading of ASCII files with legacy Mac line endings (#801)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -372,6 +372,7 @@ Improvements:
 			(only the first 512 columns are loaded, the other ones were previously ignored silently)
 
 Bug fixes:
+	- ASCII files saved with legacy Mac line endings (a lone CR) were read as a single line, silently loading only one point
 	- the weights derived from normals comparison during ICP registration of 2 clouds could be wrong (the wrong normals were compared)
 	- editing the Global Shift & Scale information of a polyline would make CC crash
 	- segmenting a cloud with polylines depending on it but not directly present below the cloud entity in the DB tree could lead

--- a/libs/qCC_io/src/AsciiFilter.cpp
+++ b/libs/qCC_io/src/AsciiFilter.cpp
@@ -36,6 +36,7 @@
 #include <ccScalarField.h>
 
 // System
+#include <algorithm>
 #include <cassert>
 #include <cstring>
 
@@ -51,6 +52,91 @@ static bool s_saveSFBeforeColor       = false;
 static bool s_saveColumnsNamesHeader  = false;
 static bool s_savePointCountHeader    = false;
 static bool s_doNotCreateLabels       = false;
+
+//! Number of bytes inspected to guess the line ending style of a file
+static constexpr qint64 LINE_ENDING_SNIFF_SIZE = 64 * 1024;
+
+//! Returns whether some data uses legacy Mac line endings (a lone CR, without any LF)
+static bool UsesLoneCRLineEndings(const char* data, qint64 size)
+{
+	bool crFound = false;
+	for (qint64 i = 0; i < size; ++i)
+	{
+		if (data[i] == '\n')
+		{
+			// LF or CRLF: QTextStream already handles both
+			return false;
+		}
+		if (data[i] == '\r')
+		{
+			crFound = true;
+		}
+	}
+
+	return crFound;
+}
+
+namespace
+{
+	//! Read-only device that turns lone CR line endings into LF ones on the fly
+	/** QTextStream::readLine only breaks on LF, so a file saved with legacy Mac
+	    (CR only) line endings would be read as a single very long line. Such files
+	    contain no LF at all, therefore replacing every CR by a LF is enough, and
+	    leaves the rest of the content untouched.
+	**/
+	class CRToLFDevice : public QIODevice
+	{
+	  public:
+		explicit CRToLFDevice(QIODevice& source)
+		    : m_source(source)
+		{
+		}
+
+		bool isSequential() const override
+		{
+			return m_source.isSequential();
+		}
+
+		qint64 size() const override
+		{
+			return m_source.size();
+		}
+
+		qint64 bytesAvailable() const override
+		{
+			return QIODevice::bytesAvailable() + m_source.bytesAvailable();
+		}
+
+		bool seek(qint64 pos) override
+		{
+			// one input byte always maps to exactly one output byte
+			return QIODevice::seek(pos) && m_source.seek(pos);
+		}
+
+	  protected:
+		qint64 readData(char* data, qint64 maxSize) override
+		{
+			qint64 bytesRead = m_source.read(data, maxSize);
+			for (qint64 i = 0; i < bytesRead; ++i)
+			{
+				if (data[i] == '\r')
+				{
+					data[i] = '\n';
+				}
+			}
+
+			return bytesRead;
+		}
+
+		qint64 writeData(const char*, qint64) override
+		{
+			return -1; // read-only
+		}
+
+	  private:
+		QIODevice& m_source;
+	};
+} // namespace
 
 void AsciiFilter::SetDefaultSkippedLineCount(int count)
 {
@@ -427,7 +513,22 @@ CC_FILE_ERROR AsciiFilter::loadFile(const QString&  filename,
 		return CC_FERR_READING;
 	}
 
-	QTextStream stream(&file);
+	// files saved with legacy Mac line endings (a lone CR) would otherwise be read as a single line
+	QScopedPointer<CRToLFDevice> crToLFDevice;
+	{
+		const QByteArray head = file.peek(LINE_ENDING_SNIFF_SIZE); // doesn't move the read position
+		if (UsesLoneCRLineEndings(head.constData(), head.size()))
+		{
+			ccLog::Warning(QString("[ASCII] File '%1' uses legacy Mac line endings (CR): they will be read as regular ones").arg(filename));
+			crToLFDevice.reset(new CRToLFDevice(file));
+			if (!crToLFDevice->open(QIODevice::ReadOnly))
+			{
+				return CC_FERR_READING;
+			}
+		}
+	}
+
+	QTextStream stream(crToLFDevice ? static_cast<QIODevice*>(crToLFDevice.data()) : static_cast<QIODevice*>(&file));
 
 	return loadStream(stream, filename, file.size(), container, parameters);
 }
@@ -437,7 +538,18 @@ CC_FILE_ERROR AsciiFilter::loadAsciiData(const QByteArray& data,
                                          ccHObject&        container,
                                          LoadParameters&   parameters)
 {
-	QTextStream stream(data);
+	// same as above, but the data is already in memory so it can be converted directly
+	QByteArray        convertedData;
+	const QByteArray* inputData = &data;
+	if (UsesLoneCRLineEndings(data.constData(), std::min<qint64>(data.size(), LINE_ENDING_SNIFF_SIZE)))
+	{
+		ccLog::Warning(QString("[ASCII] '%1' uses legacy Mac line endings (CR): they will be read as regular ones").arg(sourceName));
+		convertedData = data;
+		convertedData.replace('\r', '\n');
+		inputData = &convertedData;
+	}
+
+	QTextStream stream(*inputData);
 
 	return loadStream(stream, sourceName, data.size(), container, parameters);
 }


### PR DESCRIPTION
Addresses #801.

`QTextStream::readLine()` only breaks on LF, so an ASCII file written with legacy Mac line endings (a lone CR) is read as one very long line. The crash is gone — the 512 column cap takes care of that — but the file still loads wrongly, and silently. The same 12 point cloud, saved two ways:

    lf_only.xyz  -> error=0  points=12
    cr_only.xyz  -> error=0  points=1

@asmaloney suggested reading character by character in the thread. I went a different way: the four `readLine()` calls include the loader's main loop, which runs once per point of every ASCII file, and I didn't want to slow the common case down for a legacy format.

`loadStream()` hands the same `QTextStream` to the dialog and to the loading loop, so there is one place to intervene. `AsciiFilter::loadFile` now peeks at the first 64 KB and, only if it finds a CR and no LF, wraps the `QFile` in a small read-only `QIODevice` that turns CR into LF as the bytes are read. The `readLine()` calls are untouched.

Notes:
- Nothing changes for files that already load: the device isn't created unless the sniff matches, and CRLF files always contain a LF.
- Replacing every CR is safe because such files contain no LF — the same condition the detection tests for.
- `loadAsciiData()` already has its data in memory, so there it's a plain `replace()`.

Built on Ubuntu 24.04 with GCC 15.3 and Qt 6.9.3, no new warnings. Loaded the same cloud saved as LF, CR only and CRLF: before the change the CR file gave 1 point, after it all three give 12, with identical coordinates. Not built on Windows or macOS.
