### PR TITLE
Make the ASCII column type names translatable

### DIFF
--- a/libs/qCC_io/include/AsciiOpenDlg.h
+++ b/libs/qCC_io/include/AsciiOpenDlg.h
@@ -22,6 +22,7 @@
 #include "qCC_io.h"
 
 // Qt
+#include <QCoreApplication>
 #include <QDialog>
 #include <QString>
 
@@ -157,30 +158,30 @@ class AsciiHeaderColumns
 	}
 };
 
-const char ASCII_OPEN_DLG_TYPES_NAMES[ASCII_OPEN_DLG_TYPES_COUNT][20] = {"Ignore",
-                                                                         "coord. X",
-                                                                         "coord. Y",
-                                                                         "coord. Z",
-                                                                         "Nx",
-                                                                         "Ny",
-                                                                         "Nz",
-                                                                         "Red (0-255)",
-                                                                         "Green (0-255)",
-                                                                         "Blue (0-255)",
-                                                                         "Alpha (0-255)",
-                                                                         "Red.float (0-1)",
-                                                                         "Green.float (0-1)",
-                                                                         "Blue.float (0-1)",
-                                                                         "Alpha.float (0-1)",
-                                                                         "Grey",
-                                                                         "RGBAi",
-                                                                         "RGBAf",
-                                                                         "Label",
-                                                                         "Quaternion W",
-                                                                         "Quaternion X",
-                                                                         "Quaternion Y",
-                                                                         "Quaternion Z",
-                                                                         "Scalar"};
+const char ASCII_OPEN_DLG_TYPES_NAMES[ASCII_OPEN_DLG_TYPES_COUNT][20] = {QT_TRANSLATE_NOOP("AsciiOpenDlg", "Ignore"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "coord. X"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "coord. Y"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "coord. Z"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "Nx"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "Ny"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "Nz"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "Red (0-255)"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "Green (0-255)"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "Blue (0-255)"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "Alpha (0-255)"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "Red.float (0-1)"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "Green.float (0-1)"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "Blue.float (0-1)"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "Alpha.float (0-1)"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "Grey"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "RGBAi"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "RGBAf"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "Label"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "Quaternion W"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "Quaternion X"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "Quaternion Y"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "Quaternion Z"),
+                                                                         QT_TRANSLATE_NOOP("AsciiOpenDlg", "Scalar")};
 
 class QComboBox;
 class QPushButton;

--- a/libs/qCC_io/src/AsciiOpenDlg.cpp
+++ b/libs/qCC_io/src/AsciiOpenDlg.cpp
@@ -626,7 +626,7 @@ void AsciiOpenDlg::updateTable()
 		propsText.reserve(ASCII_OPEN_DLG_TYPES_COUNT);
 		for (unsigned i = 0; i < ASCII_OPEN_DLG_TYPES_COUNT; i++)
 		{
-			propsText << QString(ASCII_OPEN_DLG_TYPES_NAMES[i]);
+			propsText << tr(ASCII_OPEN_DLG_TYPES_NAMES[i]);
 		}
 	}
 
@@ -1144,7 +1144,7 @@ bool AsciiOpenDlg::CheckOpenSequence(const AsciiOpenDlg::Sequence& sequence, QSt
 		{
 			if (counters[i] > 1)
 			{
-				errorMessage = tr("'%1' defined at least twice!").arg(ASCII_OPEN_DLG_TYPES_NAMES[i]);
+				errorMessage = tr("'%1' defined at least twice!").arg(tr(ASCII_OPEN_DLG_TYPES_NAMES[i]));
 				return false;
 			}
 		}


### PR DESCRIPTION
Follow-up to #2365. That one made the strings in `AsciiOpenDlg.cpp` translatable but missed the ones people look at most: the column type names ("coord. X", "Scalar", and so on) that fill the combo box under every column of the preview table. They also get pasted into the `'%1' defined at least twice!` message, so that message was translated while the name inside it stayed in English.

They're a `const char[][20]` array in the header, so lupdate needs `QT_TRANSLATE_NOOP` on the declaration, plus a lookup where they're used.

Notes:
- `QT_TRANSLATE_NOOP` just expands to the literal, so the array keeps its type and size.
- I pinned the context to `AsciiOpenDlg` so it matches the `tr()` calls and stays with the rest of the dialog.
- With no translation available the labels read exactly as before.

Built on Ubuntu 24.04 with GCC 15.3 and Qt 6.9.3, no new warnings. lupdate now picks the labels up in the `AsciiOpenDlg` context (9 -> 33 messages for libs/qCC_io), and with a small .qm translating two of them the combo boxes show the translated text while the rest stay English. Not built on Windows or macOS.
