### PR TITLE
Run the SOR filter in a worker thread to keep the GUI responsive (#2358)

### DIFF
--- a/libs/CCPluginAPI/include/CMakeLists.txt
+++ b/libs/CCPluginAPI/include/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources( ${PROJECT_NAME}
 	PRIVATE
 		${CMAKE_CURRENT_LIST_DIR}/CCPluginAPI.h
 		${CMAKE_CURRENT_LIST_DIR}/ccArgumentParser.h
+		${CMAKE_CURRENT_LIST_DIR}/ccBackgroundTask.h
 		${CMAKE_CURRENT_LIST_DIR}/ccColorScaleSelector.h
 		${CMAKE_CURRENT_LIST_DIR}/ccColorScaleEditorDlg.h
 		${CMAKE_CURRENT_LIST_DIR}/ccColorScaleEditorWidget.h

--- a/libs/CCPluginAPI/include/ccBackgroundTask.h
+++ b/libs/CCPluginAPI/include/ccBackgroundTask.h
@@ -1,0 +1,70 @@
+#pragma once
+// ##########################################################################
+// #                                                                        #
+// #                            CLOUDCOMPARE                                #
+// #                                                                        #
+// #  This program is free software; you can redistribute it and/or modify  #
+// #  it under the terms of the GNU General Public License as published by  #
+// #  the Free Software Foundation; version 2 of the License.               #
+// #                                                                        #
+// #  This program is distributed in the hope that it will be useful,       #
+// #  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+// #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+// #  GNU General Public License for more details.                          #
+// #                                                                        #
+// #                   COPYRIGHT: CloudCompare project                      #
+// #                                                                        #
+// ##########################################################################
+
+// Qt
+#include <QEventLoop>
+#include <QFutureWatcher>
+#include <QtConcurrentRun>
+
+// System
+#include <type_traits>
+#include <utility>
+
+//! Helper to run a long computation without freezing the GUI
+class ccBackgroundTask
+{
+  public:
+	//! Runs a function in a worker thread while the GUI keeps refreshing
+	/** Calling a long computation directly from the GUI thread blocks it. Progress
+	    dialogs post their refresh to the GUI thread (see ccProgressDialog::update),
+	    so while that thread is blocked nothing is repainted and the application
+	    looks frozen, even though the progress value is being updated.
+
+	    This runs 'function' in a worker thread and spins a local event loop until it
+	    is done. Queued refreshes are then processed as they arrive, so the progress
+	    dialog updates and the Cancel button stays usable. The call still only
+	    returns once the function has finished, so callers don't need restructuring.
+
+	    \warning the rest of the application also stays responsive while the function
+	    runs, so the caller should make sure that starting another operation in the
+	    meantime is either harmless or prevented.
+
+	    \param function the function to run
+	    \return whatever the function returns
+	**/
+	template <typename Func>
+	static auto Run(Func&& function) -> decltype(function())
+	{
+		using ResultType = decltype(function());
+
+		QFutureWatcher<ResultType> watcher;
+		QEventLoop                 loop;
+
+		// queued, so that the loop is still quit properly if the function happens to
+		// finish before exec() has started
+		QObject::connect(&watcher, &QFutureWatcherBase::finished, &loop, &QEventLoop::quit, Qt::QueuedConnection);
+
+		watcher.setFuture(QtConcurrent::run(std::forward<Func>(function)));
+		loop.exec();
+
+		if constexpr (!std::is_void_v<ResultType>)
+		{
+			return watcher.result();
+		}
+	}
+};

--- a/libs/qCC_db/src/ccProgressDialog.cpp
+++ b/libs/qCC_db/src/ccProgressDialog.cpp
@@ -18,14 +18,9 @@
 #include "ccProgressDialog.h"
 
 // Qt
-#include <CCPlatform.h>
 #include <QCoreApplication>
-#include <QProgressBar>
 #include <QPushButton>
 #include <QThread>
-#if defined(CC_WINDOWS)
-#include <windows.h>
-#endif
 
 ccProgressDialog::ccProgressDialog(bool     showCancelButton,
                                    QWidget* parent /*=nullptr*/)
@@ -76,9 +71,6 @@ void ccProgressDialog::update(float percent)
 			// breathe so that the dialog is actually repainted
 			refresh();
 			QCoreApplication::processEvents();
-#if defined(CC_WINDOWS)
-			::Sleep(1);
-#endif
 		}
 		else
 		{

--- a/libs/qCC_db/src/ccProgressDialog.cpp
+++ b/libs/qCC_db/src/ccProgressDialog.cpp
@@ -71,7 +71,7 @@ void ccProgressDialog::update(float percent)
 	{
 		m_currentValue = value;
 #if defined(CC_WINDOWS)
-		if (QThread::currentThread() && QThread::currentThread()->isMainThread())
+		if (QThread::currentThread() == thread())
 		{
 			refresh();
 			::Sleep(1);
@@ -81,23 +81,38 @@ void ccProgressDialog::update(float percent)
 		{
 			QTimer::singleShot(0, this, [this]()
 			                   { refresh(); });
-			QCoreApplication::processEvents();
 		}
 	}
 }
 
 void ccProgressDialog::setMethodTitle(QString methodTitle)
 {
-	setWindowTitle(methodTitle);
+	if (QThread::currentThread() == thread())
+	{
+		setWindowTitle(methodTitle);
+		QCoreApplication::processEvents();
+	}
+	else
+	{
+		QTimer::singleShot(0, this, [this, methodTitle]()
+		                   { setWindowTitle(methodTitle); });
+	}
 }
 
 void ccProgressDialog::setInfo(QString infoStr)
 {
-	setLabelText(infoStr);
-	if (isVisible())
+	if (QThread::currentThread() == thread())
 	{
-		QProgressDialog::update();
-		QCoreApplication::processEvents();
+		if (isVisible())
+		{
+			QProgressDialog::update();
+			QCoreApplication::processEvents();
+		}
+	}
+	else
+	{
+		QTimer::singleShot(0, this, [this, infoStr]()
+		                   { setLabelText(infoStr); });
 	}
 }
 

--- a/libs/qCC_db/src/ccProgressDialog.cpp
+++ b/libs/qCC_db/src/ccProgressDialog.cpp
@@ -22,8 +22,8 @@
 #include <QCoreApplication>
 #include <QProgressBar>
 #include <QPushButton>
-#if defined(CC_WINDOWS)
 #include <QThread>
+#if defined(CC_WINDOWS)
 #include <windows.h>
 #endif
 
@@ -103,13 +103,32 @@ void ccProgressDialog::setInfo(QString infoStr)
 
 void ccProgressDialog::start()
 {
+	// thread-safe: algorithms may call this from a worker thread, and a widget can
+	// only be shown from the thread it lives in
 	m_lastRefreshValue = -1;
-	show();
-	QCoreApplication::processEvents();
+	if (QThread::currentThread() == thread())
+	{
+		show();
+		QCoreApplication::processEvents();
+	}
+	else
+	{
+		QTimer::singleShot(0, this, [this]()
+		                   { show(); });
+	}
 }
 
 void ccProgressDialog::stop()
 {
-	hide();
-	QCoreApplication::processEvents();
+	// thread-safe, see start()
+	if (QThread::currentThread() == thread())
+	{
+		hide();
+		QCoreApplication::processEvents();
+	}
+	else
+	{
+		QTimer::singleShot(0, this, [this]()
+		                   { hide(); });
+	}
 }

--- a/libs/qCC_db/src/ccProgressDialog.cpp
+++ b/libs/qCC_db/src/ccProgressDialog.cpp
@@ -70,15 +70,19 @@ void ccProgressDialog::update(float percent)
 	if (value != m_currentValue)
 	{
 		m_currentValue = value;
-#if defined(CC_WINDOWS)
 		if (QThread::currentThread() == thread())
 		{
+			// called from the GUI thread: refresh directly, and let the event loop
+			// breathe so that the dialog is actually repainted
 			refresh();
+			QCoreApplication::processEvents();
+#if defined(CC_WINDOWS)
 			::Sleep(1);
+#endif
 		}
 		else
-#endif
 		{
+			// called from a worker thread: the refresh has to happen in the GUI thread
 			QTimer::singleShot(0, this, [this]()
 			                   { refresh(); });
 		}
@@ -103,6 +107,7 @@ void ccProgressDialog::setInfo(QString infoStr)
 {
 	if (QThread::currentThread() == thread())
 	{
+		setLabelText(infoStr);
 		if (isVisible())
 		{
 			QProgressDialog::update();

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -64,6 +64,7 @@
 #include <ccRenderingTools.h>
 
 // CCPluginAPI
+#include <ccBackgroundTask.h>
 #include <ccQtHelpers.h>
 
 // local includes
@@ -6024,13 +6025,17 @@ void MainWindow::doActionSORFilter()
 			continue;
 		}
 
-		// computation
-		CCCoreLib::ReferenceCloud* selection = CCCoreLib::CloudSamplingTools::sorFilter(cloud,
-		                                                                                s_sorFilterKnn,
-		                                                                                s_sorFilterNSigma,
-		                                                                                cloud->getOctree().data(),
-		                                                                                &pDlg,
-		                                                                                s_maxThreadCount);
+		// computation (in a worker thread, so that the progress dialog keeps refreshing)
+		CCCoreLib::ReferenceCloud* selection = ccBackgroundTask::Run(
+		    [&]()
+		    {
+			    return CCCoreLib::CloudSamplingTools::sorFilter(cloud,
+			                                                    s_sorFilterKnn,
+			                                                    s_sorFilterNSigma,
+			                                                    cloud->getOctree().data(),
+			                                                    &pDlg,
+			                                                    s_maxThreadCount);
+		    });
 
 		if (selection)
 		{


### PR DESCRIPTION
Addresses #2358, carrying on from the discussion there.

`ccBackgroundTask::Run()` takes a function, runs it on a worker thread, and spins a local event loop until it comes back. The call only returns once the function is done, so callers don't need rewriting. I put it in CCPluginAPI as its own header rather than in `ccQtHelpers.h`, so nothing that already includes that picks up a QtConcurrent dependency it didn't have.

The new file uses the `COPYRIGHT: CloudCompare project` banner, the same one `ccArgumentParser.h` has, rather than the older EDF R&D / TELECOM ParisTech one that most of the files in that folder still carry. Let me know if you'd rather it matched the neighbours instead.

The SOR call site ends up like this:

```cpp
CCCoreLib::ReferenceCloud* selection = ccBackgroundTask::Run(
    [&]()
    {
	    return CCCoreLib::CloudSamplingTools::sorFilter(cloud, s_sorFilterKnn, s_sorFilterNSigma,
	                                                    cloud->getOctree().data(), &pDlg, s_maxThreadCount);
    });
```

I had to touch `ccProgressDialog` as well. Algorithms call `start()` and `stop()` on the callback, and once the work happens on a worker thread those calls arrive there too, so `show()` and `hide()` were being called from the wrong thread. Qt complains about it ("Timers cannot be stopped from another thread"). They now hop over to the GUI thread the same way `update()` already did.

To see whether the event loop really keeps running, I put a timer on the GUI thread during a SOR over 3M points and counted the ticks:

| | heartbeats | took | points kept |
| --- | --- | --- | --- |
| before | 1 of a possible 19 | 973 ms | 2525966 |
| after | 19 of 19 | 960 ms | 2525966 |

Same output, same time.

I also tried it in the GUI on a 6M point cloud, and two things came up.

The bar now visibly resets once partway through. That's just the octree being built first and then the filter itself, two phases that each go from 0 to 100. It always did that, you simply couldn't see it before because the bar never moved.

There's also still a short freeze right at the end. That one is `cloud->partialClone(selection)` copying the surviving points, which runs after the call above and is still on the GUI thread. It has no progress callback so I left it alone, but it could go through the same helper if you'd rather the whole action stayed responsive.

Two things I'd like your view on.

The rest of the app is live now while SOR runs. That's the whole point, but it does mean someone could start something else halfway through. The progress dialog goes out of its way not to take focus (`WA_ShowWithoutActivating`), so making it modal felt like something to ask about rather than just do.

And I only did SOR here, like you suggested. The noise filter, C2C distances and M3C2 would suit the same thing, and the hand written wait loops in qPoissonRecon, qRANSAC_SD, qMeshBoolean, qCork and qPCL could fold into it as well. Happy to do those as follow ups once you're happy with how this looks.

Built on Ubuntu 24.04 with GCC 15.3 and Qt 6.9.3, no new warnings. Not built on Windows or macOS.
