### PR TITLE
Run the noise filter and distance computations in a worker thread (#2358)

### DIFF
--- a/libs/qCC_db/include/ccPointCloud.h
+++ b/libs/qCC_db/include/ccPointCloud.h
@@ -707,7 +707,6 @@ class QCC_DB_LIB_API ccPointCloud : public CCCoreLib::PointCloudTpl<ccGenericPoi
 		bool             applyToSFduringRGB      = false;
 		RGB_FILTER_TYPES filterType              = RGB_FILTER_TYPES::NONE;
 		unsigned char    burntOutColorThreshold  = 0;
-		bool             commandLine             = false;
 		double           sigmaSF                 = -1;
 		double           spatialSigma            = -1;
 		bool             blendGrayscale          = false;

--- a/qCC/ccCommandLineCommands.cpp
+++ b/qCC/ccCommandLineCommands.cpp
@@ -6602,7 +6602,6 @@ bool CommandFilter::process(ccCommandLineInterface& cmd)
 	bool applyToSF  = false;
 	bool gaussian   = false;
 	ccPointCloud::RgbFilterOptions(filterParams);
-	filterParams.commandLine = true;
 	while (!cmd.arguments().empty())
 	{
 		QString argument = cmd.arguments().front();
@@ -6753,11 +6752,11 @@ bool CommandFilter::process(ccCommandLineInterface& cmd)
 	}
 	if (applyToSF)
 	{
-		return ccEntityAction::sfGaussianFilter(selectedEntities, filterParams, cmd.widgetParent());
+		return ccEntityAction::sfGaussianFilter(selectedEntities, filterParams, cmd.widgetParent(), true);
 	}
 	else if (applyToRGB)
 	{
-		return ccEntityAction::rgbGaussianFilter(selectedEntities, filterParams, cmd.widgetParent());
+		return ccEntityAction::rgbGaussianFilter(selectedEntities, filterParams, cmd.widgetParent(), true);
 	}
 
 	return true;

--- a/qCC/ccComparisonDlg.cpp
+++ b/qCC/ccComparisonDlg.cpp
@@ -29,6 +29,7 @@
 #include <ScalarFieldTools.h>
 
 // qCC_db
+#include <ccBackgroundTask.h>
 #include <ccGBLSensor.h>
 #include <ccGenericMesh.h>
 #include <ccHObject.h>
@@ -852,12 +853,17 @@ bool ccComparisonDlg::computeDistances()
 			c2cParams.CPSet         = nullptr;
 		}
 
-		result = CCCoreLib::DistanceComputationTools::computeCloud2CloudDistances(m_compCloud,
-		                                                                          m_refCloud,
-		                                                                          c2cParams,
-		                                                                          progressDlg.data(),
-		                                                                          m_compOctree.data(),
-		                                                                          m_refOctree.data());
+		// in a worker thread, so that the progress dialog keeps refreshing
+		result = ccBackgroundTask::Run(
+		    [&]()
+		    {
+			    return CCCoreLib::DistanceComputationTools::computeCloud2CloudDistances(m_compCloud,
+			                                                                            m_refCloud,
+			                                                                            c2cParams,
+			                                                                            progressDlg.data(),
+			                                                                            m_compOctree.data(),
+			                                                                            m_refOctree.data());
+		    });
 		break;
 
 	case CLOUDMESH_DIST: // cloud-mesh
@@ -873,11 +879,16 @@ bool ccComparisonDlg::computeDistances()
 			c2mParams.robust          = robust;
 		}
 
-		result = CCCoreLib::DistanceComputationTools::computeCloud2MeshDistances(m_compCloud,
-		                                                                         m_refMesh,
-		                                                                         c2mParams,
-		                                                                         progressDlg.data(),
-		                                                                         m_compOctree.data());
+		// in a worker thread, so that the progress dialog keeps refreshing
+		result = ccBackgroundTask::Run(
+		    [&]()
+		    {
+			    return CCCoreLib::DistanceComputationTools::computeCloud2MeshDistances(m_compCloud,
+			                                                                           m_refMesh,
+			                                                                           c2mParams,
+			                                                                           progressDlg.data(),
+			                                                                           m_compOctree.data());
+		    });
 		break;
 	}
 	qint64 elapsedTime_ms = eTimer.elapsed();

--- a/qCC/ccEntityAction.cpp
+++ b/qCC/ccEntityAction.cpp
@@ -2878,87 +2878,94 @@ namespace ccEntityAction
 			bbox = coDlg.getCustomBBox();
 		}
 
-		return ccBackgroundTask::Run(
-		    [&]()
-		    {
-			    for (const auto cloud : clouds)
-			    {
-				    // we temporarily detach entity, as it may undergo
-				    //'severe' modifications (octree deletion, etc.) --> see ccPointCloud::computeOctree
-				    ccMainAppInterface*                  instance = dynamic_cast<ccMainAppInterface*>(parent);
-				    ccMainAppInterface::ccHObjectContext objContext;
-				    if (instance)
-				    {
-					    objContext = instance->removeObjectTemporarilyFromDBTree(cloud);
-				    }
+		// the dialog values are read here, on the GUI thread
+		const ccComputeOctreeDlg::ComputationMode mode           = coDlg.getMode();
+		const double                              chosenCellSize = coDlg.getMinCellSize();
 
-				    // computation
-				    QElapsedTimer eTimer;
-				    eTimer.start();
-				    ccOctree::Shared octree(nullptr);
-				    switch (coDlg.getMode())
+		for (const auto cloud : clouds)
+		{
+			// we temporarily detach entity, as it may undergo
+			//'severe' modifications (octree deletion, etc.) --> see ccPointCloud::computeOctree
+			// (the DB tree is a Qt model, so this has to stay on the GUI thread)
+			ccMainAppInterface*                  instance = dynamic_cast<ccMainAppInterface*>(parent);
+			ccMainAppInterface::ccHObjectContext objContext;
+			if (instance)
+			{
+				objContext = instance->removeObjectTemporarilyFromDBTree(cloud);
+			}
+
+			// for a cell-size based custom box, we must update it for each cloud!
+			if (mode == ccComputeOctreeDlg::MIN_CELL_SIZE)
+			{
+				PointCoordinateType halfBoxWidth = static_cast<PointCoordinateType>(chosenCellSize * (1 << ccOctree::MAX_OCTREE_LEVEL) / 2.0);
+				ccBBox              bbBox        = cloud->getOwnBB();
+				CCVector3           C            = bbBox.getCenter();
+				bbox                             = ccBBox(C - CCVector3(halfBoxWidth, halfBoxWidth, halfBoxWidth),
+                              C + CCVector3(halfBoxWidth, halfBoxWidth, halfBoxWidth),
+                              bbBox.isValid());
+			}
+
+			// only the computation itself runs in a worker thread
+			QElapsedTimer eTimer;
+			eTimer.start();
+			ccOctree::Shared octree = ccBackgroundTask::Run(
+			    [&]() -> ccOctree::Shared
+			    {
+				    switch (mode)
 				    {
 				    case ccComputeOctreeDlg::DEFAULT:
-					    octree = cloud->computeOctree(&pDlg);
-					    break;
+					    return cloud->computeOctree(&pDlg);
+
 				    case ccComputeOctreeDlg::MIN_CELL_SIZE:
 				    case ccComputeOctreeDlg::CUSTOM_BBOX:
 				    {
-					    // for a cell-size based custom box, we must update it for each cloud!
-					    if (coDlg.getMode() == ccComputeOctreeDlg::MIN_CELL_SIZE)
-					    {
-						    double              cellSize     = coDlg.getMinCellSize();
-						    PointCoordinateType halfBoxWidth = static_cast<PointCoordinateType>(cellSize * (1 << ccOctree::MAX_OCTREE_LEVEL) / 2.0);
-						    ccBBox              bbBox        = cloud->getOwnBB();
-						    CCVector3           C            = bbBox.getCenter();
-						    bbox                             = ccBBox(C - CCVector3(halfBoxWidth, halfBoxWidth, halfBoxWidth),
-                                          C + CCVector3(halfBoxWidth, halfBoxWidth, halfBoxWidth),
-                                          bbBox.isValid());
-					    }
 					    cloud->deleteOctree();
-					    octree = ccOctree::Shared(new ccOctree(cloud));
-					    if (octree->build(bbox.minCorner(), bbox.maxCorner(), nullptr, nullptr, &pDlg) > 0)
+					    ccOctree::Shared newOctree(new ccOctree(cloud));
+					    if (newOctree->build(bbox.minCorner(), bbox.maxCorner(), nullptr, nullptr, &pDlg) > 0)
 					    {
-						    ccOctreeProxy* proxy = new ccOctreeProxy(octree);
-						    proxy->setDisplay(cloud->getDisplay());
-						    cloud->addChild(proxy);
+						    return newOctree;
 					    }
-					    else
-					    {
-						    octree.clear();
-					    }
+					    return ccOctree::Shared(nullptr);
 				    }
-				    break;
+
 				    default:
 					    Q_ASSERT(false);
-					    return false;
+					    return ccOctree::Shared(nullptr);
 				    }
-				    qint64 elapsedTime_ms = eTimer.elapsed();
+			    });
+			qint64 elapsedTime_ms = eTimer.elapsed();
 
-				    // put object back in tree
-				    if (instance)
-				    {
-					    instance->putObjectBackIntoDBTree(cloud, objContext);
-				    }
+			// attaching the proxy touches the scene graph, so it stays on the GUI thread too
+			if (octree && mode != ccComputeOctreeDlg::DEFAULT)
+			{
+				ccOctreeProxy* proxy = new ccOctreeProxy(octree);
+				proxy->setDisplay(cloud->getDisplay());
+				cloud->addChild(proxy);
+			}
 
-				    if (octree)
-				    {
-					    ccLog::Print("[doActionComputeOctree] Timing: %2.3f s", static_cast<double>(elapsedTime_ms) / 1000.0);
-					    cloud->setEnabled(true); // for vertices!
-					    ccOctreeProxy* proxy = cloud->getOctreeProxy();
-					    assert(proxy);
-					    proxy->setVisible(true);
-					    proxy->setEnabled(true);
-					    proxy->prepareDisplayForRefresh();
-				    }
-				    else
-				    {
-					    ccLog::Warning(QObject::tr("Octree computation on cloud '%1' failed!").arg(cloud->getName()));
-				    }
-			    }
+			// put object back in tree
+			if (instance)
+			{
+				instance->putObjectBackIntoDBTree(cloud, objContext);
+			}
 
-			    return true;
-		    });
+			if (octree)
+			{
+				ccLog::Print("[doActionComputeOctree] Timing: %2.3f s", static_cast<double>(elapsedTime_ms) / 1000.0);
+				cloud->setEnabled(true); // for vertices!
+				ccOctreeProxy* proxy = cloud->getOctreeProxy();
+				assert(proxy);
+				proxy->setVisible(true);
+				proxy->setEnabled(true);
+				proxy->prepareDisplayForRefresh();
+			}
+			else
+			{
+				ccLog::Warning(QObject::tr("Octree computation on cloud '%1' failed!").arg(cloud->getName()));
+			}
+		}
+
+		return true;
 	}
 
 	//////////

--- a/qCC/ccEntityAction.cpp
+++ b/qCC/ccEntityAction.cpp
@@ -30,6 +30,7 @@
 #include <WeibullDistribution.h>
 
 // qCC_db
+#include <ccBackgroundTask.h>
 #include <ccColorScalesManager.h>
 #include <ccFacet.h>
 #include <ccGenericPrimitive.h>
@@ -2230,18 +2231,22 @@ namespace ccEntityAction
 
 			ccProgressDialog pDlg(true, parent);
 			pDlg.setAutoClose(false);
+			pDlg.setModal(true);
 
 			size_t errors = 0;
 
-			for (auto cloud : clouds)
-			{
-				Q_ASSERT(cloud != nullptr);
+			ccBackgroundTask::Run(
+			    [&]()
+			    {
+				    for (auto cloud : clouds)
+				    {
+					    Q_ASSERT(cloud != nullptr);
 
-				bool result                 = false;
-				bool normalsAlreadyOriented = false;
+					    bool result                 = false;
+					    bool normalsAlreadyOriented = false;
 
-				if (useGridStructure && cloud->gridCount())
-				{
+					    if (useGridStructure && cloud->gridCount())
+					    {
 #if 0
 					ccPointCloud* newCloud = new ccPointCloud("temp");
 					newCloud->reserve(cloud->size());
@@ -2273,94 +2278,95 @@ namespace ccEntityAction
 						addToDB(newCloud);
 					}
 #endif
-					if (s_orientNormals)
-					{
-						if (orientNormalsWithGrids || orientNormalsWithSensors) // withGrids and withSensors take precedence over other methods
-						{
-							ccLog::Print("[computeNormals] Compute + orient normals with grids");
-							result = cloud->computeNormalsWithGrids(minGridAngle_deg, &pDlg, ccNormalVectors::UNDEFINED);
-							if (orientNormalsWithGrids) // it is possible to orient the normals later with sensors or MST
-							{
-								normalsAlreadyOriented = true;
-							}
-						}
-						else
-						{
-							ccLog::Print("[computeNormals] Compute normals with grids, preferred orientation: " + QString::number(preferredOrientation) + " (255 = undefined)");
-							normalsAlreadyOriented = preferredOrientation != ccNormalVectors::UNDEFINED;
-							result                 = cloud->computeNormalsWithGrids(minGridAngle_deg, &pDlg, preferredOrientation); // the previous normals are overwritten if any
-						}
-					}
-					else
-					{
-						ccLog::Print("[computeNormals] Compute + orient normals with grids");
-						normalsAlreadyOriented = true;
-						result                 = cloud->computeNormalsWithGrids(minGridAngle_deg, &pDlg, ccNormalVectors::UNDEFINED);
-					}
-				}
-				else
-				{
-					// compute normals with the octree
-					ccLog::Print("[computeNormals] compute normals with octree, preferred orientation: " + QString::number(preferredOrientation) + " (255 = undefined)");
-					normalsAlreadyOriented = s_orientNormals && (preferredOrientation != ccNormalVectors::UNDEFINED);
-					result                 = cloud->computeNormalsWithOctree(model, s_orientNormals ? preferredOrientation : ccNormalVectors::UNDEFINED, defaultRadius, &pDlg);
-					if (result)
-					{
-						// save the normal computation radius as meta-data
-						cloud->setMetaData(s_NormalScaleKey, defaultRadius);
-					}
-				}
+						    if (s_orientNormals)
+						    {
+							    if (orientNormalsWithGrids || orientNormalsWithSensors) // withGrids and withSensors take precedence over other methods
+							    {
+								    ccLog::Print("[computeNormals] Compute + orient normals with grids");
+								    result = cloud->computeNormalsWithGrids(minGridAngle_deg, &pDlg, ccNormalVectors::UNDEFINED);
+								    if (orientNormalsWithGrids) // it is possible to orient the normals later with sensors or MST
+								    {
+									    normalsAlreadyOriented = true;
+								    }
+							    }
+							    else
+							    {
+								    ccLog::Print("[computeNormals] Compute normals with grids, preferred orientation: " + QString::number(preferredOrientation) + " (255 = undefined)");
+								    normalsAlreadyOriented = preferredOrientation != ccNormalVectors::UNDEFINED;
+								    result                 = cloud->computeNormalsWithGrids(minGridAngle_deg, &pDlg, preferredOrientation); // the previous normals are overwritten if any
+							    }
+						    }
+						    else
+						    {
+							    ccLog::Print("[computeNormals] Compute + orient normals with grids");
+							    normalsAlreadyOriented = true;
+							    result                 = cloud->computeNormalsWithGrids(minGridAngle_deg, &pDlg, ccNormalVectors::UNDEFINED);
+						    }
+					    }
+					    else
+					    {
+						    // compute normals with the octree
+						    ccLog::Print("[computeNormals] compute normals with octree, preferred orientation: " + QString::number(preferredOrientation) + " (255 = undefined)");
+						    normalsAlreadyOriented = s_orientNormals && (preferredOrientation != ccNormalVectors::UNDEFINED);
+						    result                 = cloud->computeNormalsWithOctree(model, s_orientNormals ? preferredOrientation : ccNormalVectors::UNDEFINED, defaultRadius, &pDlg);
+						    if (result)
+						    {
+							    // save the normal computation radius as meta-data
+							    cloud->setMetaData(s_NormalScaleKey, defaultRadius);
+						    }
+					    }
 
-				// do we need to orient the normals? (this may have been already done if 'orientNormalsForThisCloud' is true)
-				if (result && s_orientNormals && !normalsAlreadyOriented)
-				{
-					if (cloud->gridCount() && orientNormalsWithGrids)
-					{
-						ccLog::Print("[computeNormals] orient normals with grids");
-						// we can still use the grid structure(s) to orient the normals!
-						result = cloud->orientNormalsWithGrids();
-					}
-					else if (cloud->hasSensor() && orientNormalsWithSensors)
-					{
-						ccLog::Print("[computeNormals] orient normals with sensors");
-						result = false;
+					    // do we need to orient the normals? (this may have been already done if 'orientNormalsForThisCloud' is true)
+					    if (result && s_orientNormals && !normalsAlreadyOriented)
+					    {
+						    if (cloud->gridCount() && orientNormalsWithGrids)
+						    {
+							    ccLog::Print("[computeNormals] orient normals with grids");
+							    // we can still use the grid structure(s) to orient the normals!
+							    result = cloud->orientNormalsWithGrids();
+						    }
+						    else if (cloud->hasSensor() && orientNormalsWithSensors)
+						    {
+							    ccLog::Print("[computeNormals] orient normals with sensors");
+							    result = false;
 
-						// RJ: TODO: the issue here is that a cloud can have multiple sensors.
-						// As the association to sensor is not explicit in CC, given a cloud
-						// some points can belong to one sensor and some others can belongs to others sensors.
-						// so it's why here grid orientation has precedence over sensor orientation because in this
-						// case association is more explicit.
-						// Here we take the first valid viewpoint for now even if it's not a good one...
-						for (unsigned i = 0; i < cloud->getChildrenNumber(); ++i)
-						{
-							ccHObject* child = cloud->getChild(i);
-							if (child && child->isKindOf(CC_TYPES::SENSOR))
-							{
-								ccSensor* sensor = ccHObjectCaster::ToSensor(child);
-								CCVector3 sensorPosition;
-								if (sensor->getActiveAbsoluteCenter(sensorPosition))
-								{
-									result = cloud->orientNormalsTowardViewPoint(sensorPosition, &pDlg);
-									break;
-								}
-							}
-						}
-					}
-					else if (orientNormalsMST)
-					{
-						ccLog::Print("[computeNormals] orient normals with Minimum Spanning Tree");
-						// use Minimum Spanning Tree to resolve normals direction
-						result = cloud->orientNormalsWithMST(mstNeighbors, &pDlg);
-					}
-				}
+							    // RJ: TODO: the issue here is that a cloud can have multiple sensors.
+							    // As the association to sensor is not explicit in CC, given a cloud
+							    // some points can belong to one sensor and some others can belongs to others sensors.
+							    // so it's why here grid orientation has precedence over sensor orientation because in this
+							    // case association is more explicit.
+							    // Here we take the first valid viewpoint for now even if it's not a good one...
+							    for (unsigned i = 0; i < cloud->getChildrenNumber(); ++i)
+							    {
+								    ccHObject* child = cloud->getChild(i);
+								    if (child && child->isKindOf(CC_TYPES::SENSOR))
+								    {
+									    ccSensor* sensor = ccHObjectCaster::ToSensor(child);
+									    CCVector3 sensorPosition;
+									    if (sensor->getActiveAbsoluteCenter(sensorPosition))
+									    {
+										    result = cloud->orientNormalsTowardViewPoint(sensorPosition, &pDlg);
+										    break;
+									    }
+								    }
+							    }
+						    }
+						    else if (orientNormalsMST)
+						    {
+							    ccLog::Print("[computeNormals] orient normals with Minimum Spanning Tree");
+							    // use Minimum Spanning Tree to resolve normals direction
+							    result = cloud->orientNormalsWithMST(mstNeighbors, &pDlg);
+						    }
+					    }
 
-				if (!result)
-				{
-					++errors;
-				}
+					    if (!result)
+					    {
+						    ++errors;
+					    }
 
-				cloud->prepareDisplayForRefresh();
-			}
+					    cloud->prepareDisplayForRefresh();
+				    }
+			    });
 
 			if (errors != 0)
 			{
@@ -2395,12 +2401,16 @@ namespace ccEntityAction
 				ccMainAppInterface*                  instance = dynamic_cast<ccMainAppInterface*>(parent);
 				ccMainAppInterface::ccHObjectContext objContext;
 				if (instance)
+				{
 					objContext = instance->removeObjectTemporarilyFromDBTree(mesh);
+				}
 				mesh->clearTriNormals();
 				mesh->showNormals(false);
 				bool result = mesh->computeNormals(computePerVertexNormals);
 				if (instance)
+				{
 					instance->putObjectBackIntoDBTree(mesh, objContext);
+				}
 
 				if (!result)
 				{

--- a/qCC/ccEntityAction.cpp
+++ b/qCC/ccEntityAction.cpp
@@ -11,7 +11,7 @@
 // #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
 // #  GNU General Public License for more details.                          #
 // #                                                                        #
-// #          COPYRIGHT: CloudCompare project                               #
+// #                   COPYRIGHT: CloudCompare project                      #
 // #                                                                        #
 // ##########################################################################
 
@@ -53,7 +53,6 @@
 #include "ccColorLevelsDlg.h"
 #include "ccCommon.h"
 #include "ccComputeOctreeDlg.h"
-#include "ccConsole.h"
 #include "ccEntityAction.h"
 #include "ccExportCoordToSFDlg.h"
 #include "ccHistogramWindow.h"
@@ -110,7 +109,9 @@ namespace ccEntityAction
 		QColor        colour      = QColorDialog::getColor(s_lastColor, parent, QString(), QColorDialog::ShowAlphaChannel);
 
 		if (!colour.isValid())
+		{
 			return false;
+		}
 
 		s_lastColor = colour;
 
@@ -122,7 +123,9 @@ namespace ccEntityAction
 			{
 				// automatically parse a group's children set
 				for (unsigned i = 0; i < ent->getChildrenNumber(); ++i)
+				{
 					selectedEntities.push_back(ent->getChild(i));
+				}
 			}
 			else if (ent->isA(CC_TYPES::POINT_CLOUD) || ent->isA(CC_TYPES::MESH))
 			{
@@ -299,7 +302,7 @@ namespace ccEntityAction
 	{
 		if (selectedEntities.size() != 1)
 		{
-			ccConsole::Error(QObject::tr("Select one and only one colored cloud or mesh!"));
+			ccLog::Error(QT_TR_NOOP("Select one and only one colored cloud or mesh!"));
 			return false;
 		}
 
@@ -317,7 +320,7 @@ namespace ccEntityAction
 		}
 		if (!pc->hasColors())
 		{
-			ccConsole::Error(QObject::tr("Selected entity has no colors!"));
+			ccLog::Error(QT_TR_NOOP("Selected entity has no colors!"));
 			return false;
 		}
 
@@ -332,7 +335,7 @@ namespace ccEntityAction
 	{
 		if (selectedEntities.size() != 2)
 		{
-			ccConsole::Error(QObject::tr("Select 2 entities (clouds or meshes)!"));
+			ccLog::Error(QT_TR_NOOP("Select 2 entities (clouds or meshes)!"));
 			return false;
 		}
 
@@ -344,18 +347,18 @@ namespace ccEntityAction
 
 		if (!cloud1 || !cloud2)
 		{
-			ccConsole::Error(QObject::tr("Select 2 entities (clouds or meshes)!"));
+			ccLog::Error(QT_TR_NOOP("Select 2 entities (clouds or meshes)!"));
 			return false;
 		}
 
 		if (!cloud1->hasColors() && !cloud2->hasColors())
 		{
-			ccConsole::Error(QObject::tr("None of the selected entities has per-point or per-vertex colors!"));
+			ccLog::Error(QT_TR_NOOP("None of the selected entities has per-point or per-vertex colors!"));
 			return false;
 		}
 		else if (cloud1->hasColors() && cloud2->hasColors())
 		{
-			ccConsole::Error(QObject::tr("Both entities have colors! Remove the colors on the entity you wish to import the colors to!"));
+			ccLog::Error(QT_TR_NOOP("Both entities have colors! Remove the colors on the entity you wish to import the colors to!"));
 			return false;
 		}
 
@@ -371,25 +374,36 @@ namespace ccEntityAction
 
 		if (!dest->isA(CC_TYPES::POINT_CLOUD))
 		{
-			ccConsole::Error(QObject::tr("Destination cloud (or vertices) must be a real point cloud!"));
+			ccLog::Error(QT_TR_NOOP("Destination cloud (or vertices) must be a real point cloud!"));
 			return false;
 		}
 
 		ccProgressDialog pDlg(true, parent);
+		pDlg.setModal(true);
 
-		if (static_cast<ccPointCloud*>(dest)->interpolateColorsFrom(source, &pDlg))
+		bool success = ccBackgroundTask::Run(
+		    [&]()
+		    {
+			    if (static_cast<ccPointCloud*>(dest)->interpolateColorsFrom(source, &pDlg))
+			    {
+				    ent2->showColors(true);
+				    ent2->showSF(false); // just in case
+			    }
+			    else
+			    {
+				    return false;
+			    }
+
+			    ent2->prepareDisplayForRefresh_recursive();
+			    return true;
+		    });
+
+		if (!success)
 		{
-			ent2->showColors(true);
-			ent2->showSF(false); // just in case
-		}
-		else
-		{
-			ccConsole::Error(QObject::tr("An error occurred! (see console)"));
+			ccLog::Error(QT_TR_NOOP("An error occurred! (see console)"));
 		}
 
-		ent2->prepareDisplayForRefresh_recursive();
-
-		return true;
+		return success;
 	}
 
 	//! Interpolate scalar fields from one entity and transfer them to another one
@@ -397,7 +411,7 @@ namespace ccEntityAction
 	{
 		if (selectedEntities.size() != 2)
 		{
-			ccConsole::Error(QObject::tr("Select 2 entities (clouds or meshes)!"));
+			ccLog::Error(QT_TR_NOOP("Select 2 entities (clouds or meshes)!"));
 			return false;
 		}
 
@@ -409,19 +423,19 @@ namespace ccEntityAction
 
 		if (nullptr == cloud1 || nullptr == cloud2)
 		{
-			ccConsole::Error(QObject::tr("Select 2 entities (clouds or meshes)!"));
+			ccLog::Error(QT_TR_NOOP("Select 2 entities (clouds or meshes)!"));
 			return false;
 		}
 
 		if (!cloud1->hasScalarFields() && !cloud2->hasScalarFields())
 		{
-			ccConsole::Error(QObject::tr("None of the selected entities has per-point or per-vertex colors!"));
+			ccLog::Error(QT_TR_NOOP("None of the selected entities has per-point or per-vertex colors!"));
 			return false;
 		}
 		else if (cloud1->hasScalarFields() && cloud2->hasScalarFields())
 		{
 			// ask the user to chose which will be the 'source' cloud
-			ccOrderChoiceDlg ocDlg(cloud1, QObject::tr("Source"), cloud2, QObject::tr("Destination"), app);
+			ccOrderChoiceDlg ocDlg(cloud1, QT_TR_NOOP("Source"), cloud2, QT_TR_NOOP("Destination"), app);
 			if (!ocDlg.exec())
 			{
 				// process cancelled by the user
@@ -451,7 +465,7 @@ namespace ccEntityAction
 			}
 			else if (sfCount > 1)
 			{
-				ccItemSelectionDlg isDlg(true, app->getMainWindow(), QObject::tr("entity"));
+				ccItemSelectionDlg isDlg(true, app->getMainWindow(), QT_TR_NOOP("entity"));
 				QStringList        scalarFields;
 				{
 					for (unsigned i = 0; i < sfCount; ++i)
@@ -468,7 +482,7 @@ namespace ccEntityAction
 				isDlg.getSelectedIndexes(sfIndexes);
 				if (sfIndexes.empty())
 				{
-					ccConsole::Error(QObject::tr("No scalar field was selected"));
+					ccLog::Error(QT_TR_NOOP("No scalar field was selected"));
 					return false;
 				}
 			}
@@ -479,7 +493,7 @@ namespace ccEntityAction
 		}
 		catch (const std::bad_alloc&)
 		{
-			ccConsole::Error(QObject::tr("Not enough memory!"));
+			ccLog::Error(QT_TR_NOOP("Not enough memory!"));
 			return false;
 		}
 
@@ -512,21 +526,32 @@ namespace ccEntityAction
 		params.sigma                               = iDlg.kernelDoubleSpinBox->value();
 
 		ccProgressDialog pDlg(true, app->getMainWindow());
-		unsigned         sfCountBefore = dest->getNumberOfScalarFields();
+		pDlg.setModal(true);
 
-		if (ccPointCloudInterpolator::InterpolateScalarFieldsFrom(dest, source, sfIndexes, params, &pDlg))
+		bool success = ccBackgroundTask::Run(
+		    [&]()
+		    {
+			    if (ccPointCloudInterpolator::InterpolateScalarFieldsFrom(dest, source, sfIndexes, params, &pDlg))
+			    {
+				    unsigned sfCountBefore = dest->getNumberOfScalarFields();
+				    dest->setCurrentDisplayedScalarField(static_cast<int>(std::min(sfCountBefore + 1, dest->getNumberOfScalarFields())) - 1);
+				    dest->showSF(true);
+			    }
+			    else
+			    {
+				    return false;
+			    }
+
+			    dest->prepareDisplayForRefresh_recursive();
+			    return true;
+		    });
+
+		if (!success)
 		{
-			dest->setCurrentDisplayedScalarField(static_cast<int>(std::min(sfCountBefore + 1, dest->getNumberOfScalarFields())) - 1);
-			dest->showSF(true);
-		}
-		else
-		{
-			ccConsole::Error(QObject::tr("An error occurred! (see console)"));
+			ccLog::Error(QT_TR_NOOP("An error occurred! (see console)"));
 		}
 
-		dest->prepareDisplayForRefresh_recursive();
-
-		return true;
+		return success;
 	}
 
 	//! Interpolate scalar fields from one entity and transfer them to another one without the dialog
@@ -534,33 +559,39 @@ namespace ccEntityAction
 	{
 		if (!source || !dest)
 		{
-			ccConsole::Error(QObject::tr("Unexpected null cloud pointers!"));
+			ccLog::Error(QT_TR_NOOP("Unexpected null cloud pointers!"));
 			return false;
 		}
 
 		if (!source->hasScalarFields())
 		{
-			ccConsole::Error(QObject::tr("[ccEntityAction::interpolateSFs] The source cloud has no scalar field!"));
+			ccLog::Error(QT_TR_NOOP("[ccEntityAction::interpolateSFs] The source cloud has no scalar field!"));
 			return false;
 		}
 
 		unsigned sfCount = source->getNumberOfScalarFields();
 		if (sfIndex > static_cast<int>(sfCount))
 		{
-			ccConsole::Error(QObject::tr("[ccEntityAction::interpolateSFs] Invalid scalar field index!"));
+			ccLog::Error(QT_TR_NOOP("[ccEntityAction::interpolateSFs] Invalid scalar field index!"));
 			return false;
 		}
 
 		ccProgressDialog pDlg(true, parent);
+		pDlg.setModal(true);
 
-		std::vector<int> sfIndexes({sfIndex});
-		if (!ccPointCloudInterpolator::InterpolateScalarFieldsFrom(dest, source, sfIndexes, params, parent ? &pDlg : nullptr))
+		bool success = ccBackgroundTask::Run(
+		    [&]()
+		    {
+			    std::vector<int> sfIndexes({sfIndex});
+			    return ccPointCloudInterpolator::InterpolateScalarFieldsFrom(dest, source, sfIndexes, params, parent ? &pDlg : nullptr);
+		    });
+
+		if (!success)
 		{
-			ccConsole::Error(QObject::tr("[ccEntityAction::interpolateSFs] An error occurred! (see console)"));
-			return false;
+			ccLog::Error(QT_TR_NOOP("An error occurred! (see console)"));
 		}
 
-		return true;
+		return success;
 	}
 
 	bool convertTextureToColor(ccHObject::Container selectedEntities, QWidget* parent /*=nullptr*/)
@@ -581,7 +612,7 @@ namespace ccEntityAction
 				{
 					if (mesh->hasColors()
 					    && QMessageBox::warning(parent,
-					                            QObject::tr("Mesh already has colors"),
+					                            QT_TR_NOOP("Mesh already has colors"),
 					                            QObject::tr("Mesh '%1' already has colors! Overwrite them?").arg(mesh->getName()),
 					                            QMessageBox::Yes | QMessageBox::No,
 					                            QMessageBox::No)
@@ -615,9 +646,9 @@ namespace ccEntityAction
 		bool          useCustomIntensityRange = false;
 		static double s_minI                  = 0.0;
 		static double s_maxI                  = 1.0;
-		if (QMessageBox::question(parent, QObject::tr("Intensity range"), QObject::tr("Do you want to define the theoretical intensity range (yes)\nor use the actual one (no)?"), QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes)
+		if (QMessageBox::question(parent, QT_TR_NOOP("Intensity range"), QT_TR_NOOP("Do you want to define the theoretical intensity range (yes)\nor use the actual one (no)?"), QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes)
 		{
-			ccAskTwoDoubleValuesDlg atdvDlg(QObject::tr("Min"), QObject::tr("Max"), -1000000.0, 1000000.0, s_minI, s_maxI, 3, QObject::tr("Theroetical intensity"), parent);
+			ccAskTwoDoubleValuesDlg atdvDlg(QT_TR_NOOP("Min"), QT_TR_NOOP("Max"), -1000000.0, 1000000.0, s_minI, s_maxI, 3, QT_TR_NOOP("Theroetical intensity"), parent);
 			if (!atdvDlg.exec())
 			{
 				// process cancelled by the user
@@ -665,7 +696,7 @@ namespace ccEntityAction
 				if (sfIdx < 0)
 				{
 					// let the user choose the right scalar field
-					ccPickOneElementDlg poeDlg(QObject::tr("Intensity scalar field"), QObject::tr("Choose scalar field"), parent);
+					ccPickOneElementDlg poeDlg(QT_TR_NOOP("Intensity scalar field"), QT_TR_NOOP("Choose scalar field"), parent);
 					for (unsigned i = 0; i < pc->getNumberOfScalarFields(); ++i)
 					{
 						CCCoreLib::ScalarField* sf = pc->getScalarField(i);
@@ -709,7 +740,10 @@ namespace ccEntityAction
 		return true;
 	}
 
-	bool rgbGaussianFilter(ccHObject::Container selectedEntities, ccPointCloud::RgbFilterOptions filterParams, QWidget* parent /*=nullptr*/)
+	bool rgbGaussianFilter(ccHObject::Container           selectedEntities,
+	                       ccPointCloud::RgbFilterOptions filterParams,
+	                       QWidget*                       parent /*=nullptr*/,
+	                       bool                           noDialog /*=false*/)
 	{
 		if (selectedEntities.empty())
 		{
@@ -762,9 +796,9 @@ namespace ccEntityAction
 		if (selectedCloudsWithColors.empty())
 		{
 			if (filterParams.filterType == ccPointCloud::RGB_FILTER_TYPES::BILATERAL)
-				ccConsole::Error(QObject::tr("Select at least one cloud or mesh with RGB colors and an active scalar field"));
+				ccLog::Error(QT_TR_NOOP("Select at least one cloud or mesh with RGB colors and an active scalar field"));
 			else
-				ccConsole::Error(QObject::tr("Select at least one cloud or mesh with RGB colors"));
+				ccLog::Error(QT_TR_NOOP("Select at least one cloud or mesh with RGB colors"));
 			return false;
 		}
 
@@ -784,15 +818,15 @@ namespace ccEntityAction
 		}
 
 		QScopedPointer<ccProgressDialog> pDlg;
-		if (!filterParams.commandLine)
+		if (parent && !noDialog)
 		{
 			bool ok = false;
 
 			if (filterParams.filterType == ccPointCloud::RGB_FILTER_TYPES::BILATERAL)
 			{
-				ccAskThreeDoubleValuesDlg dlg(QObject::tr("Spatial sigma"),
-				                              QObject::tr("Scalar sigma"),
-				                              QObject::tr("Color threshold"),
+				ccAskThreeDoubleValuesDlg dlg(QT_TR_NOOP("Spatial sigma"),
+				                              QT_TR_NOOP("Scalar sigma"),
+				                              QT_TR_NOOP("Color threshold"),
 				                              DBL_MIN,
 				                              1.0e9,
 				                              spatialSigma,
@@ -802,11 +836,11 @@ namespace ccEntityAction
 				                              nullptr,
 				                              parent);
 
-				dlg.setWindowTitle(QObject::tr("RGB bilateral filter"));
+				dlg.setWindowTitle(QT_TR_NOOP("RGB bilateral filter"));
 
-				dlg.doubleSpinBox1->setStatusTip(QObject::tr("3*sigma = 99.7% attenuation"));
-				dlg.doubleSpinBox2->setStatusTip(QObject::tr("Scalar sigma controls how much the filter behaves as a Gaussian Filter\nSigma at +inf uses the whole range of scalars"));
-				dlg.doubleSpinBox3->setStatusTip(QObject::tr("For averaging, it will only use colors for which all components are in the range[threshold:255 - threshold]"));
+				dlg.doubleSpinBox1->setStatusTip(QT_TR_NOOP("3*sigma = 99.7% attenuation"));
+				dlg.doubleSpinBox2->setStatusTip(QT_TR_NOOP("Scalar sigma controls how much the filter behaves as a Gaussian Filter\nSigma at +inf uses the whole range of scalars"));
+				dlg.doubleSpinBox3->setStatusTip(QT_TR_NOOP("For averaging, it will only use colors for which all components are in the range[threshold:255 - threshold]"));
 				if (!dlg.exec())
 				{
 					return false;
@@ -819,8 +853,8 @@ namespace ccEntityAction
 			}
 			else
 			{
-				ccAskTwoDoubleValuesDlg dlg(QObject::tr("Spatial sigma"),
-				                            QObject::tr("Color threshold"),
+				ccAskTwoDoubleValuesDlg dlg(QT_TR_NOOP("Spatial sigma"),
+				                            QT_TR_NOOP("Color threshold"),
 				                            DBL_MIN,
 				                            1.0e9,
 				                            spatialSigma,
@@ -828,10 +862,10 @@ namespace ccEntityAction
 				                            8,
 				                            nullptr,
 				                            parent);
-				dlg.setWindowTitle(QObject::tr("RGB gaussian/mean/median filter"));
+				dlg.setWindowTitle(QT_TR_NOOP("RGB gaussian/mean/median filter"));
 
-				dlg.doubleSpinBox1->setStatusTip(QObject::tr("3*sigma = 99.7% attenuation"));
-				dlg.doubleSpinBox2->setStatusTip(QObject::tr("For averaging, it will only use colors for which all components are in the range [threshold:255-threshold]"));
+				dlg.doubleSpinBox1->setStatusTip(QT_TR_NOOP("3*sigma = 99.7% attenuation"));
+				dlg.doubleSpinBox2->setStatusTip(QT_TR_NOOP("For averaging, it will only use colors for which all components are in the range [threshold:255-threshold]"));
 				if (!dlg.exec())
 				{
 					return false;
@@ -847,97 +881,121 @@ namespace ccEntityAction
 		{
 			pDlg.reset(new ccProgressDialog(true, parent));
 			pDlg->setAutoClose(false);
+			pDlg->setModal(true);
 		}
 
-		for (auto entAndPC : selectedCloudsWithColors)
+		QString errorMessage;
+
+		bool success = ccBackgroundTask::Run(
+		    [&]()
+		    {
+			    for (auto entAndPC : selectedCloudsWithColors)
+			    {
+				    ccPointCloud* pc = entAndPC.second;
+				    assert(pc);
+				    int sfIdx = 0;
+				    if ((filterParams.filterType == ccPointCloud::RGB_FILTER_TYPES::BILATERAL) || filterParams.applyToSFduringRGB)
+				    {
+					    // we set the displayed SF as "OUT" SF
+					    int outSfIdx = pc->getCurrentDisplayedScalarFieldIndex();
+					    Q_ASSERT(outSfIdx >= 0);
+
+					    pc->setCurrentOutScalarField(outSfIdx);
+
+					    if (filterParams.applyToSFduringRGB)
+					    {
+						    CCCoreLib::ScalarField* outSF = pc->getCurrentOutScalarField();
+						    Q_ASSERT(outSF != nullptr);
+						    QString sfName;
+						    if (filterParams.filterType == ccPointCloud::RGB_FILTER_TYPES::BILATERAL)
+						    {
+							    sfName = QString("%1.bilsmooth(%2,%3)").arg(QString::fromStdString(outSF->getName())).arg(spatialSigma).arg(sigmaSF);
+						    }
+						    else if (filterParams.filterType == ccPointCloud::RGB_FILTER_TYPES::GAUSSIAN)
+						    {
+							    sfName = QString("%1.smooth(%2)").arg(QString::fromStdString(outSF->getName())).arg(spatialSigma);
+						    }
+						    else if (filterParams.filterType == ccPointCloud::RGB_FILTER_TYPES::MEAN)
+						    {
+							    sfName = QString("%1.meansmooth(%2)").arg(QString::fromStdString(outSF->getName())).arg(spatialSigma);
+						    }
+						    else
+						    {
+							    sfName = QString("%1.medsmooth(%2)").arg(QString::fromStdString(outSF->getName())).arg(spatialSigma);
+						    }
+
+						    sfIdx = pc->getScalarFieldIndexByName(sfName.toStdString());
+						    if (sfIdx < 0)
+						    {
+							    sfIdx = pc->addScalarField(sfName.toStdString()); // output SF has same type as input SF
+						    }
+						    if (sfIdx >= 0)
+						    {
+							    pc->setCurrentInScalarField(sfIdx);
+						    }
+						    else
+						    {
+							    errorMessage = QObject::tr("Failed to create scalar field for cloud '%1' (not enough memory?)").arg(pc->getName());
+							    return false;
+						    }
+					    }
+				    }
+
+				    ccOctree::Shared octree = pc->getOctree();
+				    if (!octree)
+				    {
+					    octree = pc->computeOctree(parent ? pDlg.data() : nullptr);
+					    if (!octree)
+					    {
+						    errorMessage = QObject::tr("Failed to compute octree for cloud '%1'").arg(pc->getName());
+						    return false;
+					    }
+				    }
+
+				    QElapsedTimer eTimer;
+				    eTimer.start();
+				    if (false == pc->applyFilterToRGB(static_cast<PointCoordinateType>(spatialSigma), static_cast<PointCoordinateType>(sigmaSF), filterParams, parent ? pDlg.data() : nullptr))
+				    {
+					    errorMessage = QT_TR_NOOP("An error occurred! (see console)");
+					    return false;
+				    }
+				    ccLog::Print("[RGBFilter] Timing: %3.2f s.", eTimer.elapsed() / 1000.0);
+
+				    if (filterParams.applyToSFduringRGB)
+				    {
+					    // calc sf min/max for correct display.
+					    pc->setCurrentDisplayedScalarField(sfIdx);
+					    pc->showSF(sfIdx >= 0);
+					    CCCoreLib::ScalarField* sf = pc->getCurrentDisplayedScalarField();
+					    if (sf)
+					    {
+						    sf->computeMinAndMax();
+					    }
+				    }
+				    // automatically hide any SF and show the colors instead
+				    entAndPC.first->prepareDisplayForRefresh_recursive();
+				    entAndPC.first->showColors(true);
+				    entAndPC.first->showSF(false);
+			    }
+
+			    return true;
+		    });
+
+		if (!success && !errorMessage.isEmpty())
 		{
-			ccPointCloud* pc = entAndPC.second;
-			assert(pc);
-			int sfIdx = 0;
-			if ((filterParams.filterType == ccPointCloud::RGB_FILTER_TYPES::BILATERAL) || filterParams.applyToSFduringRGB)
-			{
-				// we set the displayed SF as "OUT" SF
-				int outSfIdx = pc->getCurrentDisplayedScalarFieldIndex();
-				Q_ASSERT(outSfIdx >= 0);
-
-				pc->setCurrentOutScalarField(outSfIdx);
-
-				if (filterParams.applyToSFduringRGB)
-				{
-					CCCoreLib::ScalarField* outSF = pc->getCurrentOutScalarField();
-					Q_ASSERT(outSF != nullptr);
-					QString sfName;
-					if (filterParams.filterType == ccPointCloud::RGB_FILTER_TYPES::BILATERAL)
-					{
-						sfName = QString("%1.bilsmooth(%2,%3)").arg(QString::fromStdString(outSF->getName())).arg(spatialSigma).arg(sigmaSF);
-					}
-					else if (filterParams.filterType == ccPointCloud::RGB_FILTER_TYPES::GAUSSIAN)
-					{
-						sfName = QString("%1.smooth(%2)").arg(QString::fromStdString(outSF->getName())).arg(spatialSigma);
-					}
-					else if (filterParams.filterType == ccPointCloud::RGB_FILTER_TYPES::MEAN)
-					{
-						sfName = QString("%1.meansmooth(%2)").arg(QString::fromStdString(outSF->getName())).arg(spatialSigma);
-					}
-					else
-					{
-						sfName = QString("%1.medsmooth(%2)").arg(QString::fromStdString(outSF->getName())).arg(spatialSigma);
-					}
-
-					sfIdx = pc->getScalarFieldIndexByName(sfName.toStdString());
-					if (sfIdx < 0)
-						sfIdx = pc->addScalarField(sfName.toStdString()); // output SF has same type as input SF
-					if (sfIdx >= 0)
-						pc->setCurrentInScalarField(sfIdx);
-					else
-					{
-						ccConsole::Error(QObject::tr("Failed to create scalar field for cloud '%1' (not enough memory?)").arg(pc->getName()));
-						return false;
-					}
-				}
-			}
-
-			ccOctree::Shared octree = pc->getOctree();
-			if (!octree)
-			{
-				octree = pc->computeOctree(parent ? pDlg.data() : nullptr);
-				if (!octree)
-				{
-					ccConsole::Error(QObject::tr("Couldn't compute octree for cloud '%1'!").arg(pc->getName()));
-					continue;
-				}
-			}
-
-			QElapsedTimer eTimer;
-			eTimer.start();
-			pc->applyFilterToRGB(static_cast<PointCoordinateType>(spatialSigma),
-			                     static_cast<PointCoordinateType>(sigmaSF),
-			                     filterParams,
-			                     parent ? pDlg.data() : nullptr);
-			ccConsole::Print("[RGBFilter] Timing: %3.2f s.", eTimer.elapsed() / 1000.0);
-
-			if (filterParams.applyToSFduringRGB)
-			{
-				// calc sf min/max for correct display.
-				pc->setCurrentDisplayedScalarField(sfIdx);
-				pc->showSF(sfIdx >= 0);
-				CCCoreLib::ScalarField* sf = pc->getCurrentDisplayedScalarField();
-				if (sf)
-					sf->computeMinAndMax();
-			}
-			// automatically hide any SF and show the colors instead
-			entAndPC.first->prepareDisplayForRefresh_recursive();
-			entAndPC.first->showColors(true);
-			entAndPC.first->showSF(false);
+			ccLog::Error(errorMessage);
 		}
 
-		return true;
+		return success;
 	}
 
 	//////////
 	// Scalar Fields
 
-	bool sfGaussianFilter(ccHObject::Container selectedEntities, ccPointCloud::RgbFilterOptions filterParams, QWidget* parent /*=nullptr*/)
+	bool sfGaussianFilter(ccHObject::Container           selectedEntities,
+	                      ccPointCloud::RgbFilterOptions filterParams,
+	                      QWidget*                       parent /*=nullptr*/,
+	                      bool                           noDialog /*=false*/)
 	{
 		if (selectedEntities.empty())
 		{
@@ -947,7 +1005,7 @@ namespace ccEntityAction
 		double spatialSigma = filterParams.spatialSigma == -1 ? ccLibAlgorithms::GetDefaultCloudKernelSize(selectedEntities) : filterParams.spatialSigma;
 		if (spatialSigma < 0.0)
 		{
-			ccConsole::Error(QObject::tr("No eligible point cloud in selection!"));
+			ccLog::Error(QT_TR_NOOP("No eligible point cloud in selection!"));
 			return false;
 		}
 
@@ -966,7 +1024,7 @@ namespace ccEntityAction
 			CCCoreLib::ScalarField* testSF = testPC->getCurrentDisplayedScalarField();
 			if (!testSF)
 			{
-				ccConsole::Error(QObject::tr("No active scalar field"));
+				ccLog::Error(QT_TR_NOOP("No active scalar field"));
 				return false;
 			}
 			if (filterParams.sigmaSF == -1)
@@ -981,12 +1039,12 @@ namespace ccEntityAction
 		}
 
 		QScopedPointer<ccProgressDialog> pDlg;
-		if (!filterParams.commandLine)
+		if (parent && !noDialog)
 		{
 			if (filterParams.filterType == ccPointCloud::RGB_FILTER_TYPES::BILATERAL)
 			{
-				ccAskTwoDoubleValuesDlg dlg(QObject::tr("Spatial sigma"),
-				                            QObject::tr("Scalar sigma"),
+				ccAskTwoDoubleValuesDlg dlg(QT_TR_NOOP("Spatial sigma"),
+				                            QT_TR_NOOP("Scalar sigma"),
 				                            DBL_MIN,
 				                            1.0e9,
 				                            spatialSigma,
@@ -995,10 +1053,10 @@ namespace ccEntityAction
 				                            nullptr,
 				                            parent);
 
-				dlg.setWindowTitle(QObject::tr("SF bilateral filter"));
+				dlg.setWindowTitle(QT_TR_NOOP("SF bilateral filter"));
 
-				dlg.doubleSpinBox1->setStatusTip(QObject::tr("3*sigma = 99.7% attenuation"));
-				dlg.doubleSpinBox2->setStatusTip(QObject::tr("Scalar field's sigma controls how much the filter behaves as a Gaussian Filter\nSigma at +inf uses the whole range of scalars"));
+				dlg.doubleSpinBox1->setStatusTip(QT_TR_NOOP("3*sigma = 99.7% attenuation"));
+				dlg.doubleSpinBox2->setStatusTip(QT_TR_NOOP("Scalar field's sigma controls how much the filter behaves as a Gaussian Filter\nSigma at +inf uses the whole range of scalars"));
 				if (!dlg.exec())
 					return false;
 
@@ -1011,7 +1069,7 @@ namespace ccEntityAction
 				bool ok = false;
 
 				spatialSigma = QInputDialog::getDouble(parent,
-				                                       QObject::tr("SF gaussian/mean/median filter"),
+				                                       QT_TR_NOOP("SF gaussian/mean/median filter"),
 				                                       "sigma:",
 				                                       spatialSigma,
 				                                       DBL_MIN,
@@ -1029,103 +1087,119 @@ namespace ccEntityAction
 		{
 			pDlg.reset(new ccProgressDialog(true, parent));
 			pDlg->setAutoClose(false);
+			pDlg->setModal(true);
 		}
 
-		for (ccHObject* ent : selectedEntities)
+		QString errorMessage;
+
+		bool success = ccBackgroundTask::Run(
+		    [&]()
+		    {
+			    for (ccHObject* ent : selectedEntities)
+			    {
+				    bool          lockedVertices = false;
+				    ccPointCloud* pc             = ccHObjectCaster::ToPointCloud(ent, &lockedVertices);
+
+				    if (nullptr == pc)
+				    {
+					    continue;
+				    }
+				    if (lockedVertices)
+				    {
+					    ccUtils::DisplayLockedVerticesWarning(ent->getName(), selectedEntities.size() == 1);
+					    continue;
+				    }
+
+				    // the algorithm will use the currently displayed SF
+				    CCCoreLib::ScalarField* sf = pc->getCurrentDisplayedScalarField();
+				    if (sf)
+				    {
+					    // we set the displayed SF as "OUT" SF
+					    int outSfIdx = pc->getCurrentDisplayedScalarFieldIndex();
+					    Q_ASSERT(outSfIdx >= 0);
+
+					    pc->setCurrentOutScalarField(outSfIdx);
+					    CCCoreLib::ScalarField* outSF = pc->getCurrentOutScalarField();
+					    Q_ASSERT(outSF != nullptr);
+
+					    QString sfName;
+					    if (filterParams.filterType == ccPointCloud::RGB_FILTER_TYPES::BILATERAL)
+					    {
+						    sfName = QString("%1.bilsmooth(%2,%3)").arg(QString::fromStdString(outSF->getName())).arg(spatialSigma).arg(scalarFieldSigma);
+					    }
+					    else if (filterParams.filterType == ccPointCloud::RGB_FILTER_TYPES::GAUSSIAN)
+					    {
+						    sfName = QString("%1.smooth(%2)").arg(QString::fromStdString(outSF->getName())).arg(spatialSigma);
+					    }
+					    else if (filterParams.filterType == ccPointCloud::RGB_FILTER_TYPES::MEAN)
+					    {
+						    sfName = QString("%1.meansmooth(%2)").arg(QString::fromStdString(outSF->getName())).arg(spatialSigma);
+					    }
+					    else
+					    {
+						    sfName = QString("%1.medsmooth(%2)").arg(QString::fromStdString(outSF->getName())).arg(spatialSigma);
+					    }
+
+					    int sfIdx = pc->getScalarFieldIndexByName(sfName.toStdString());
+					    if (sfIdx < 0)
+						    sfIdx = pc->addScalarField(sfName.toStdString()); // output SF has same type as input SF
+					    if (sfIdx >= 0)
+						    pc->setCurrentInScalarField(sfIdx);
+					    else
+					    {
+						    errorMessage = QObject::tr("Failed to create scalar field for cloud '%1' (not enough memory?)").arg(pc->getName());
+						    return false;
+					    }
+
+					    ccOctree::Shared octree = pc->getOctree();
+					    if (!octree)
+					    {
+						    octree = pc->computeOctree(parent ? pDlg.data() : nullptr);
+						    if (!octree)
+						    {
+							    errorMessage = QObject::tr("Couldn't compute octree for cloud '%1'!").arg(pc->getName());
+							    return false;
+						    }
+					    }
+
+					    QElapsedTimer eTimer;
+					    eTimer.start();
+
+					    if (!CCCoreLib::ScalarFieldTools::applyScalarFieldGaussianFilter(static_cast<PointCoordinateType>(spatialSigma),
+					                                                                     pc,
+					                                                                     static_cast<PointCoordinateType>(scalarFieldSigma),
+					                                                                     parent ? pDlg.data() : nullptr,
+					                                                                     octree.data()))
+					    {
+						    errorMessage = QObject::tr("Failed to apply filter on cloud %1").arg(pc->getName());
+						    return false;
+					    }
+
+					    ccLog::Print("SF [Bilateral/Gaussian/Mean/Median filter] Timing: %3.2f s.", eTimer.elapsed() / 1000.0);
+					    pc->setCurrentDisplayedScalarField(sfIdx);
+					    pc->showSF(sfIdx >= 0);
+					    sf = pc->getCurrentDisplayedScalarField();
+					    if (sf)
+					    {
+						    sf->computeMinAndMax();
+					    }
+					    pc->prepareDisplayForRefresh_recursive();
+				    }
+				    else
+				    {
+					    ccLog::Warning(QObject::tr("Entity [%1] has no active scalar field!").arg(pc->getName()));
+				    }
+			    }
+
+			    return true;
+		    });
+
+		if (!success && !errorMessage.isEmpty())
 		{
-			bool          lockedVertices = false;
-			ccPointCloud* pc             = ccHObjectCaster::ToPointCloud(ent, &lockedVertices);
-
-			if (nullptr == pc)
-			{
-				continue;
-			}
-			if (lockedVertices)
-			{
-				ccUtils::DisplayLockedVerticesWarning(ent->getName(), selectedEntities.size() == 1);
-				continue;
-			}
-
-			// the algorithm will use the currently displayed SF
-			CCCoreLib::ScalarField* sf = pc->getCurrentDisplayedScalarField();
-			if (sf)
-			{
-				// we set the displayed SF as "OUT" SF
-				int outSfIdx = pc->getCurrentDisplayedScalarFieldIndex();
-				Q_ASSERT(outSfIdx >= 0);
-
-				pc->setCurrentOutScalarField(outSfIdx);
-				CCCoreLib::ScalarField* outSF = pc->getCurrentOutScalarField();
-				Q_ASSERT(outSF != nullptr);
-
-				QString sfName;
-				if (filterParams.filterType == ccPointCloud::RGB_FILTER_TYPES::BILATERAL)
-				{
-					sfName = QString("%1.bilsmooth(%2,%3)").arg(QString::fromStdString(outSF->getName())).arg(spatialSigma).arg(scalarFieldSigma);
-				}
-				else if (filterParams.filterType == ccPointCloud::RGB_FILTER_TYPES::GAUSSIAN)
-				{
-					sfName = QString("%1.smooth(%2)").arg(QString::fromStdString(outSF->getName())).arg(spatialSigma);
-				}
-				else if (filterParams.filterType == ccPointCloud::RGB_FILTER_TYPES::MEAN)
-				{
-					sfName = QString("%1.meansmooth(%2)").arg(QString::fromStdString(outSF->getName())).arg(spatialSigma);
-				}
-				else
-				{
-					sfName = QString("%1.medsmooth(%2)").arg(QString::fromStdString(outSF->getName())).arg(spatialSigma);
-				}
-
-				int sfIdx = pc->getScalarFieldIndexByName(sfName.toStdString());
-				if (sfIdx < 0)
-					sfIdx = pc->addScalarField(sfName.toStdString()); // output SF has same type as input SF
-				if (sfIdx >= 0)
-					pc->setCurrentInScalarField(sfIdx);
-				else
-				{
-					ccConsole::Error(QObject::tr("Failed to create scalar field for cloud '%1' (not enough memory?)").arg(pc->getName()));
-					return false;
-				}
-
-				ccOctree::Shared octree = pc->getOctree();
-				if (!octree)
-				{
-					octree = pc->computeOctree(parent ? pDlg.data() : nullptr);
-					if (!octree)
-					{
-						ccConsole::Error(QObject::tr("Couldn't compute octree for cloud '%1'!").arg(pc->getName()));
-						return false;
-					}
-				}
-
-				QElapsedTimer eTimer;
-				eTimer.start();
-
-				if (!CCCoreLib::ScalarFieldTools::applyScalarFieldGaussianFilter(static_cast<PointCoordinateType>(spatialSigma),
-				                                                                 pc,
-				                                                                 static_cast<PointCoordinateType>(scalarFieldSigma),
-				                                                                 parent ? pDlg.data() : nullptr,
-				                                                                 octree.data()))
-				{
-					ccConsole::Warning(QObject::tr("[Bilateral/Gaussian/Mean/Median filter]  Failed to apply filter"));
-					return false;
-				}
-
-				ccConsole::Print("SF [Bilateral/Gaussian/Mean/Median filter] Timing: %3.2f s.", eTimer.elapsed() / 1000.0);
-				pc->setCurrentDisplayedScalarField(sfIdx);
-				pc->showSF(sfIdx >= 0);
-				sf = pc->getCurrentDisplayedScalarField();
-				if (sf)
-					sf->computeMinAndMax();
-				pc->prepareDisplayForRefresh_recursive();
-			}
-			else
-			{
-				ccConsole::Warning(QObject::tr("Entity [%1] has no active scalar field!").arg(pc->getName()));
-			}
+			ccLog::Error(errorMessage);
 		}
 
-		return true;
+		return success;
 	}
 
 	bool sfConvertToRGB(ccHObject::Container selectedEntities, QWidget* parent /*=nullptr*/)
@@ -1134,14 +1208,18 @@ namespace ccEntityAction
 		bool mixWithExistingColors = false;
 
 		QMessageBox::StandardButton answer = QMessageBox::warning(parent,
-		                                                          QObject::tr("Scalar Field to RGB"),
-		                                                          QObject::tr("Mix with existing colors (if any)?"),
+		                                                          QT_TR_NOOP("Scalar Field to RGB"),
+		                                                          QT_TR_NOOP("Mix with existing colors (if any)?"),
 		                                                          QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel,
 		                                                          QMessageBox::Yes);
 		if (answer == QMessageBox::Yes)
+		{
 			mixWithExistingColors = true;
+		}
 		else if (answer == QMessageBox::Cancel)
+		{
 			return false;
+		}
 
 		for (ccHObject* ent : selectedEntities)
 		{
@@ -1180,8 +1258,8 @@ namespace ccEntityAction
 
 		bool ok              = false;
 		s_randomColorsNumber = QInputDialog::getInt(parent,
-		                                            QObject::tr("Random colors"),
-		                                            QObject::tr("Number of random colors (will be regularly sampled over the SF interval):"),
+		                                            QT_TR_NOOP("Random colors"),
+		                                            QT_TR_NOOP("Number of random colors (will be regularly sampled over the SF interval):"),
 		                                            s_randomColorsNumber,
 		                                            2,
 		                                            INT_MAX,
@@ -1194,7 +1272,7 @@ namespace ccEntityAction
 		RGBAColorsTableType* randomColors = new RGBAColorsTableType;
 		if (!randomColors->reserveSafe(static_cast<unsigned>(s_randomColorsNumber)))
 		{
-			ccConsole::Error(QObject::tr("Not enough memory!"));
+			ccLog::Error(QT_TR_NOOP("Not enough memory!"));
 			return false;
 		}
 
@@ -1227,7 +1305,7 @@ namespace ccEntityAction
 			{
 				if (!pc->resizeTheRGBTable(false))
 				{
-					ccConsole::Error(QObject::tr("Not enough memory!"));
+					ccLog::Error(QT_TR_NOOP("Not enough memory!"));
 					break;
 				}
 				else
@@ -1272,17 +1350,17 @@ namespace ccEntityAction
 				// if there is no displayed SF --> nothing to do!
 				if (sf == nullptr)
 				{
-					ccConsole::Warning(QObject::tr("Cloud %1 has no displayed scalar field!").arg(pc->getName()));
+					ccLog::Warning(QObject::tr("Cloud %1 has no displayed scalar field!").arg(pc->getName()));
 				}
 				else
 				{
 					const std::string& sfName  = sf->getName();
 					bool               ok      = false;
 					QString            newName = QInputDialog::getText(parent,
-                                                            QObject::tr("SF name"),
-                                                            QObject::tr("name:"),
+                                                            QT_TR_NOOP("SF name"),
+                                                            QT_TR_NOOP("name:"),
                                                             QLineEdit::Normal,
-                                                            QString(!sfName.empty() ? QString::fromStdString(sfName) : QObject::tr("unknown")),
+                                                            QString(!sfName.empty() ? QString::fromStdString(sfName) : QT_TR_NOOP("unknown")),
                                                             &ok);
 					if (ok)
 					{
@@ -1308,7 +1386,7 @@ namespace ccEntityAction
 					sfIdx = pc->addScalarField(CC_DEFAULT_ID_SF_NAME);
 				if (sfIdx < 0)
 				{
-					ccLog::Warning(QObject::tr("Not enough memory!"));
+					ccLog::Warning(QT_TR_NOOP("Not enough memory!"));
 					return false;
 				}
 
@@ -1567,8 +1645,8 @@ namespace ccEntityAction
 	{
 		bool   ok  = false;
 		double out = QInputDialog::getDouble(parent,
-		                                     QObject::tr("SF --> coordinate"),
-		                                     QObject::tr("Enter the coordinate equivalent to NaN values:"),
+		                                     QT_TR_NOOP("SF --> coordinate"),
+		                                     QT_TR_NOOP("Enter the coordinate equivalent to NaN values:"),
 		                                     minSFValue,
 		                                     -1.0e9,
 		                                     1.0e9,
@@ -1581,7 +1659,7 @@ namespace ccEntityAction
 		}
 		else
 		{
-			ccLog::Warning(QObject::tr("[SetSFAsCoord] By default the coordinate equivalent to NaN values will be the minimum SF value"));
+			ccLog::Warning(QT_TR_NOOP("[SetSFAsCoord] By default the coordinate equivalent to NaN values will be the minimum SF value"));
 			return minSFValue;
 		}
 	}
@@ -1604,7 +1682,7 @@ namespace ccEntityAction
 		}
 
 		ccSetSFsAsVec3Dialog dlg(pc, "X", "Y", "Z", true, parent);
-		dlg.setWindowTitle(QObject::tr("Set SFs as coords"));
+		dlg.setWindowTitle(QT_TR_NOOP("Set SFs as coords"));
 
 		static bool s_firstTime = true;
 		static int  xIndex      = ccSetSFsAsVec3Dialog::SF_INDEX_UNCHANGED;
@@ -1676,7 +1754,7 @@ namespace ccEntityAction
 
 		ccExportCoordToSFDlg ectsDlg(parent);
 		ectsDlg.warningLabel->setVisible(false);
-		ectsDlg.setWindowTitle(QObject::tr("Export SF to coordinate(s)"));
+		ectsDlg.setWindowTitle(QT_TR_NOOP("Export SF to coordinate(s)"));
 
 		if (!ectsDlg.exec())
 		{
@@ -1748,7 +1826,7 @@ namespace ccEntityAction
 
 			if (!pc->exportCoordToSF(exportDims))
 			{
-				ccLog::Error(QObject::tr("The process failed!"));
+				ccLog::Error(QT_TR_NOOP("The process failed!"));
 				return true; // true because we want the UI to be updated anyway
 			}
 
@@ -1775,7 +1853,7 @@ namespace ccEntityAction
 		const bool cloudHadNormals = pc->hasNormals();
 
 		ccSetSFsAsVec3Dialog dlg(pc, "Nx", "Ny", "Nz", cloudHadNormals, parent);
-		dlg.setWindowTitle(QObject::tr("Set SFs as normals"));
+		dlg.setWindowTitle(QT_TR_NOOP("Set SFs as normals"));
 
 		static bool s_firstTime = true;
 		static int  nxIndex     = ccSetSFsAsVec3Dialog::SF_INDEX_ZERO;
@@ -1856,7 +1934,7 @@ namespace ccEntityAction
 		{
 			// ask the user
 			ccExportCoordToSFDlg ectsDlg(parent);
-			ectsDlg.setWindowTitle(QObject::tr("Export normals to SF(s)"));
+			ectsDlg.setWindowTitle(QT_TR_NOOP("Export normals to SF(s)"));
 
 			if (!ectsDlg.exec())
 			{
@@ -1891,7 +1969,7 @@ namespace ccEntityAction
 
 			if (!pc->exportNormalToSF(exportDims))
 			{
-				ccLog::Error(QObject::tr("The process failed!"));
+				ccLog::Error(QT_TR_NOOP("The process failed!"));
 				return true; // true because we want the UI to be updated anyway
 			}
 
@@ -1932,7 +2010,7 @@ namespace ccEntityAction
 
 		if (!sfaDlg.apply(pc))
 		{
-			ccConsole::Error(QObject::tr("An error occurred (see Console for more details)"));
+			ccLog::Error(QT_TR_NOOP("An error occurred! (see console)"));
 		}
 
 		pc->showSF(true);
@@ -2049,7 +2127,7 @@ namespace ccEntityAction
 				}
 				else
 				{
-					ccConsole::Warning(QObject::tr("[SfFromColor] Failed to add scalar field '%1' to cloud '%2'?!").arg(QString::fromStdString(sf->getName()), cloud->getName()));
+					ccLog::Warning(QObject::tr("[SfFromColor] Failed to add scalar field '%1' to cloud '%2'?!").arg(QString::fromStdString(sf->getName()), cloud->getName()));
 					sf->release();
 					sf = nullptr;
 				}
@@ -2091,7 +2169,7 @@ namespace ccEntityAction
 					}
 					else
 					{
-						ccConsole::Warning(QObject::tr("Mesh [%1] vertices have no activated scalar field!").arg(mesh->getName()));
+						ccLog::Warning(QObject::tr("Mesh [%1] vertices have no activated scalar field!").arg(mesh->getName()));
 					}
 				}
 			}
@@ -2107,7 +2185,7 @@ namespace ccEntityAction
 	{
 		if (selectedEntities.empty())
 		{
-			ccConsole::Error(QObject::tr("Select at least one point cloud"));
+			ccLog::Error(QT_TR_NOOP("Select at least one point cloud"));
 			return false;
 		}
 
@@ -2177,7 +2255,7 @@ namespace ccEntityAction
 					}
 					else
 					{
-						ccConsole::Error(QObject::tr("Can't compute normals on sub-meshes! Select the parent mesh instead"));
+						ccLog::Error(QT_TR_NOOP("Can't compute normals on sub-meshes! Select the parent mesh instead"));
 						return false;
 					}
 				}
@@ -2185,7 +2263,7 @@ namespace ccEntityAction
 		}
 		catch (const std::bad_alloc&)
 		{
-			ccConsole::Error(QObject::tr("Not enough memory!"));
+			ccLog::Error(QT_TR_NOOP("Not enough memory!"));
 			return false;
 		}
 
@@ -2366,14 +2444,20 @@ namespace ccEntityAction
 
 					    cloud->prepareDisplayForRefresh();
 				    }
+
+				    return (0 == errors);
 			    });
 
 			if (errors != 0)
 			{
 				if (errors < clouds.size())
-					ccConsole::Error(QObject::tr("Failed to compute or orient the normals on some clouds! (see console)"));
+				{
+					ccLog::Error(QT_TR_NOOP("Failed to compute or orient the normals on some clouds! (see console)"));
+				}
 				else
-					ccConsole::Error(QObject::tr("Failed to compute or orient the normals! (see console)"));
+				{
+					ccLog::Error(QT_TR_NOOP("Failed to compute or orient the normals! (see console)"));
+				}
 			}
 		}
 
@@ -2381,13 +2465,13 @@ namespace ccEntityAction
 		if (!meshes.empty())
 		{
 			QMessageBox question(QMessageBox::Question,
-			                     QObject::tr("Mesh normals"),
-			                     QObject::tr("Compute per-vertex normals (smooth) or per-triangle (faceted)?"),
+			                     QT_TR_NOOP("Mesh normals"),
+			                     QT_TR_NOOP("Compute per-vertex normals (smooth) or per-triangle (faceted)?"),
 			                     QMessageBox::NoButton,
 			                     parent);
 
-			QPushButton* perVertexButton   = question.addButton(QObject::tr("Per-vertex"), QMessageBox::YesRole);
-			QPushButton* perTriangleButton = question.addButton(QObject::tr("Per-triangle"), QMessageBox::NoRole);
+			QPushButton* perVertexButton   = question.addButton(QT_TR_NOOP("Per-vertex"), QMessageBox::YesRole);
+			QPushButton* perTriangleButton = question.addButton(QT_TR_NOOP("Per-triangle"), QMessageBox::NoRole);
 
 			question.exec();
 
@@ -2414,7 +2498,7 @@ namespace ccEntityAction
 
 				if (!result)
 				{
-					ccConsole::Error(QObject::tr("Failed to compute normals on mesh '%1'").arg(mesh->getName()));
+					ccLog::Error(QObject::tr("Failed to compute normals on mesh '%1'").arg(mesh->getName()));
 					continue;
 				}
 				mesh->prepareDisplayForRefresh_recursive();
@@ -2468,15 +2552,15 @@ namespace ccEntityAction
 	{
 		if (selectedEntities.empty())
 		{
-			ccConsole::Error(QObject::tr("Select at least one point cloud"));
+			ccLog::Error(QT_TR_NOOP("Select at least one point cloud"));
 			return false;
 		}
 
 		bool      ok             = false;
 		const int s_defaultLevel = 6;
 		int       value          = QInputDialog::getInt(parent,
-                                         QObject::tr("Orient normals (FM)"),
-                                         QObject::tr("Octree level"),
+                                         QT_TR_NOOP("Orient normals (FM)"),
+                                         QT_TR_NOOP("Octree level"),
                                          s_defaultLevel,
                                          1,
                                          CCCoreLib::DgmOctree::MAX_OCTREE_LEVEL,
@@ -2491,39 +2575,49 @@ namespace ccEntityAction
 
 		ccProgressDialog pDlg(false, parent);
 		pDlg.setAutoClose(false);
+		pDlg.setModal(true);
 
 		size_t errors = 0;
-		for (ccHObject* entity : selectedEntities)
-		{
-			if (!entity->isA(CC_TYPES::POINT_CLOUD))
-				continue;
 
-			ccPointCloud* cloud = static_cast<ccPointCloud*>(entity);
+		ccBackgroundTask::Run(
+		    [&]()
+		    {
+			    for (ccHObject* entity : selectedEntities)
+			    {
+				    if (!entity->isA(CC_TYPES::POINT_CLOUD))
+				    {
+					    continue;
+				    }
 
-			if (!cloud->hasNormals())
-			{
-				ccConsole::Warning(QObject::tr("Cloud '%1' has no normals!").arg(cloud->getName()));
-				continue;
-			}
+				    ccPointCloud* cloud = static_cast<ccPointCloud*>(entity);
 
-			// orient normals with Fast Marching
-			if (cloud->orientNormalsWithFM(level, &pDlg))
-			{
-				cloud->prepareDisplayForRefresh();
-			}
-			else
-			{
-				++errors;
-			}
-		}
+				    if (!cloud->hasNormals())
+				    {
+					    ccLog::Warning(QObject::tr("Cloud '%1' has no normals!").arg(cloud->getName()));
+					    continue;
+				    }
+
+				    // orient normals with Fast Marching
+				    if (cloud->orientNormalsWithFM(level, &pDlg))
+				    {
+					    cloud->prepareDisplayForRefresh();
+				    }
+				    else
+				    {
+					    ++errors;
+				    }
+			    }
+
+			    return (0 == errors);
+		    });
 
 		if (errors)
 		{
-			ccConsole::Error(QObject::tr("Process failed (check console)"));
+			ccLog::Error(QT_TR_NOOP("Process failed (check console)"));
 		}
 		else
 		{
-			ccLog::Warning(QObject::tr("Normals have been oriented: you may still have to globally invert the cloud normals however (Edit > Normals > Invert)."));
+			ccLog::Warning(QT_TR_NOOP("Normals have been oriented: you may still have to globally invert the cloud normals however (Edit > Normals > Invert)."));
 		}
 
 		return true;
@@ -2533,15 +2627,15 @@ namespace ccEntityAction
 	{
 		if (selectedEntities.empty())
 		{
-			ccConsole::Error(QObject::tr("Select at least one point cloud"));
+			ccLog::Error(QT_TR_NOOP("Select at least one point cloud"));
 			return false;
 		}
 
 		bool            ok           = false;
 		static unsigned s_defaultKNN = 6;
 		unsigned        kNN          = static_cast<unsigned>(QInputDialog::getInt(parent,
-                                                                  QObject::tr("Neighborhood size"),
-                                                                  QObject::tr("Neighbors"),
+                                                                  QT_TR_NOOP("Neighborhood size"),
+                                                                  QT_TR_NOOP("Neighbors"),
                                                                   s_defaultKNN,
                                                                   1,
                                                                   1000,
@@ -2554,40 +2648,50 @@ namespace ccEntityAction
 
 		ccProgressDialog pDlg(true, parent);
 		pDlg.setAutoClose(false);
+		pDlg.setModal(true);
 
 		size_t errors = 0;
-		for (ccHObject* entity : selectedEntities)
-		{
-			if (!entity->isA(CC_TYPES::POINT_CLOUD))
-				continue;
 
-			ccPointCloud* cloud = static_cast<ccPointCloud*>(entity);
+		ccBackgroundTask::Run(
+		    [&]()
+		    {
+			    for (ccHObject* entity : selectedEntities)
+			    {
+				    if (!entity->isA(CC_TYPES::POINT_CLOUD))
+				    {
+					    continue;
+				    }
 
-			if (!cloud->hasNormals())
-			{
-				ccConsole::Warning(QObject::tr("Cloud '%1' has no normals!").arg(cloud->getName()));
-				continue;
-			}
+				    ccPointCloud* cloud = static_cast<ccPointCloud*>(entity);
 
-			// use Minimum Spanning Tree to resolve normals direction
-			if (cloud->orientNormalsWithMST(kNN, &pDlg))
-			{
-				cloud->prepareDisplayForRefresh();
-			}
-			else
-			{
-				ccConsole::Warning(QObject::tr("Process failed on cloud '%1'").arg(cloud->getName()));
-				++errors;
-			}
-		}
+				    if (!cloud->hasNormals())
+				    {
+					    ccLog::Warning(QObject::tr("Cloud '%1' has no normals!").arg(cloud->getName()));
+					    continue;
+				    }
+
+				    // use Minimum Spanning Tree to resolve normals direction
+				    if (cloud->orientNormalsWithMST(kNN, &pDlg))
+				    {
+					    cloud->prepareDisplayForRefresh();
+				    }
+				    else
+				    {
+					    ccLog::Warning(QObject::tr("Process failed on cloud '%1'").arg(cloud->getName()));
+					    ++errors;
+				    }
+			    }
+
+			    return (0 == errors);
+		    });
 
 		if (errors)
 		{
-			ccConsole::Error(QObject::tr("Process failed (check console)"));
+			ccLog::Error(QT_TR_NOOP("Process failed (check console)"));
 		}
 		else
 		{
-			ccLog::Warning(QObject::tr("Normals have been oriented: you may still have to globally invert the cloud normals however (Edit > Normals > Invert)."));
+			ccLog::Warning(QT_TR_NOOP("Normals have been oriented: you may still have to globally invert the cloud normals however (Edit > Normals > Invert)."));
 		}
 
 		return true;
@@ -2642,7 +2746,7 @@ namespace ccEntityAction
 						dipSFIndex = pc->addScalarField(CC_DEFAULT_DIP_SF_NAME);
 					if (dipSFIndex < 0)
 					{
-						ccLog::Warning(QObject::tr("[ccEntityAction::convertNormalsTo] Not enough memory!"));
+						ccLog::Warning(QT_TR_NOOP("[ccEntityAction::convertNormalsTo] Not enough memory!"));
 						success = false;
 						break;
 					}
@@ -2654,7 +2758,7 @@ namespace ccEntityAction
 					if (dipDirSFIndex < 0)
 					{
 						pc->deleteScalarField(dipSFIndex);
-						ccLog::Warning(QObject::tr("[ccEntityAction::convertNormalsTo] Not enough memory!"));
+						ccLog::Warning(QT_TR_NOOP("[ccEntityAction::convertNormalsTo] Not enough memory!"));
 						success = false;
 						break;
 					}
@@ -2686,7 +2790,7 @@ namespace ccEntityAction
 
 				default:
 					Q_ASSERT(false);
-					ccLog::Warning(QObject::tr("[ccEntityAction::convertNormalsTo] Internal error: unhandled destination!"));
+					ccLog::Warning(QT_TR_NOOP("[ccEntityAction::convertNormalsTo] Internal error: unhandled destination!"));
 					success = false;
 					i       = selNum; // no need to process the selected entities anymore!
 					break;
@@ -2706,7 +2810,7 @@ namespace ccEntityAction
 		// errors should have been sent to console as warnings
 		if (errorCount)
 		{
-			ccConsole::Error(QObject::tr("Error(s) occurred! (see console)"));
+			ccLog::Error(QT_TR_NOOP("Error(s) occurred! (see console)"));
 		}
 
 		return (successCount != 0);
@@ -2751,7 +2855,7 @@ namespace ccEntityAction
 
 		if (clouds.empty() || maxBoxSize < 0.0)
 		{
-			ccLog::Warning(QObject::tr("[DoActionComputeOctree] No eligible entities in selection!"));
+			ccLog::Warning(QT_TR_NOOP("[DoActionComputeOctree] No eligible entities in selection!"));
 			return false;
 		}
 
@@ -2766,6 +2870,7 @@ namespace ccEntityAction
 
 		ccProgressDialog pDlg(true, parent);
 		pDlg.setAutoClose(false);
+		pDlg.setModal(true);
 
 		// if we must use a custom bounding box, we update 'bbox'
 		if (coDlg.getMode() == ccComputeOctreeDlg::CUSTOM_BBOX)
@@ -2773,83 +2878,87 @@ namespace ccEntityAction
 			bbox = coDlg.getCustomBBox();
 		}
 
-		for (const auto cloud : clouds)
-		{
-			// we temporarily detach entity, as it may undergo
-			//'severe' modifications (octree deletion, etc.) --> see ccPointCloud::computeOctree
-			ccMainAppInterface*                  instance = dynamic_cast<ccMainAppInterface*>(parent);
-			ccMainAppInterface::ccHObjectContext objContext;
-			if (instance)
-			{
-				objContext = instance->removeObjectTemporarilyFromDBTree(cloud);
-			}
+		return ccBackgroundTask::Run(
+		    [&]()
+		    {
+			    for (const auto cloud : clouds)
+			    {
+				    // we temporarily detach entity, as it may undergo
+				    //'severe' modifications (octree deletion, etc.) --> see ccPointCloud::computeOctree
+				    ccMainAppInterface*                  instance = dynamic_cast<ccMainAppInterface*>(parent);
+				    ccMainAppInterface::ccHObjectContext objContext;
+				    if (instance)
+				    {
+					    objContext = instance->removeObjectTemporarilyFromDBTree(cloud);
+				    }
 
-			// computation
-			QElapsedTimer eTimer;
-			eTimer.start();
-			ccOctree::Shared octree(nullptr);
-			switch (coDlg.getMode())
-			{
-			case ccComputeOctreeDlg::DEFAULT:
-				octree = cloud->computeOctree(&pDlg);
-				break;
-			case ccComputeOctreeDlg::MIN_CELL_SIZE:
-			case ccComputeOctreeDlg::CUSTOM_BBOX:
-			{
-				// for a cell-size based custom box, we must update it for each cloud!
-				if (coDlg.getMode() == ccComputeOctreeDlg::MIN_CELL_SIZE)
-				{
-					double              cellSize     = coDlg.getMinCellSize();
-					PointCoordinateType halfBoxWidth = static_cast<PointCoordinateType>(cellSize * (1 << ccOctree::MAX_OCTREE_LEVEL) / 2.0);
-					ccBBox              bbBox        = cloud->getOwnBB();
-					CCVector3           C            = bbBox.getCenter();
-					bbox                             = ccBBox(C - CCVector3(halfBoxWidth, halfBoxWidth, halfBoxWidth),
-                                  C + CCVector3(halfBoxWidth, halfBoxWidth, halfBoxWidth),
-                                  bbBox.isValid());
-				}
-				cloud->deleteOctree();
-				octree = ccOctree::Shared(new ccOctree(cloud));
-				if (octree->build(bbox.minCorner(), bbox.maxCorner(), nullptr, nullptr, &pDlg) > 0)
-				{
-					ccOctreeProxy* proxy = new ccOctreeProxy(octree);
-					proxy->setDisplay(cloud->getDisplay());
-					cloud->addChild(proxy);
-				}
-				else
-				{
-					octree.clear();
-				}
-			}
-			break;
-			default:
-				Q_ASSERT(false);
-				return false;
-			}
-			qint64 elapsedTime_ms = eTimer.elapsed();
+				    // computation
+				    QElapsedTimer eTimer;
+				    eTimer.start();
+				    ccOctree::Shared octree(nullptr);
+				    switch (coDlg.getMode())
+				    {
+				    case ccComputeOctreeDlg::DEFAULT:
+					    octree = cloud->computeOctree(&pDlg);
+					    break;
+				    case ccComputeOctreeDlg::MIN_CELL_SIZE:
+				    case ccComputeOctreeDlg::CUSTOM_BBOX:
+				    {
+					    // for a cell-size based custom box, we must update it for each cloud!
+					    if (coDlg.getMode() == ccComputeOctreeDlg::MIN_CELL_SIZE)
+					    {
+						    double              cellSize     = coDlg.getMinCellSize();
+						    PointCoordinateType halfBoxWidth = static_cast<PointCoordinateType>(cellSize * (1 << ccOctree::MAX_OCTREE_LEVEL) / 2.0);
+						    ccBBox              bbBox        = cloud->getOwnBB();
+						    CCVector3           C            = bbBox.getCenter();
+						    bbox                             = ccBBox(C - CCVector3(halfBoxWidth, halfBoxWidth, halfBoxWidth),
+                                          C + CCVector3(halfBoxWidth, halfBoxWidth, halfBoxWidth),
+                                          bbBox.isValid());
+					    }
+					    cloud->deleteOctree();
+					    octree = ccOctree::Shared(new ccOctree(cloud));
+					    if (octree->build(bbox.minCorner(), bbox.maxCorner(), nullptr, nullptr, &pDlg) > 0)
+					    {
+						    ccOctreeProxy* proxy = new ccOctreeProxy(octree);
+						    proxy->setDisplay(cloud->getDisplay());
+						    cloud->addChild(proxy);
+					    }
+					    else
+					    {
+						    octree.clear();
+					    }
+				    }
+				    break;
+				    default:
+					    Q_ASSERT(false);
+					    return false;
+				    }
+				    qint64 elapsedTime_ms = eTimer.elapsed();
 
-			// put object back in tree
-			if (instance)
-			{
-				instance->putObjectBackIntoDBTree(cloud, objContext);
-			}
+				    // put object back in tree
+				    if (instance)
+				    {
+					    instance->putObjectBackIntoDBTree(cloud, objContext);
+				    }
 
-			if (octree)
-			{
-				ccConsole::Print("[doActionComputeOctree] Timing: %2.3f s", static_cast<double>(elapsedTime_ms) / 1000.0);
-				cloud->setEnabled(true); // for vertices!
-				ccOctreeProxy* proxy = cloud->getOctreeProxy();
-				assert(proxy);
-				proxy->setVisible(true);
-				proxy->setEnabled(true);
-				proxy->prepareDisplayForRefresh();
-			}
-			else
-			{
-				ccConsole::Warning(QObject::tr("Octree computation on cloud '%1' failed!").arg(cloud->getName()));
-			}
-		}
+				    if (octree)
+				    {
+					    ccLog::Print("[doActionComputeOctree] Timing: %2.3f s", static_cast<double>(elapsedTime_ms) / 1000.0);
+					    cloud->setEnabled(true); // for vertices!
+					    ccOctreeProxy* proxy = cloud->getOctreeProxy();
+					    assert(proxy);
+					    proxy->setVisible(true);
+					    proxy->setEnabled(true);
+					    proxy->prepareDisplayForRefresh();
+				    }
+				    else
+				    {
+					    ccLog::Warning(QObject::tr("Octree computation on cloud '%1' failed!").arg(cloud->getName()));
+				    }
+			    }
 
-		return true;
+			    return true;
+		    });
 	}
 
 	//////////
@@ -2889,7 +2998,7 @@ namespace ccEntityAction
 					    && (mesh->getParent()->isA(CC_TYPES::MESH) /*|| mesh->getParent()->isKindOf(CC_TYPES::PRIMITIVE)*/) // TODO
 					    && ccHObjectCaster::ToMesh(mesh->getParent())->getAssociatedCloud() == mesh->getAssociatedCloud())
 					{
-						ccLog::Warning(QObject::tr("[DoActionClearNormals] Can't remove normals per-vertex on a sub mesh!"));
+						ccLog::Warning(QT_TR_NOOP("[DoActionClearNormals] Can't remove normals per-vertex on a sub mesh!"));
 					}
 					else // mesh is alone, we can freely remove normals
 					{
@@ -3003,7 +3112,7 @@ namespace ccEntityAction
 
 	bool statisticalTest(ccHObject::Container selectedEntities, QWidget* parent /*=nullptr*/)
 	{
-		ccPickOneElementDlg poeDlg(QObject::tr("Distribution"), QObject::tr("Choose distribution"), parent);
+		ccPickOneElementDlg poeDlg(QT_TR_NOOP("Distribution"), QT_TR_NOOP("Choose distribution"), parent);
 		poeDlg.addElement("Gauss");
 		poeDlg.addElement("Weibull");
 		poeDlg.setDefaultIndex(0);
@@ -3014,28 +3123,27 @@ namespace ccEntityAction
 
 		int distribIndex = poeDlg.getSelectedIndex();
 
-		ccStatisticalTestDlg* sDlg = nullptr;
+		QScopedPointer<ccStatisticalTestDlg> sDlg;
 		switch (distribIndex)
 		{
 		case 0: // Gauss
-			sDlg = new ccStatisticalTestDlg("mu", "sigma", QString(), QObject::tr("Local Statistical Test (Gauss)"), parent);
+			sDlg.reset(new ccStatisticalTestDlg("mu", "sigma", QString(), QT_TR_NOOP("Local Statistical Test (Gauss)"), parent));
 			break;
 		case 1: // Weibull
-			sDlg = new ccStatisticalTestDlg("a", "b", "shift", QObject::tr("Local Statistical Test (Weibull)"), parent);
+			sDlg.reset(new ccStatisticalTestDlg("a", "b", "shift", QT_TR_NOOP("Local Statistical Test (Weibull)"), parent));
 			break;
 		default:
-			ccConsole::Error(QObject::tr("Invalid distribution!"));
+			ccLog::Error(QT_TR_NOOP("Invalid distribution!"));
 			return false;
 		}
 
 		if (!sDlg->exec())
 		{
-			sDlg->deleteLater();
 			return false;
 		}
 
 		// build up corresponding distribution
-		CCCoreLib::GenericDistribution* distrib = nullptr;
+		QScopedPointer<CCCoreLib::GenericDistribution> distrib;
 		{
 			ScalarType a = static_cast<ScalarType>(sDlg->getParam1());
 			ScalarType b = static_cast<ScalarType>(sDlg->getParam2());
@@ -3047,13 +3155,13 @@ namespace ccEntityAction
 			{
 				CCCoreLib::NormalDistribution* N = new CCCoreLib::NormalDistribution();
 				N->setParameters(a, b * b); // warning: we input sigma2 here (not sigma)
-				distrib = static_cast<CCCoreLib::GenericDistribution*>(N);
+				distrib.reset(N);
 				break;
 			}
 			case 1: // Weibull
 				CCCoreLib::WeibullDistribution* W = new CCCoreLib::WeibullDistribution();
 				W->setParameters(a, b, c);
-				distrib = static_cast<CCCoreLib::GenericDistribution*>(W);
+				distrib.reset(W);
 				break;
 			}
 		}
@@ -3063,96 +3171,115 @@ namespace ccEntityAction
 
 		ccProgressDialog pDlg(true, parent);
 		pDlg.setAutoClose(false);
+		pDlg.setModal(true);
 
-		for (ccHObject* ent : selectedEntities)
+		QString errorMessage;
+
+		bool success = ccBackgroundTask::Run(
+		    [&]()
+		    {
+			    for (ccHObject* ent : selectedEntities)
+			    {
+				    ccPointCloud* pc = ccHObjectCaster::ToPointCloud(ent);
+
+				    if (nullptr == pc)
+				    {
+					    continue;
+				    }
+
+				    // we apply method on currently displayed SF
+				    ccScalarField* inSF = pc->getCurrentDisplayedScalarField();
+				    if (inSF == nullptr)
+				    {
+					    // TODO handle error?
+					    continue;
+				    }
+
+				    Q_ASSERT(inSF->capacity() != 0);
+
+				    // force SF as 'OUT' field (in case of)
+				    const int outSfIdx = pc->getCurrentDisplayedScalarFieldIndex();
+				    pc->setCurrentOutScalarField(outSfIdx);
+
+				    // force Chi2 Distances field as 'IN' field (create it by the way if necessary)
+				    int chi2SfIdx = pc->getScalarFieldIndexByName(CC_CHI2_DISTANCES_DEFAULT_SF_NAME);
+
+				    if (chi2SfIdx < 0)
+					    chi2SfIdx = pc->addScalarField(CC_CHI2_DISTANCES_DEFAULT_SF_NAME);
+
+				    if (chi2SfIdx < 0)
+				    {
+					    errorMessage = QT_TR_NOOP("Couldn't allocate a new scalar field for computing chi2 distances! Try to free some memory ...");
+					    return false;
+				    }
+				    pc->setCurrentInScalarField(chi2SfIdx);
+
+				    // compute octree if necessary
+				    ccOctree::Shared theOctree = pc->getOctree();
+				    if (!theOctree)
+				    {
+					    theOctree = pc->computeOctree(&pDlg);
+					    if (!theOctree)
+					    {
+						    errorMessage = QObject::tr("Couldn't compute octree for cloud '%1'!").arg(pc->getName());
+						    return false;
+					    }
+				    }
+
+				    QElapsedTimer eTimer;
+				    eTimer.start();
+
+				    double chi2dist = CCCoreLib::StatisticalTestingTools::testCloudWithStatisticalModel(distrib.data(), pc, nn, pChi2, &pDlg, theOctree.data());
+
+				    if (chi2dist >= 0.0)
+				    {
+					    ccLog::Print("[Chi2 Test] Timing: %3.2f ms.", eTimer.elapsed() / 1000.0);
+					    ccLog::Print(QObject::tr("[Chi2 Test] %1 test result = %2").arg(distrib->getName()).arg(chi2dist));
+
+					    // we set the theoretical Chi2 distance limit as the minimum displayed SF value so that all points below are grayed
+					    {
+						    ccScalarField* chi2SF = static_cast<ccScalarField*>(pc->getCurrentInScalarField());
+						    Q_ASSERT(chi2SF);
+						    chi2SF->computeMinAndMax();
+						    chi2dist *= chi2dist;
+						    chi2SF->setMinDisplayed(static_cast<ScalarType>(chi2dist));
+						    chi2SF->setSymmetricalScale(false);
+						    chi2SF->setSaturationStart(static_cast<ScalarType>(chi2dist));
+						    // chi2SF->setSaturationStop(chi2dist);
+
+						    pc->setCurrentDisplayedScalarField(chi2SfIdx);
+						    pc->showSF(true);
+						    pc->prepareDisplayForRefresh_recursive();
+					    }
+				    }
+				    else
+				    {
+					    errorMessage = QObject::tr("[Chi2 Test] Test failed (error code %1)").arg(static_cast<int>(chi2dist));
+					    return false;
+				    }
+			    }
+
+			    return true;
+		    });
+
+		if (!success && !errorMessage.isEmpty())
 		{
-			ccPointCloud* pc = ccHObjectCaster::ToPointCloud(ent);
-
-			if (nullptr == pc)
-			{
-				continue;
-			}
-
-			// we apply method on currently displayed SF
-			ccScalarField* inSF = pc->getCurrentDisplayedScalarField();
-			if (inSF == nullptr)
-			{
-				// TODO handle error?
-				continue;
-			}
-
-			Q_ASSERT(inSF->capacity() != 0);
-
-			// force SF as 'OUT' field (in case of)
-			const int outSfIdx = pc->getCurrentDisplayedScalarFieldIndex();
-			pc->setCurrentOutScalarField(outSfIdx);
-
-			// force Chi2 Distances field as 'IN' field (create it by the way if necessary)
-			int chi2SfIdx = pc->getScalarFieldIndexByName(CC_CHI2_DISTANCES_DEFAULT_SF_NAME);
-
-			if (chi2SfIdx < 0)
-				chi2SfIdx = pc->addScalarField(CC_CHI2_DISTANCES_DEFAULT_SF_NAME);
-
-			if (chi2SfIdx < 0)
-			{
-				ccConsole::Error(QObject::tr("Couldn't allocate a new scalar field for computing chi2 distances! Try to free some memory ..."));
-				break;
-			}
-			pc->setCurrentInScalarField(chi2SfIdx);
-
-			// compute octree if necessary
-			ccOctree::Shared theOctree = pc->getOctree();
-			if (!theOctree)
-			{
-				theOctree = pc->computeOctree(&pDlg);
-				if (!theOctree)
-				{
-					ccConsole::Error(QObject::tr("Couldn't compute octree for cloud '%1'!").arg(pc->getName()));
-					break;
-				}
-			}
-
-			QElapsedTimer eTimer;
-			eTimer.start();
-
-			double chi2dist = CCCoreLib::StatisticalTestingTools::testCloudWithStatisticalModel(distrib, pc, nn, pChi2, &pDlg, theOctree.data());
-
-			ccConsole::Print("[Chi2 Test] Timing: %3.2f ms.", eTimer.elapsed() / 1000.0);
-			ccConsole::Print(QObject::tr("[Chi2 Test] %1 test result = %2").arg(distrib->getName()).arg(chi2dist));
-
-			// we set the theoretical Chi2 distance limit as the minimum displayed SF value so that all points below are grayed
-			{
-				ccScalarField* chi2SF = static_cast<ccScalarField*>(pc->getCurrentInScalarField());
-				Q_ASSERT(chi2SF);
-				chi2SF->computeMinAndMax();
-				chi2dist *= chi2dist;
-				chi2SF->setMinDisplayed(static_cast<ScalarType>(chi2dist));
-				chi2SF->setSymmetricalScale(false);
-				chi2SF->setSaturationStart(static_cast<ScalarType>(chi2dist));
-				// chi2SF->setSaturationStop(chi2dist);
-
-				pc->setCurrentDisplayedScalarField(chi2SfIdx);
-				pc->showSF(true);
-				pc->prepareDisplayForRefresh_recursive();
-			}
+			ccLog::Error(errorMessage);
 		}
 
-		delete distrib;
-		distrib = nullptr;
-
-		sDlg->deleteLater();
-
-		return true;
+		return success;
 	}
 
 	bool computeStatParams(ccHObject::Container selectedEntities, QWidget* parent /*=nullptr*/)
 	{
-		ccPickOneElementDlg pDlg(QObject::tr("Distribution"), QObject::tr("Distribution Fitting"), parent);
-		pDlg.addElement("Normal (Gauss)");
-		pDlg.addElement("Weibull");
+		ccPickOneElementDlg pDlg(QT_TR_NOOP("Distribution"), QT_TR_NOOP("Distribution Fitting"), parent);
+		pDlg.addElement(QT_TR_NOOP("Normal (Gauss)"));
+		pDlg.addElement(QT_TR_NOOP("Weibull"));
 		pDlg.setDefaultIndex(0);
 		if (!pDlg.exec())
+		{
 			return false;
+		}
 
 		CCCoreLib::GenericDistribution* distrib = nullptr;
 		{
@@ -3229,7 +3356,7 @@ namespace ccEntityAction
 				}
 				}
 				description.prepend(QString("%1: ").arg(distrib->getName()));
-				ccConsole::Print(QObject::tr("[Distribution fitting] %1").arg(description));
+				ccLog::Print(QObject::tr("[Distribution fitting] %1").arg(description));
 
 				const unsigned        numberOfClasses = static_cast<unsigned>(ceil(sqrt(static_cast<double>(sfValidCount))));
 				std::vector<unsigned> histo;
@@ -3241,7 +3368,7 @@ namespace ccEntityAction
 				}
 				catch (const std::bad_alloc&)
 				{
-					ccConsole::Warning(QObject::tr("[Distribution fitting] Not enough memory!"));
+					ccLog::Warning(QT_TR_NOOP("[Distribution fitting] Not enough memory!"));
 					continue;
 				}
 
@@ -3252,11 +3379,11 @@ namespace ccEntityAction
 
 					if (chi2dist >= 0.0)
 					{
-						ccConsole::Print(QObject::tr("[Distribution fitting] %1: Chi2 Distance = %2").arg(distrib->getName()).arg(chi2dist));
+						ccLog::Print(QObject::tr("[Distribution fitting] %1: Chi2 Distance = %2").arg(distrib->getName()).arg(chi2dist));
 					}
 					else
 					{
-						ccConsole::Warning(QObject::tr("[Distribution fitting] Failed to compute Chi2 distance?!"));
+						ccLog::Warning(QT_TR_NOOP("[Distribution fitting] Failed to compute Chi2 distance?!"));
 						continue;
 					}
 				}
@@ -3277,17 +3404,17 @@ namespace ccEntityAction
 					}
 
 					double rms = sqrt(squareSum / sfValidCount);
-					ccConsole::Print(QObject::tr("Scalar field statistics:"));
-					ccConsole::Print(QObject::tr("Number of valid values = %1 / %2 (%3%)").arg(sfValidCount).arg(pc->size()).arg((100.0 * sfValidCount) / pc->size(), 0, 'f', 2));
-					ccConsole::Print(QObject::tr("Sum of all valid values = %1").arg(QString::number(sum, 'f', 6)));
-					ccConsole::Print(QObject::tr("Sum of all valid squared values = %1").arg(QString::number(squareSum, 'f', 6)));
-					ccConsole::Print(QObject::tr("Average value = %1").arg(sum / sfValidCount));
-					ccConsole::Print(QObject::tr("RMS (Root Mean Square) = %1").arg(rms));
+					ccLog::Print(QT_TR_NOOP("Scalar field statistics:"));
+					ccLog::Print(QObject::tr("Number of valid values = %1 / %2 (%3%)").arg(sfValidCount).arg(pc->size()).arg((100.0 * sfValidCount) / pc->size(), 0, 'f', 2));
+					ccLog::Print(QObject::tr("Sum of all valid values = %1").arg(QString::number(sum, 'f', 6)));
+					ccLog::Print(QObject::tr("Sum of all valid squared values = %1").arg(QString::number(squareSum, 'f', 6)));
+					ccLog::Print(QObject::tr("Average value = %1").arg(sum / sfValidCount));
+					ccLog::Print(QObject::tr("RMS (Root Mean Square) = %1").arg(rms));
 				}
 
 				// show histogram
 				ccHistogramWindowDlg* hDlg = new ccHistogramWindowDlg(parent);
-				hDlg->setWindowTitle(QObject::tr("[Distribution fitting]"));
+				hDlg->setWindowTitle(QT_TR_NOOP("[Distribution fitting]"));
 
 				ccHistogramWindow* histogram = hDlg->window();
 				histogram->fromBinArray(histo, sf);
@@ -3295,14 +3422,14 @@ namespace ccEntityAction
 				histogram->setCurveValues(npis);
 				npis.clear();
 				histogram->setTitle(description);
-				histogram->setAxisLabels(QString::fromStdString(sf->getName()), QObject::tr("Count"));
+				histogram->setAxisLabels(QString::fromStdString(sf->getName()), QT_TR_NOOP("Count"));
 				histogram->refresh();
 
 				hDlg->show();
 			}
 			else
 			{
-				ccConsole::Warning(QObject::tr("[Entity: %1]-[SF: %2] Couldn't compute distribution parameters!").arg(pc->getName(), QString::fromStdString(sf->getName())));
+				ccLog::Warning(QObject::tr("[Entity: %1]-[SF: %2] Couldn't compute distribution parameters!").arg(pc->getName(), QString::fromStdString(sf->getName())));
 			}
 		}
 

--- a/qCC/ccEntityAction.h
+++ b/qCC/ccEntityAction.h
@@ -37,10 +37,10 @@ namespace ccEntityAction
 	bool interpolateColors(ccHObject::Container selectedEntities, QWidget* parent = nullptr);
 	bool convertTextureToColor(ccHObject::Container selectedEntities, QWidget* parent = nullptr);
 	bool enhanceRGBWithIntensities(ccHObject::Container selectedEntities, QWidget* parent = nullptr);
-	bool rgbGaussianFilter(ccHObject::Container selectedEntities, ccPointCloud::RgbFilterOptions filterParams, QWidget* parent = nullptr);
+	bool rgbGaussianFilter(ccHObject::Container selectedEntities, ccPointCloud::RgbFilterOptions filterParams, QWidget* parent = nullptr, bool noDialog = false);
 
 	// Scalar Fields
-	bool sfGaussianFilter(ccHObject::Container selectedEntities, ccPointCloud::RgbFilterOptions filterParams, QWidget* parent = nullptr);
+	bool sfGaussianFilter(ccHObject::Container selectedEntities, ccPointCloud::RgbFilterOptions filterParams, QWidget* parent = nullptr, bool noDialog = false);
 	bool sfConvertToRGB(ccHObject::Container selectedEntities, QWidget* parent = nullptr);
 	bool sfConvertToRandomRGB(ccHObject::Container selectedEntities, QWidget* parent = nullptr);
 	bool sfRename(ccHObject::Container selectedEntities, QWidget* parent = nullptr);

--- a/qCC/mainwindow.cpp
+++ b/qCC/mainwindow.cpp
@@ -6159,17 +6159,22 @@ void MainWindow::doActionFilterNoise()
 		}
 
 		// computation
-		CCCoreLib::ReferenceCloud* selection = CCCoreLib::CloudSamplingTools::noiseFilter(cloud,
-		                                                                                  static_cast<PointCoordinateType>(kernelRadius),
-		                                                                                  s_noiseFilterNSigma,
-		                                                                                  s_noiseFilterRemoveIsolatedPoints,
-		                                                                                  s_noiseFilterUseKnn,
-		                                                                                  s_noiseFilterKnn,
-		                                                                                  s_noiseFilterUseAbsError,
-		                                                                                  s_noiseFilterAbsError,
-		                                                                                  cloud->getOctree().data(),
-		                                                                                  &pDlg,
-		                                                                                  s_maxThreadCount);
+		// computation (in a worker thread, so that the progress dialog keeps refreshing)
+		CCCoreLib::ReferenceCloud* selection = ccBackgroundTask::Run(
+		    [&]()
+		    {
+			    return CCCoreLib::CloudSamplingTools::noiseFilter(cloud,
+			                                                      static_cast<PointCoordinateType>(kernelRadius),
+			                                                      s_noiseFilterNSigma,
+			                                                      s_noiseFilterRemoveIsolatedPoints,
+			                                                      s_noiseFilterUseKnn,
+			                                                      s_noiseFilterKnn,
+			                                                      s_noiseFilterUseAbsError,
+			                                                      s_noiseFilterAbsError,
+			                                                      cloud->getOctree().data(),
+			                                                      &pDlg,
+			                                                      s_maxThreadCount);
+		    });
 
 		if (selection)
 		{


### PR DESCRIPTION
Same thing as #2375, applied to the other two.

The noise filter was easy, it's the same shape as SOR.

Distances took a bit more thought. I first wrapped the whole `switch (m_compType)`, then noticed the cases read widgets while setting their parameters up, like `lmKNNSpinBox->value()`. That would have meant touching Qt widgets from a worker thread, so now only the two computation calls are wrapped and the setup stays where it was. Cloud to mesh came along for free, it's in the same switch.

Checked both the same way as before. The GUI keeps redrawing during the computation and the results come out identical.

This sits on top of #2375, so it shows that commit too until it merges.

Built on Ubuntu 24.04 with GCC 15.3 and Qt 6.9.3, no new warnings. Not built on Windows or macOS.
