### PR TITLE
Use ccBackgroundTask in the qPoissonRecon and qCanupo plugins (#2358)

### DIFF
--- a/libs/CCPluginAPI/include/ccBackgroundTask.h
+++ b/libs/CCPluginAPI/include/ccBackgroundTask.h
@@ -67,4 +67,24 @@ class ccBackgroundTask
 			return watcher.result();
 		}
 	}
+
+	//! Waits for an already started task, while the GUI keeps refreshing
+	/** Same idea as Run, but for code that has already launched something with
+	    QtConcurrent (a map, for instance). Waiting on it directly would block the
+	    GUI thread, and wrapping it in Run would mean blocking inside a thread of
+	    the same pool, which can deadlock when few threads are allowed.
+
+	    \param future the task to wait for
+	**/
+	template <typename T>
+	static void Wait(QFuture<T>& future)
+	{
+		QFutureWatcher<T> watcher;
+		QEventLoop        loop;
+
+		QObject::connect(&watcher, &QFutureWatcherBase::finished, &loop, &QEventLoop::quit, Qt::QueuedConnection);
+
+		watcher.setFuture(future);
+		loop.exec();
+	}
 };

--- a/plugins/core/Standard/qCanupo/src/qCanupoTools.cpp
+++ b/plugins/core/Standard/qCanupo/src/qCanupoTools.cpp
@@ -32,6 +32,7 @@
 
 //qCC_plugins
 #include <ccMainAppInterface.h>
+#include <ccBackgroundTask.h>
 #include <ccQtHelpers.h>
 
 //Qt
@@ -346,15 +347,7 @@ bool qCanupoTools::ComputeCorePointsDescriptors(CCCoreLib::GenericIndexedCloud* 
 
 		// Do not use a blocking map, as it's blocking the UI as well
 		auto future = QtConcurrent::map(corePointsIndexes, ComputeCorePointDescriptor);
-		while (!future.isFinished())
-		{
-#if defined(CC_WINDOWS)
-			::Sleep(250);
-#else
-			usleep(250 * 1000);
-#endif
-			QCoreApplication::processEvents();
-		}
+		ccBackgroundTask::Wait(future);
 	}
 	else
 	{

--- a/plugins/core/Standard/qPoissonRecon/src/qPoissonRecon.cpp
+++ b/plugins/core/Standard/qPoissonRecon/src/qPoissonRecon.cpp
@@ -35,6 +35,7 @@
 //qCC_db
 #include <ccPointCloud.h>
 #include <ccMesh.h>
+#include <ccBackgroundTask.h>
 #include <ccProgressDialog.h>
 #include <ccScalarField.h>
 
@@ -441,22 +442,8 @@ void qPoissonRecon::doAction()
 			s_densitySF = (densitySF = new ccScalarField("Density"));
 		}
 
-		QFuture<bool> future = QtConcurrent::run(doReconstruct);
-
-		//wait until process is finished!
-		while (!future.isFinished())
-		{
-#if defined(CC_WINDOWS)
-			::Sleep(500);
-#else
-			usleep(500 * 1000);
-#endif
-
-			pDlg.setValue(pDlg.value() + 1);
-			QApplication::processEvents();
-		}
-
-		result = future.result();
+		//run in a worker thread, so that the progress dialog keeps refreshing
+		result = ccBackgroundTask::Run(doReconstruct);
 
 		s_cloud = nullptr;
 		s_mesh = nullptr;


### PR DESCRIPTION
Carrying on from #2375 and #2377, this time in the plugins. Two of the six that still have their own wait loop.

qPoissonRecon had this:

```cpp
QFuture<bool> future = QtConcurrent::run(doReconstruct);
while (!future.isFinished())
{
#if defined(CC_WINDOWS)
	::Sleep(500);
#else
	usleep(500 * 1000);
#endif
	pDlg.setValue(pDlg.value() + 1);
	QApplication::processEvents();
}
result = future.result();
```

which turns into `result = ccBackgroundTask::Run(doReconstruct);`. That also gets rid of the made up progress, since `pDlg.setValue(pDlg.value() + 1)` was just adding one to the bar every half second no matter what the computation was actually doing.

qCanupo is a bit different. It uses `QtConcurrent::map` rather than `run`, and there's already a comment in there saying a blocking map would block the UI. Wrapping it in `Run` would have meant blocking inside a thread from the same pool, which can deadlock if the user turns the thread count down, so I added a small `Wait()` alongside `Run()` for futures that have already been started:

```cpp
auto future = QtConcurrent::map(corePointsIndexes, ComputeCorePointDescriptor);
ccBackgroundTask::Wait(future);
```

I left the rest of both files alone. `plugins/core/Standard` isn't in the format target, so running clang-format over them would have added a few hundred lines of noise.

Only these two are switched on in my build, so the other four (qCork, qMeshBoolean, qPCL, qRANSAC_SD) are the same pattern but I can't compile them here. Happy to do those as well if you'd rather have them all together.

For what it's worth, #2290 was a CANUPO freeze report that got closed without a fix.

Built on Ubuntu 24.04 with GCC 15.3 and Qt 6.9.3, no new warnings. Not built on Windows or macOS.
