### PR TITLE
Use ccBackgroundTask in the qRANSAC_SD, qPCL and qM3C2 plugins (#2358)

### DIFF
--- a/plugins/core/Standard/qM3C2/src/qM3C2Process.cpp
+++ b/plugins/core/Standard/qM3C2/src/qM3C2Process.cpp
@@ -26,6 +26,7 @@
 
 //qCC_plugins
 #include <ccMainAppInterface.h>
+#include <ccBackgroundTask.h>
 #include <ccQtHelpers.h>
 
 //qCC_db
@@ -997,7 +998,8 @@ bool qM3C2Process::Compute(const qM3C2Dialog& dlg, QString& errorMessage, ccPoin
 				}
 				assert(maxThreadCount > 0 && maxThreadCount <= QThread::idealThreadCount());
 				QThreadPool::globalInstance()->setMaxThreadCount(maxThreadCount);
-				QtConcurrent::blockingMap(pointIndexes, ComputeM3C2DistForPoint);
+				auto future = QtConcurrent::map(pointIndexes, ComputeM3C2DistForPoint);
+				ccBackgroundTask::Wait(future);
 			}
 			else
 			{

--- a/plugins/core/Standard/qM3C2/src/qM3C2Tools.cpp
+++ b/plugins/core/Standard/qM3C2/src/qM3C2Tools.cpp
@@ -34,6 +34,7 @@
 
 //qCC
 #include <ccMainAppInterface.h>
+#include <ccBackgroundTask.h>
 #include <ccQtHelpers.h>
 
 //Qt
@@ -297,7 +298,8 @@ bool qM3C2Normals::ComputeCorePointsNormals(CCCoreLib::GenericIndexedCloud* core
 			maxThreadCount = ccQtHelpers::GetMaxThreadCount();
 		}
 		QThreadPool::globalInstance()->setMaxThreadCount(maxThreadCount);
-		QtConcurrent::blockingMap(corePointsIndexes, ComputeCorePointNormal);
+		auto future = QtConcurrent::map(corePointsIndexes, ComputeCorePointNormal);
+		ccBackgroundTask::Wait(future);
 	}
 	else
 	{
@@ -448,7 +450,8 @@ bool qM3C2Normals::UpdateNormalOrientationsWithCloud(	CCCoreLib::GenericIndexedC
 				maxThreadCount = ccQtHelpers::GetMaxThreadCount();
 			}
 			QThreadPool::globalInstance()->setMaxThreadCount(maxThreadCount);
-			QtConcurrent::blockingMap(pointIndexes, OrientPointNormalWithCloud);
+			auto future = QtConcurrent::map(pointIndexes, OrientPointNormalWithCloud);
+			ccBackgroundTask::Wait(future);
 		}
 		else
 		{

--- a/plugins/core/Standard/qPCL/PclUtils/filters/BaseFilter.cpp
+++ b/plugins/core/Standard/qPCL/PclUtils/filters/BaseFilter.cpp
@@ -25,6 +25,7 @@
 #include <CCPlatform.h>
 
 //qCC
+#include <ccBackgroundTask.h>
 #include <ccMainAppInterface.h>
 
 //Qt
@@ -148,20 +149,8 @@ int BaseFilter::start()
 	s_filter = this;
 	s_computing = true;
 
-	QFuture<void> future = QtConcurrent::run(DoCompute);
-	int progress = 0;
-	while (!future.isFinished())
-	{
-#if defined(CC_WINDOWS)
-		::Sleep(500);
-#else
-		usleep(500 * 1000);
-#endif
-		if (m_showProgress)
-		{
-			pDlg.setValue(++progress);
-		}
-	}
+	//run in a worker thread, so that the progress dialog keeps refreshing
+	ccBackgroundTask::Run(DoCompute);
 	
 	int result = s_computeStatus;
 	s_filter = nullptr;

--- a/plugins/core/Standard/qRANSAC_SD/src/qRANSAC_SD.cpp
+++ b/plugins/core/Standard/qRANSAC_SD/src/qRANSAC_SD.cpp
@@ -50,6 +50,7 @@
 #include <ccCylinder.h>
 #include <ccCone.h>
 #include <ccTorus.h>
+#include <ccBackgroundTask.h>
 #include <ccProgressDialog.h>
 
 //CCCoreLib
@@ -503,21 +504,8 @@ ccHObject* qRansacSD::executeRANSAC(ccPointCloud* ccPC, const RansacParams& para
 		s_cloud = &cloud;
 		QElapsedTimer eTimer;
 		eTimer.start();
-		QFuture<void> future = QtConcurrent::run(doDetection);
-
-		while (!future.isFinished())
-		{
-#if defined(CC_WINDOWS)
-			::Sleep(500);
-#else
-			usleep(500 * 1000);
-#endif
-			if (!silent && pDlg)
-			{
-				pDlg->setValue(pDlg->value() + 1);
-			}
-			QApplication::processEvents();
-		}
+		//run in a worker thread, so that the progress dialog keeps refreshing
+		ccBackgroundTask::Run(doDetection);
 		remaining = static_cast<unsigned>(s_remainingPoints);
 
 		QApplication::processEvents();


### PR DESCRIPTION
Three more after #2380.

qRANSAC_SD and qPCL's `BaseFilter` both used `QtConcurrent::run` with a polling loop, so each one becomes a single `ccBackgroundTask::Run(...)`.

The qPCL one is worth a mention, because its loop had no `processEvents()` in it at all:

```cpp
QFuture<void> future = QtConcurrent::run(DoCompute);
int progress = 0;
while (!future.isFinished())
{
#if defined(CC_WINDOWS)
	::Sleep(500);
#else
	usleep(500 * 1000);
#endif
	if (m_showProgress)
	{
		pDlg.setValue(++progress);
	}
}
```

so while a PCL filter was running the window had no chance to repaint between the sleeps.

I also did qM3C2, which is a different case. It wasn't polling at all, it was calling `QtConcurrent::blockingMap` directly in three places, so the GUI thread was blocked outright with no progress of any kind. Same thing you and I looked at in DgmOctree for #2358. I used `Wait()` rather than wrapping the map in `Run()`, to avoid blocking inside a thread of the same pool.

While I was looking around I also checked qPDALIO, since it calls `waitForFinished()`. That one is already fine: it sets up a `QFutureWatcher`, then runs `pDlg->exec()`, so the dialog's own event loop keeps things alive and `waitForFinished()` has nothing left to wait for by the time it's reached. Same idea as `ccBackgroundTask`, just written out by hand. Left it alone.

That leaves qCork and qMeshBoolean. Same pattern as the others, but they want Cork and libIGL and I couldn't get hold of either here, so I haven't touched them. Looks like they're off in pixi.toml too.

Rest of the plugin files untouched, same as last time, since `plugins/core/Standard` isn't in the format target.

Built on Ubuntu 24.04 with GCC 15.3 and Qt 6.9.3, with QRANSAC_SD, QPCL and QM3C2 enabled, no new warnings. Not built on Windows or macOS.
