### PR TITLE
Faster mesh and clouds display (with GLSL 1.2 shaders)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,13 @@ New plugins
 
 Improvements:
 
+	- Display speed of clouds and meshes has been improved a lot
+		- use of a composite GLSL 1.2 program
+		- use of a LUT texture with uncompressed normals
+		- use of a color scale texture when displaying scalar fields
+		- visibility filtering done in the same program
+		- (does not work with partial or textured meshes yet)
+
 	- Display > Lock rotation about an axis
 		- now a proper 'turntable' rotation mode
 		- dedicated icon in the left 'View' toolbar

--- a/ccViewer/main.cpp
+++ b/ccViewer/main.cpp
@@ -45,7 +45,6 @@
 
 int main(int argc, char* argv[])
 {
-
 	ccViewerApplication::InitOpenGL();
 
 	// Convert the input arguments to QString before the application is initialized
@@ -184,7 +183,6 @@ int main(int argc, char* argv[])
 
 	// release global structures
 	FileIOFilter::UnregisterAll();
-	ccPointCloud::ReleaseShaders();
 
 	return result;
 }

--- a/libs/CCAppCommon/src/ccApplicationBase.cpp
+++ b/libs/CCAppCommon/src/ccApplicationBase.cpp
@@ -19,6 +19,7 @@
 
 // Qt
 #include <QDir>
+#include <QOpenGLWidget>
 #include <QProcessEnvironment>
 #include <QSettings>
 #include <QStandardPaths>
@@ -29,15 +30,15 @@
 #include <QtGlobal>
 
 // CCCoreLib
-#include "CCPlatform.h"
+#include <CCPlatform.h>
 
 // qCC_db
-#include "ccMaterial.h"
-
+#include <ccMaterial.h>
+#include <ccMesh.h>
 #include <ccPointCloud.h>
 
 // qCC_glWindow
-#include "ccGLWindowInterface.h"
+#include <ccGLWindowInterface.h>
 
 // Common
 #include "ccApplicationBase.h"
@@ -46,9 +47,6 @@
 
 // ccPluginAPI
 #include <ccPersistentSettings.h>
-
-// Qt
-#include <QOpenGLWidget>
 
 #if (QT_VERSION < QT_VERSION_CHECK(6, 4, 0))
 #error CloudCompare does not support versions of Qt prior to 6.4
@@ -132,7 +130,8 @@ ccApplicationBase::ccApplicationBase(int& argc, char** argv, bool isCommandLine,
 	ccTranslationManager::Get().loadTranslations();
 
 	connect(this, &ccApplicationBase::aboutToQuit, [=]()
-	        { ccMaterial::ReleaseTextures(); });
+	        { ccMaterial::ReleaseTextures();
+	          ccMesh::ReleaseOpenGLRessources(); });
 }
 
 QString ccApplicationBase::versionLongStr(bool includeOS) const

--- a/libs/CCAppCommon/src/ccApplicationBase.cpp
+++ b/libs/CCAppCommon/src/ccApplicationBase.cpp
@@ -33,6 +33,7 @@
 #include <CCPlatform.h>
 
 // qCC_db
+#include <ccColorScalesManager.h>
 #include <ccMaterial.h>
 #include <ccMesh.h>
 #include <ccPointCloud.h>
@@ -131,6 +132,7 @@ ccApplicationBase::ccApplicationBase(int& argc, char** argv, bool isCommandLine,
 
 	connect(this, &ccApplicationBase::aboutToQuit, [=]()
 	        { ccMaterial::ReleaseTextures();
+			  ccColorScalesManager::ReleaseUniqueInstance();
 	          ccMesh::ReleaseOpenGLRessources(); });
 }
 

--- a/libs/CCAppCommon/src/ccApplicationBase.cpp
+++ b/libs/CCAppCommon/src/ccApplicationBase.cpp
@@ -133,7 +133,8 @@ ccApplicationBase::ccApplicationBase(int& argc, char** argv, bool isCommandLine,
 	connect(this, &ccApplicationBase::aboutToQuit, [=]()
 	        { ccMaterial::ReleaseTextures();
 			  ccColorScalesManager::ReleaseUniqueInstance();
-	          ccMesh::ReleaseOpenGLRessources(); });
+	          ccMesh::ReleaseOpenGLRessources();
+	          ccPointCloud::ReleaseOpenGLRessources(); });
 }
 
 QString ccApplicationBase::versionLongStr(bool includeOS) const

--- a/libs/qCC_db/include/CMakeLists.txt
+++ b/libs/qCC_db/include/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources( ${PROJECT_NAME}
 		${CMAKE_CURRENT_LIST_DIR}/ccGLDrawContext.h
 		${CMAKE_CURRENT_LIST_DIR}/ccGLMatrix.h
 		${CMAKE_CURRENT_LIST_DIR}/ccGLMatrixTpl.h
+		${CMAKE_CURRENT_LIST_DIR}/ccGLSLHelper.h
 		${CMAKE_CURRENT_LIST_DIR}/ccGriddedTools.h
 		${CMAKE_CURRENT_LIST_DIR}/ccHObject.h
 		${CMAKE_CURRENT_LIST_DIR}/ccHObjectCaster.h

--- a/libs/qCC_db/include/ccColorScale.h
+++ b/libs/qCC_db/include/ccColorScale.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // ##########################################################################
 // #                                                                        #
 // #                              CLOUDCOMPARE                              #
@@ -15,9 +17,6 @@
 // #                                                                        #
 // ##########################################################################
 
-#ifndef CC_COLOR_SCALE_HEADER
-#define CC_COLOR_SCALE_HEADER
-
 // Local
 #include "ccColorTypes.h"
 #include "ccSerializableObject.h"
@@ -25,9 +24,12 @@
 // Qt
 #include <QList>
 #include <QSharedPointer>
+#include <QOpenGLTexture>
 
 // System
 #include <set>
+
+class QOpenGLFunctions_2_1;
 
 //! Color scale element: one value + one color
 class ccColorScaleElement
@@ -361,6 +363,21 @@ class QCC_DB_LIB_API ccColorScale : public ccSerializableObject
 	bool  fromFile(QFile& in, short dataVersion, int flags, LoadedIDMap& oldToNewIDMap) override;
 	short minimumFileVersion() const override;
 
+	//! Returns the OpenGL texture corresponding to this color scale
+	QSharedPointer<QOpenGLTexture> getTexture(QOpenGLFunctions_2_1* glFunc) const
+	{
+		if (m_texture.isNull())
+		{
+			buildTexture(glFunc);
+		}
+		return m_texture;
+	}
+
+protected:
+
+	//! Builds the OpenGL texture corresponding to this color scale
+	bool buildTexture(QOpenGLFunctions_2_1* glFunc) const;
+
   protected:
 	//! Sort elements
 	void sort();
@@ -400,6 +417,7 @@ class QCC_DB_LIB_API ccColorScale : public ccSerializableObject
 
 	//! List of custom labels
 	LabelSet m_customLabels;
-};
 
-#endif // CC_COLOR_SCALE_HEADER
+	//! OpenGL texture corresponding to this color scale
+	mutable QSharedPointer<QOpenGLTexture> m_texture;
+};

--- a/libs/qCC_db/include/ccColorScale.h
+++ b/libs/qCC_db/include/ccColorScale.h
@@ -23,8 +23,8 @@
 
 // Qt
 #include <QList>
-#include <QSharedPointer>
 #include <QOpenGLTexture>
+#include <QSharedPointer>
 
 // System
 #include <set>
@@ -373,8 +373,7 @@ class QCC_DB_LIB_API ccColorScale : public ccSerializableObject
 		return m_texture;
 	}
 
-protected:
-
+  protected:
 	//! Builds the OpenGL texture corresponding to this color scale
 	bool buildTexture(QOpenGLFunctions_2_1* glFunc) const;
 

--- a/libs/qCC_db/include/ccGLDrawContext.h
+++ b/libs/qCC_db/include/ccGLDrawContext.h
@@ -42,7 +42,7 @@ struct glDrawParams
 	bool showNorms;
 };
 
-// Drawing flags (type: short)
+//! Drawing flags (type: short)
 enum CC_DRAWING_FLAGS
 {
 	CC_DRAW_2D         = 0x0001,
@@ -53,7 +53,7 @@ enum CC_DRAWING_FLAGS
 	CC_SKIP_SELECTED   = 0x0020,
 	CC_SKIP_ALL        = 0x0030, // = CC_SKIP_UNSELECTED | CC_SKIP_SELECTED
 	CC_ENTITY_PICKING  = 0x0040, // formerly named CC_DRAW_ENTITY_NAMES
-	// CC_FREE_FLAG    = 0x0080, // UNUSED (formerly CC_DRAW_POINT_NAMES)
+	CC_NO_SHADER       = 0x0080, // shaders should not be used to display this entity (formerly CC_DRAW_POINT_NAMES)
 	// CC_FREE_FLAG    = 0x0100, // UNUSED (formerly CC_DRAW_TRI_NAMES)
 	CC_FAST_ENTITY_PICKING = 0x0200, // formerly named CC_DRAW_FAST_NAMES_ONLY
 	// CC_FREE_FLAG        = 0x03C0, // UNUSED (formerly CC_DRAW_ANY_NAMES = CC_DRAW_ENTITY_NAMES | CC_DRAW_POINT_NAMES | CC_DRAW_TRI_NAMES)
@@ -69,6 +69,7 @@ enum CC_DRAWING_FLAGS
 #define MACRO_SkipUnselected(context) ((context.drawingFlags & CC_SKIP_UNSELECTED) != 0)
 #define MACRO_SkipSelected(context) ((context.drawingFlags & CC_SKIP_SELECTED) != 0)
 #define MACRO_EntityPicking(context) ((context.drawingFlags & CC_ENTITY_PICKING) != 0)
+#define MACRO_NoShader(context) ((context.drawingFlags & CC_NO_SHADER) != 0)
 #define MACRO_FastEntityPicking(context) ((context.drawingFlags & CC_FAST_ENTITY_PICKING) != 0)
 #define MACRO_LODActivated(context) ((context.drawingFlags & CC_LOD_ACTIVATED) != 0)
 #define MACRO_VirtualTransEnabled(context) ((context.drawingFlags & CC_VIRTUAL_TRANS_ENABLED) != 0)
@@ -201,10 +202,48 @@ struct ccGLDrawContext
 	{
 	}
 
+	//! Returns the OpenGL functions for a given profile (or nullptr if not available)
 	template <class TYPE>
 	TYPE* glFunctions() const
 	{
 		return qGLContext ? QOpenGLVersionFunctionsFactory::get<TYPE>(qGLContext) : 0;
+	}
+
+	//! Catches GL errors and logs them
+	static bool CatchGLErrors(GLenum err, const char* context)
+	{
+		// catch GL errors
+		{
+			// see http://www.opengl.org/sdk/docs/man/xhtml/glGetError.xml
+			switch (err)
+			{
+			case GL_NO_ERROR:
+				return false;
+			case GL_INVALID_ENUM:
+				ccLog::Warning("[%s] OpenGL error: invalid enumerator", context);
+				break;
+			case GL_INVALID_VALUE:
+				ccLog::Warning("[%s] OpenGL error: invalid value", context);
+				break;
+			case GL_INVALID_OPERATION:
+				ccLog::Warning("[%s] OpenGL error: invalid operation", context);
+				break;
+			case GL_STACK_OVERFLOW:
+				ccLog::Warning("[%s] OpenGL error: stack overflow", context);
+				break;
+			case GL_STACK_UNDERFLOW:
+				ccLog::Warning("[%s] OpenGL error: stack underflow", context);
+				break;
+			case GL_OUT_OF_MEMORY:
+				ccLog::Warning("[%s] OpenGL error: out of memory", context);
+				break;
+			case GL_INVALID_FRAMEBUFFER_OPERATION:
+				ccLog::Warning("[%s] OpenGL error: invalid framebuffer operation", context);
+				break;
+			}
+		}
+
+		return true;
 	}
 };
 

--- a/libs/qCC_db/include/ccGLSLHelper.h
+++ b/libs/qCC_db/include/ccGLSLHelper.h
@@ -1,0 +1,69 @@
+#pragma once
+
+// ##########################################################################
+// #                                                                        #
+// #                              CLOUDCOMPARE                              #
+// #                                                                        #
+// #  This program is free software; you can redistribute it and/or modify  #
+// #  it under the terms of the GNU General Public License as published by  #
+// #  the Free Software Foundation; version 2 or later of the License.      #
+// #                                                                        #
+// #  This program is distributed in the hope that it will be useful,       #
+// #  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+// #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
+// #  GNU General Public License for more details.                          #
+// #                                                                        #
+// #                     COPYRIGHT: CloudCompare project                    #
+// #                                                                        #
+// ##########################################################################
+
+// Qt
+#include <QOpenGLShaderProgram>
+#include <QSharedPointer>
+
+class ccScalarField;
+class QOpenGLFunctions_2_1;
+
+//! OpenGL shader program helper
+class ccGLSL
+{
+  public:
+	enum Attribute
+	{
+		ATTR_POS  = 0,
+		ATTR_NOR  = 1,
+		ATTR_COL  = 2,
+		ATTR_SF   = 4,
+		ATTR_VIS  = 8,
+		ATTR_CLIP = 16,
+		// For internal use only
+		ATTR_LOG_SCALE  = 32,
+		ATTR_SYM_SCALE  = 64,
+		ATTR_HIDDEN_VAL = 128
+	};
+
+	//! Builds a shader program for displaying a point cloud
+	/** Depending on the provided attributes, the shader program will use the following attribute names:
+		- ATTR_POS  = "aPosition"
+		- ATTR_NOR  = "aNormalIndex"
+		- ATTR_COL  = "aColor"
+		- ATTR_SF   = "aSFValue"
+		- ATTR_VIS  = "aVisib"
+
+	    And the following uniform names should be set before usage:
+	    - uColorScaleTex, uTexWidth, uTexHeight, uMinVal, uMaxVal, uMinSat, uMaxSat, uSatRange, uOutOfRangeGreyScale (for scalar fields)
+	    - uNormalLUT, uLUTWidth, uLUTHeight (for normals)
+	    - uLight0Enabled, uLight1Enabled (for lighting - e.g. if ATTR_NOR is set)
+
+		\param glFunc OpenGL functions
+	    \param attributes bit field of ccGLSL::Attribute
+	    \param sf optional scalar field (for color ramp)
+	    \return shader program (nullptr if an error occurred)
+	**/
+	static QSharedPointer<QOpenGLShaderProgram> BuildDisplayProgram(QOpenGLFunctions_2_1* glFunc,
+	                                                                int                   attributes,
+	                                                                ccScalarField*        sf = nullptr);
+
+	//! Releases OpenGL ressources (GLSL programs)
+	static void ReleaseOpenGLRessources();
+};

--- a/libs/qCC_db/include/ccGLSLHelper.h
+++ b/libs/qCC_db/include/ccGLSLHelper.h
@@ -31,11 +31,11 @@ class ccGLSL
   public:
 	enum Attribute
 	{
-		ATTR_POS  = 0,
-		ATTR_NOR  = 1,
-		ATTR_COL  = 2,
-		ATTR_SF   = 4,
-		ATTR_VIS  = 8,
+		ATTR_POS = 0,
+		ATTR_NOR = 1,
+		ATTR_COL = 2,
+		ATTR_SF  = 4,
+		ATTR_VIS = 8,
 		// For internal use only
 		ATTR_LOG_SCALE  = 32,
 		ATTR_SYM_SCALE  = 64,

--- a/libs/qCC_db/include/ccGLSLHelper.h
+++ b/libs/qCC_db/include/ccGLSLHelper.h
@@ -19,6 +19,7 @@
 
 // Qt
 #include <QOpenGLShaderProgram>
+#include <QOpenGLTexture>
 #include <QSharedPointer>
 
 class ccScalarField;
@@ -44,18 +45,24 @@ class ccGLSL
 
 	//! Builds a shader program for displaying a point cloud
 	/** Depending on the provided attributes, the shader program will use the following attribute names:
-		- ATTR_POS  = "aPosition"
-		- ATTR_NOR  = "aNormalIndex"
-		- ATTR_COL  = "aColor"
-		- ATTR_SF   = "aSFValue"
-		- ATTR_VIS  = "aVisib"
+	    - ATTR_POS  = "aPosition"
+	    - ATTR_NOR  = "aNormalIndex"
+	    - ATTR_COL  = "aColor"
+	    - ATTR_SF   = "aSFValue"
+	    - ATTR_VIS  = "aVisib"
 
 	    And the following uniform names should be set before usage:
 	    - uColorScaleTex, uTexWidth, uTexHeight, uMinVal, uMaxVal, uMinSat, uMaxSat, uSatRange, uOutOfRangeGreyScale (for scalar fields)
 	    - uNormalLUT, uLUTWidth, uLUTHeight (for normals)
 	    - uLight0Enabled, uLight1Enabled (for lighting - e.g. if ATTR_NOR is set)
 
-		\param glFunc OpenGL functions
+	    If normals are used (ATTR_NOR), a 2D texture containing a normal LUT (see ccGLSL::GetNormalLUTTexture) must be set as uniform
+	    (see ccGLSL::SetLUTTextureUniforms) and must be bound to unit 0.
+
+	    If a scalar field is used (ATTR_SF), a 2D texture containing the color ramp (see ccColorScale::getTexture) must be set as uniform
+	    (see ccGLSL::SetSFTextureUniforms) and must be bound to unit 1.
+
+	    \param glFunc OpenGL functions
 	    \param attributes bit field of ccGLSL::Attribute
 	    \param sf optional scalar field (for color ramp)
 	    \return shader program (nullptr if an error occurred)
@@ -66,4 +73,45 @@ class ccGLSL
 
 	//! Releases OpenGL ressources (GLSL programs)
 	static void ReleaseOpenGLRessources();
+
+	//! Returns a 2D texture containing a normal LUT (for OpenGL rendering)
+	/** The texture will be created on the first call, and then stored in the shared texture database
+	    \param glFunc OpenGL functions (OpenGL 2.1)
+	    \return the texture
+	**/
+	static QSharedPointer<QOpenGLTexture> GetNormalLUTTexture(QOpenGLFunctions_2_1* glFunc);
+
+	//! Sets the uniforms related to a LUT texture (for OpenGL rendering)
+	/** \param glFunc OpenGL functions (OpenGL 2.1)
+	    \param prog shader program
+	    \param lutTex LUT texture
+	**/
+	static void SetLUTTextureUniforms(QOpenGLFunctions_2_1* glFunc,
+	                                  QOpenGLShaderProgram* prog,
+	                                  QOpenGLTexture*       lutTex);
+
+	//! Sets the uniforms related to a scalar field texture (for OpenGL rendering)
+	/** \param glFunc OpenGL functions (OpenGL 2.1)
+	    \param prog shader program
+	    \param sfTex LUT texture
+	    \param sf scalar field
+	**/
+	static void SetSFTextureUniforms(QOpenGLFunctions_2_1* glFunc,
+	                                 QOpenGLShaderProgram* prog,
+	                                 QOpenGLTexture*       sfTex,
+	                                 ccScalarField*        sf);
+
+	//! Sets the uniforms related to lighting (for OpenGL rendering)
+	/** \param glFunc OpenGL functions (OpenGL 2.1)
+	    \param prog shader program
+	**/
+	static void SetLightUniforms(QOpenGLFunctions_2_1* glFunc,
+	                             QOpenGLShaderProgram* prog);
+
+  protected:
+	//! Creates a 2D texture containing a normal LUT (for OpenGL rendering)
+	/** \param glFunc OpenGL functions (OpenGL 2.1)
+	    \return created texture
+	**/
+	static QSharedPointer<QOpenGLTexture> CreateNormalLUTTexture(QOpenGLFunctions_2_1* glFunc);
 };

--- a/libs/qCC_db/include/ccGLSLHelper.h
+++ b/libs/qCC_db/include/ccGLSLHelper.h
@@ -36,7 +36,6 @@ class ccGLSL
 		ATTR_COL  = 2,
 		ATTR_SF   = 4,
 		ATTR_VIS  = 8,
-		ATTR_CLIP = 16,
 		// For internal use only
 		ATTR_LOG_SCALE  = 32,
 		ATTR_SYM_SCALE  = 64,

--- a/libs/qCC_db/include/ccMaterial.h
+++ b/libs/qCC_db/include/ccMaterial.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // ##########################################################################
 // #                                                                        #
 // #                              CLOUDCOMPARE                              #
@@ -15,9 +17,6 @@
 // #                                                                        #
 // ##########################################################################
 
-#ifndef CC_MATERIAL_HEADER
-#define CC_MATERIAL_HEADER
-
 // Local
 #include "ccColorTypes.h"
 #include "ccSerializableObject.h"
@@ -27,6 +26,7 @@
 #include <QSharedPointer>
 #include <QtGui/qopengl.h>
 
+class ccMaterialDB;
 class QImage;
 class QOpenGLContext;
 
@@ -180,6 +180,9 @@ class QCC_DB_LIB_API ccMaterial : public ccSerializableObject
 	//! Adds a texture to the global texture DB
 	static void AddTexture(QImage image, const QString& absoluteFilename);
 
+	//! Returns the global texture DB
+	static ccMaterialDB* GetTextureDB();
+
 	//! Release all texture objects
 	/** Should be called BEFORE the global shared context is destroyed.
 	 **/
@@ -231,5 +234,3 @@ class QCC_DB_LIB_API ccMaterial : public ccSerializableObject
 	QOpenGLTexture::Filter m_texMinificationFilter;
 	QOpenGLTexture::Filter m_texMagnificationFilter;
 };
-
-#endif // CC_MATERIAL_HEADER

--- a/libs/qCC_db/include/ccMaterialDB.h
+++ b/libs/qCC_db/include/ccMaterialDB.h
@@ -31,11 +31,13 @@ class ccMaterialDB : public QObject
 	Q_OBJECT
 
   public:
+	//! Default constructor
 	ccMaterialDB()
 	    : m_initialized(false)
 	{
 	}
 
+	//! Initializes the database (connects the file watcher)
 	void init()
 	{
 		if (!m_initialized)
@@ -45,6 +47,7 @@ class ccMaterialDB : public QObject
 		}
 	}
 
+	//! Callback called when a file has changed (deleted, renamed or updated)
 	void onFileChanged(const QString& filename)
 	{
 		if (!m_textures.contains(filename))
@@ -75,16 +78,19 @@ class ccMaterialDB : public QObject
 		}
 	}
 
+	//! Returns whether the database contains a texture associated with the given filename.
 	inline bool hasTexture(const QString& filename) const
 	{
 		return m_textures.contains(filename);
 	}
 
+	//!	Returns the texture associated with the given filename (if any).
 	inline QImage getTexture(const QString& filename) const
 	{
 		return m_textures.contains(filename) ? m_textures[filename].image : QImage();
 	}
 
+	//! Add a texture associated with the given filename to the database.
 	void addTexture(const QString& filename, const QImage& image)
 	{
 		if (!m_initialized)
@@ -102,6 +108,7 @@ class ccMaterialDB : public QObject
 		}
 	}
 
+	//!	Increase the texture counter associated with the given filename.
 	void increaseTextureCounter(const QString& filename)
 	{
 		if (m_textures.contains(filename))
@@ -115,6 +122,7 @@ class ccMaterialDB : public QObject
 		}
 	}
 
+	//!	Decrease the texture counter associated with the given filename.
 	void releaseTexture(const QString& filename)
 	{
 		if (m_textures.contains(filename))
@@ -130,6 +138,7 @@ class ccMaterialDB : public QObject
 		}
 	}
 
+	//!	Remove the texture associated with the given filename from the database.
 	void removeTexture(const QString& filename)
 	{
 		m_textures.remove(filename);
@@ -139,16 +148,41 @@ class ccMaterialDB : public QObject
 		openGLTextures.remove(filename);
 	}
 
-	QMap<QString, QSharedPointer<QOpenGLTexture>> openGLTextures;
+	//! Add an OpenGL texture associated with the given filename to the database.
+	void addOpenGLTexture(const QString& filename, QSharedPointer<QOpenGLTexture> texture)
+	{
+		openGLTextures[filename] = texture;
+	}
+
+	//! Remove the OpenGL texture associated with the given filename from the database.
+	void removeOpenGLTexture(const QString& filename)
+	{
+		openGLTextures.remove(filename);
+	}
+
+	//!	Returns the OpenGL texture associated with the given filename (if any).
+	QSharedPointer<QOpenGLTexture> getOpenGLTexture(const QString& filename) const
+	{
+		return openGLTextures.contains(filename) ? openGLTextures[filename] : nullptr;
+	}
+
+	//!	Releases all OpenGL textures associated with the database.
+	void releaseAllOpenGLTextures()
+	{
+		openGLTextures.clear();
+	}
 
   protected:
+	QMap<QString, QSharedPointer<QOpenGLTexture>> openGLTextures; //!< OpenGL textures associated with the database
+
+	//! Texture information
 	struct TextureInfo
 	{
-		QImage   image;
-		unsigned counter = 0;
+		QImage   image;       //!< Texture image
+		unsigned counter = 0; //!< Texture counter (number of times the texture is used)
 	};
 
-	bool                       m_initialized;
-	QFileSystemWatcher         m_watcher;
-	QMap<QString, TextureInfo> m_textures;
+	bool                       m_initialized; //!< Whether the database has been initialized (file watcher connected)
+	QFileSystemWatcher         m_watcher;     //!< File system watcher to monitor texture files for changes
+	QMap<QString, TextureInfo> m_textures;    //!< Texture information associated with the database
 };

--- a/libs/qCC_db/include/ccMaterialDB.h
+++ b/libs/qCC_db/include/ccMaterialDB.h
@@ -23,6 +23,7 @@
 #include <QFileInfo>
 #include <QFileSystemWatcher>
 #include <QImage>
+#include <QOpenGLContext>
 #include <QOpenGLTexture>
 
 //! Smart texture database

--- a/libs/qCC_db/include/ccMesh.h
+++ b/libs/qCC_db/include/ccMesh.h
@@ -470,6 +470,9 @@ class QCC_DB_LIB_API ccMesh : public ccGenericMesh
 	               bool                                arbitraryOutputCS = false,
 	               CCCoreLib::GenericProgressCallback* progressCb        = nullptr) const;
 
+	//! Releases OpenGL ressources (textures, VBOs, etc.)
+	static void ReleaseOpenGLRessources();
+
   protected: // methods
 	// inherited from ccHObject
 	void  drawMeOnly(CC_DRAW_CONTEXT& context) override;

--- a/libs/qCC_db/include/ccNormalVectors.h
+++ b/libs/qCC_db/include/ccNormalVectors.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // ##########################################################################
 // #                                                                        #
 // #                              CLOUDCOMPARE                              #
@@ -15,11 +17,12 @@
 // #                                                                        #
 // ##########################################################################
 
-#ifndef CC_NORMAL_VECTORS_HEADER
-#define CC_NORMAL_VECTORS_HEADER
-
 // Local
 #include "ccGenericPointCloud.h"
+
+// Qt
+#include <QOpenGLTexture>
+#include <QSharedPointer>
 
 // System
 #include <vector>
@@ -65,7 +68,6 @@ class QCC_DB_LIB_API ccNormalVectors
 	//! 'Default' orientations
 	enum Orientation
 	{
-
 		PLUS_X              = 0,  //!< N.x always positive
 		MINUS_X             = 1,  //!< N.x always negative
 		PLUS_Y              = 2,  //!< N.y always positive
@@ -214,6 +216,20 @@ class QCC_DB_LIB_API ccNormalVectors
 	 **/
 	static bool ComputeNormalWithQuadric(CCCoreLib::GenericIndexedCloudPersist* points, const CCVector3& P, CCVector3& N);
 
+  public:
+	//! Returns a 2D texture containing a normal LUT (for OpenGL rendering)
+	/** The texture will be created on the first call, and then stored in the shared texture database
+		\param glFunc OpenGL functions (OpenGL 2.1)
+	    \return the texture
+	**/
+	static QSharedPointer<QOpenGLTexture> GetNormalLUTTexture(QOpenGLFunctions_2_1* glFunc);
+
+	//! Creates a 2D texture containing a normal LUT (for OpenGL rendering)
+	/** \param glFunc OpenGL functions (OpenGL 2.1)
+	    \return created texture
+	**/
+	static QSharedPointer<QOpenGLTexture> CreateNormalLUTTexture(QOpenGLFunctions_2_1* glFunc);
+
   protected:
 	//! Default constructor
 	/** Shouldn't be called directly. Use 'GetUniqueInstance' instead.
@@ -238,5 +254,3 @@ class QCC_DB_LIB_API ccNormalVectors
 	//! Cellular method for octree-based normal computation
 	static bool ComputeNormsAtLevelWithTri(const CCCoreLib::DgmOctree::octreeCell& cell, void** additionalParameters, CCCoreLib::NormalizedProgress* nProgress = nullptr);
 };
-
-#endif // CC_NORMAL_VECTORS_HEADER

--- a/libs/qCC_db/include/ccNormalVectors.h
+++ b/libs/qCC_db/include/ccNormalVectors.h
@@ -219,7 +219,7 @@ class QCC_DB_LIB_API ccNormalVectors
   public:
 	//! Returns a 2D texture containing a normal LUT (for OpenGL rendering)
 	/** The texture will be created on the first call, and then stored in the shared texture database
-		\param glFunc OpenGL functions (OpenGL 2.1)
+	    \param glFunc OpenGL functions (OpenGL 2.1)
 	    \return the texture
 	**/
 	static QSharedPointer<QOpenGLTexture> GetNormalLUTTexture(QOpenGLFunctions_2_1* glFunc);

--- a/libs/qCC_db/include/ccNormalVectors.h
+++ b/libs/qCC_db/include/ccNormalVectors.h
@@ -20,10 +20,6 @@
 // Local
 #include "ccGenericPointCloud.h"
 
-// Qt
-#include <QOpenGLTexture>
-#include <QSharedPointer>
-
 // System
 #include <vector>
 
@@ -215,20 +211,6 @@ class QCC_DB_LIB_API ccNormalVectors
 	/** The normal is computed at the first point (assuming the others are its neighbors).
 	 **/
 	static bool ComputeNormalWithQuadric(CCCoreLib::GenericIndexedCloudPersist* points, const CCVector3& P, CCVector3& N);
-
-  public:
-	//! Returns a 2D texture containing a normal LUT (for OpenGL rendering)
-	/** The texture will be created on the first call, and then stored in the shared texture database
-	    \param glFunc OpenGL functions (OpenGL 2.1)
-	    \return the texture
-	**/
-	static QSharedPointer<QOpenGLTexture> GetNormalLUTTexture(QOpenGLFunctions_2_1* glFunc);
-
-	//! Creates a 2D texture containing a normal LUT (for OpenGL rendering)
-	/** \param glFunc OpenGL functions (OpenGL 2.1)
-	    \return created texture
-	**/
-	static QSharedPointer<QOpenGLTexture> CreateNormalLUTTexture(QOpenGLFunctions_2_1* glFunc);
 
   protected:
 	//! Default constructor

--- a/libs/qCC_db/include/ccPointCloud.h
+++ b/libs/qCC_db/include/ccPointCloud.h
@@ -978,32 +978,10 @@ class QCC_DB_LIB_API ccPointCloud : public CCCoreLib::PointCloudTpl<ccGenericPoi
 
   protected: // VBO
 	//! Init/updates VBOs
-	bool updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams& glParams);
+	bool updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams& glParams, bool noSF = false, bool noNormals = false);
 
 	//! Composite VBO structure
-	class VBO
-	{
-	  public:
-		QOpenGLBuffer vertexBuffer;      //!< vertex buffer
-		QOpenGLBuffer colorBuffer;       //!< color buffer
-		QOpenGLBuffer normalIndexBuffer; //!< normal indexes buffer
-
-		//! Inits the VBO
-		/** \return the number of allocated bytes (or -1 if an error occurred)
-		 **/
-		int init(int count, bool withColors, bool withNormals, bool* reallocated = nullptr);
-
-		//! Releases the VBO
-		void destroy();
-
-		//! Default constructor
-		VBO()
-		    : vertexBuffer(QOpenGLBuffer::VertexBuffer)
-		    , colorBuffer(QOpenGLBuffer::VertexBuffer)
-		    , normalIndexBuffer(QOpenGLBuffer::VertexBuffer)
-		{
-		}
-	};
+	class VBO;
 
 	//! VBO set
 	struct vboSet

--- a/libs/qCC_db/include/ccPointCloud.h
+++ b/libs/qCC_db/include/ccPointCloud.h
@@ -1054,7 +1054,7 @@ class QCC_DB_LIB_API ccPointCloud : public CCCoreLib::PointCloudTpl<ccGenericPoi
 	// per-block data transfer to the GPU (VBO or standard mode)
 	void glChunkVertexPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs, bool useProg = false);
 	void glChunkColorPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs, bool useProg = false);
-	void glChunkSFPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs);
+	void glChunkSFPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs, bool useProg = false);
 	void glChunkNormalPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs, bool useProg = false);
 
   public: // Level of Detail (LOD)

--- a/libs/qCC_db/include/ccPointCloud.h
+++ b/libs/qCC_db/include/ccPointCloud.h
@@ -936,6 +936,9 @@ class QCC_DB_LIB_API ccPointCloud : public CCCoreLib::PointCloudTpl<ccGenericPoi
 	 **/
 	static void ReleaseShaders();
 
+	//! Releases OpenGL ressources (textures, VBOs, etc.)
+	static void ReleaseOpenGLRessources();
+
   protected:
 	// inherited from ccHObject
 	void  drawMeOnly(CC_DRAW_CONTEXT& context) override;

--- a/libs/qCC_db/include/ccPointCloud.h
+++ b/libs/qCC_db/include/ccPointCloud.h
@@ -980,21 +980,27 @@ class QCC_DB_LIB_API ccPointCloud : public CCCoreLib::PointCloudTpl<ccGenericPoi
 	//! Init/updates VBOs
 	bool updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams& glParams);
 
-	class VBO : public QOpenGLBuffer
+	//! Composite VBO structure
+	class VBO
 	{
 	  public:
-		int rgbShift;
-		int normalShift;
+		QOpenGLBuffer vertexBuffer;      //!< vertex buffer
+		QOpenGLBuffer colorBuffer;       //!< color buffer
+		QOpenGLBuffer normalIndexBuffer; //!< normal indexes buffer
 
 		//! Inits the VBO
 		/** \return the number of allocated bytes (or -1 if an error occurred)
 		 **/
 		int init(int count, bool withColors, bool withNormals, bool* reallocated = nullptr);
 
+		//! Releases the VBO
+		void destroy();
+
+		//! Default constructor
 		VBO()
-		    : QOpenGLBuffer(QOpenGLBuffer::VertexBuffer)
-		    , rgbShift(0)
-		    , normalShift(0)
+		    : vertexBuffer(QOpenGLBuffer::VertexBuffer)
+		    , colorBuffer(QOpenGLBuffer::VertexBuffer)
+		    , normalIndexBuffer(QOpenGLBuffer::VertexBuffer)
 		{
 		}
 	};
@@ -1046,10 +1052,10 @@ class QCC_DB_LIB_API ccPointCloud : public CCCoreLib::PointCloudTpl<ccGenericPoi
 	vboSet m_vboManager;
 
 	// per-block data transfer to the GPU (VBO or standard mode)
-	void glChunkVertexPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs);
-	void glChunkColorPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs);
+	void glChunkVertexPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs, bool useProg = false);
+	void glChunkColorPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs, bool useProg = false);
 	void glChunkSFPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs);
-	void glChunkNormalPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs);
+	void glChunkNormalPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs, bool useProg = false);
 
   public: // Level of Detail (LOD)
 	//! Initializes the LOD structure

--- a/libs/qCC_db/include/ccScalarField.h
+++ b/libs/qCC_db/include/ccScalarField.h
@@ -301,6 +301,12 @@ class QCC_DB_LIB_API ccScalarField : public CCCoreLib::ScalarField
 	bool  fromFile(QFile& in, short dataVersion, int flags, LoadedIDMap& oldToNewIDMap) override;
 	short minimumFileVersion() const override;
 
+	//! Returns the underlying data vector (const)
+	const std::vector<float>& data() const
+	{
+		return *this;
+	}
+
   protected: // methods
 	//! Default destructor
 	/** Call release instead

--- a/libs/qCC_db/src/CMakeLists.txt
+++ b/libs/qCC_db/src/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources( ${PROJECT_NAME}
 	    ${CMAKE_CURRENT_LIST_DIR}/ccGenericMesh.cpp
 	    ${CMAKE_CURRENT_LIST_DIR}/ccGenericPointCloud.cpp
 	    ${CMAKE_CURRENT_LIST_DIR}/ccGenericPrimitive.cpp
+		${CMAKE_CURRENT_LIST_DIR}/ccGLSLHelper.cpp
 	    ${CMAKE_CURRENT_LIST_DIR}/ccGriddedTools.cpp
 	    ${CMAKE_CURRENT_LIST_DIR}/ccHObject.cpp
 	    ${CMAKE_CURRENT_LIST_DIR}/ccHObjectCaster.cpp

--- a/libs/qCC_db/src/ccColorScale.cpp
+++ b/libs/qCC_db/src/ccColorScale.cpp
@@ -18,6 +18,7 @@
 #include "ccColorScale.h"
 
 // Qt
+#include <QOpenGLFunctions_2_1>
 #include <QUuid>
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
@@ -139,6 +140,8 @@ void ccColorScale::sort()
 void ccColorScale::update()
 {
 	m_updated = false;
+
+	m_texture.clear();
 
 	if (m_steps.size() >= static_cast<int>(MIN_STEPS))
 	{
@@ -703,4 +706,69 @@ ccColorScale::Shared ccColorScale::LoadFromXML(const QString& filename)
 	}
 
 	return scale;
+}
+
+bool ccColorScale::buildTexture(QOpenGLFunctions_2_1* glFunc) const
+{
+	if (!glFunc)
+	{
+		assert(false);
+		return false;
+	}
+
+	m_texture.clear();
+
+	// Query max texture size
+	GLint maxTexSize = 0;
+	glFunc->glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTexSize);
+	if (maxTexSize <= 0)
+	{
+		return false;
+	}
+
+	const GLint  squareSize = std::min(maxTexSize, (1 << 6)); // number of samples per dimension (max is 2^6 = 64)
+	const size_t texels     = static_cast<size_t>(squareSize) * static_cast<size_t>(squareSize);
+
+	// buffer RGB unsigned bytes
+	std::vector<unsigned char> pixels;
+	try
+	{
+		pixels.resize(texels * 3);
+	}
+	catch (const std::bad_alloc&)
+	{
+		ccLog::Warning("[ccColorScale::buildTexture] Not enough memory");
+		return false;
+	}
+
+	// fill: for each index, call ccNormalCompressor::Decompress
+	for (size_t i = 0; i < texels; ++i)
+	{
+		auto col = getColorByRelativePos(i / static_cast<double>(texels), &ccColor::lightGreyRGB);
+		assert(col);
+
+		pixels[i * 3 + 0] = col->r;
+		pixels[i * 3 + 1] = col->g;
+		pixels[i * 3 + 2] = col->b;
+	}
+
+	// generate GL texture
+	{
+		QSharedPointer<QOpenGLTexture> tex(new QOpenGLTexture(QOpenGLTexture::Target2D));
+
+		// configure texture
+		tex->setFormat(QOpenGLTexture::RGB8_UNorm);
+		tex->setSize(squareSize, squareSize);
+		tex->allocateStorage();
+		tex->setWrapMode(QOpenGLTexture::ClampToEdge);
+		tex->setMinificationFilter(QOpenGLTexture::Nearest);
+		tex->setMagnificationFilter(QOpenGLTexture::Nearest);
+
+		// upload data
+		tex->setData(QOpenGLTexture::RGB, QOpenGLTexture::UInt8, pixels.data());
+
+		m_texture = tex;
+	}
+
+	return true;
 }

--- a/libs/qCC_db/src/ccGLSLHelper.cpp
+++ b/libs/qCC_db/src/ccGLSLHelper.cpp
@@ -1,0 +1,399 @@
+// ##########################################################################
+// #                                                                        #
+// #                              CLOUDCOMPARE                              #
+// #                                                                        #
+// #  This program is free software; you can redistribute it and/or modify  #
+// #  it under the terms of the GNU General Public License as published by  #
+// #  the Free Software Foundation; version 2 or later of the License.      #
+// #                                                                        #
+// #  This program is distributed in the hope that it will be useful,       #
+// #  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+// #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
+// #  GNU General Public License for more details.                          #
+// #                                                                        #
+// #                     COPYRIGHT: CloudCompare project                    #
+// #                                                                        #
+// ##########################################################################
+
+#include "../include/ccGLSLHelper.h"
+
+// Local
+#include "../include/ccScalarField.h"
+
+// Qt
+#include <QOpenGLFunctions_2_1>
+
+// enum Attribute
+//{
+//	ATTR_POS  = 0,
+//	ATTR_NOR  = 1,
+//	ATTR_COL  = 2,
+//	ATTR_SF   = 4,
+//	ATTR_VIS  = 8,
+//	ATTR_CLIP = 16,
+//	// For internal use only
+//	ATTR_LOG_SCALE  = 32,
+//	ATTR_SYM_SCALE  = 64,
+//	ATTR_HIDDEN_VAL = 128
+// };
+
+//! Map or already built shader programs
+static QMap<int, QSharedPointer<QOpenGLShaderProgram>> s_programs;
+
+void ccGLSL::ReleaseOpenGLRessources()
+{
+	if (!QOpenGLContext::currentContext())
+	{
+		ccLog::Warning("[ccGLSL::ReleaseOpenGLRessources] No valid OpenGL context");
+		return;
+	}
+
+	s_programs.clear();
+}
+
+QSharedPointer<QOpenGLShaderProgram> ccGLSL::BuildDisplayProgram(QOpenGLFunctions_2_1* glFunc,
+                                                                 int                   attributes,
+                                                                 ccScalarField*        sf /*=nullptr*/)
+{
+	if (!glFunc)
+	{
+		assert(false);
+		return nullptr;
+	}
+
+	// add secondary attributes
+	if (attributes & ATTR_SF)
+	{
+		if (!sf)
+		{
+			assert(false);
+			return nullptr;
+		}
+
+		if (sf->logScale())
+		{
+			attributes |= ATTR_LOG_SCALE;
+		}
+		else if (sf->symmetricalScale())
+		{
+			attributes |= ATTR_SYM_SCALE;
+		}
+		if (!sf->areNaNValuesShownInGrey())
+		{
+			attributes |= ATTR_HIDDEN_VAL;
+		}
+	}
+
+	if (s_programs.contains(attributes))
+	{
+		return s_programs[attributes];
+	}
+
+	// Vertex programs
+	static const char* VertexProgHeaderSrc =
+	    "#version 120\n"
+	    "attribute vec3 aPosition;\n"
+	    "varying vec4 vColor;\n"
+	    "varying vec4 vVertexPos;\n";
+
+	static const char* VertexProgVisibilityAttributesSrc =
+	    "attribute float aVisib;\n";
+
+	static const char* VertexProgColorAttributesSrc =
+	    "attribute vec4 aColor;\n";
+
+	static const char* VertexProgSFAttributesSrc =
+	    "attribute float aSFValue;\n"
+	    "uniform sampler2D uColorScaleTex;\n"
+	    "uniform int uTexWidth;\n"
+	    "uniform int uTexHeight;\n"
+	    "uniform float uMinVal;\n"
+	    "uniform float uMaxVal;\n"
+	    "uniform float uMinSat;\n"
+	    "uniform float uMaxSat;\n"
+	    "uniform float uSatRange;\n"
+	    "uniform float uOutOfRangeGreyScale;\n";
+
+	static const char* VertexProgNormAttributesSrc =
+	    "attribute float aNormalIndex;\n"
+	    "varying vec3 vNormal;\n"
+	    "uniform sampler2D uNormalLUT;\n"
+	    "uniform int uLUTWidth;\n"
+	    "uniform int uLUTHeight;\n";
+
+	static const char* VertexProgFetchNormFuncSrc =
+	    "vec3 fetchNormalFromLUT(float fi)\n"
+	    "{\n"
+	    "	float w  = float(uLUTWidth);\n"
+	    "	float h  = float(uLUTHeight);\n"
+	    "	float tx = mod(fi, w);\n"
+	    "	float ty = floor(fi / w);\n"
+	    "	vec2 uv = vec2((tx + 0.5) / w, (ty + 0.5) / h);\n"
+	    "	vec3 enc = texture2D(uNormalLUT, uv).rgb;\n"
+	    "	vec3 n = enc * 2.0 - 1.0;\n"
+	    "	return normalize(n);\n"
+	    "}\n";
+
+	static const char* VertexProgFetchSFColorFuncSrc =
+	    "vec4 fetchColorFromTex(float sfVal)\n"
+	    "{\n"
+	    "   float v = normalizeSFVal(sfVal);\n"
+	    "   v = v * float(uTexWidth * uTexHeight - 1);\n"
+	    "	float w  = float(uTexWidth);\n"
+	    "	float h  = float(uTexHeight);\n"
+	    "	float tx = mod(v, w);\n"
+	    "	float ty = floor(v/ w);\n"
+	    "	vec2 uv = vec2(tx / w, ty / h);\n"
+	    "	vec4 color = texture2D(uColorScaleTex, uv);\n"
+	    "	return color;\n"
+	    "}\n";
+
+	static const char* NormalizeNonSymmetricalValueFuncSrc =
+	    "float normalizeSFVal(float sfVal)\n"
+	    "{\n"
+	    "   if (sfVal <= uMinSat)\n"
+	    "      return 0.0;\n"
+	    "   if (sfVal >= uMaxSat)\n"
+	    "      return 1.0;\n"
+	    "   return (sfVal - uMinSat) / uSatRange;\n"
+	    "}\n";
+
+	static const char* NormalizeSymmetricalValueFuncSrc =
+	    "float normalizeSFVal(float sfVal)\n"
+	    "{\n"
+	    "   if (abs(sfVal) <= uMinSat)\n"
+	    "      return 0.5;\n"
+	    "   if (sfVal >= 0)\n"
+	    "   {\n"
+	    "      if (sfVal > uMaxSat)\n"
+	    "         return 1.0;\n"
+	    "      return (1.0 + (sfVal - uMinSat) / uSatRange) / 2.0;\n"
+	    "   }\n"
+	    "   else\n"
+	    "   {\n"
+	    "      if (sfVal < -uMaxSat)\n"
+	    "         return 0.0;\n"
+	    "      return (1.0 + (sfVal + uMinSat) / uSatRange) / 2.0;\n"
+	    "   }\n"
+	    "}\n";
+
+	static const char* NormalizeValueLogScaleFuncSrc =
+	    "float normalizeSFVal(float sfVal)\n"
+	    "{\n"
+	    " 	float dLog = log(max(abs(d), 0.00001)) / log(10.0);\n"
+	    "   if (dLog <= uMinSat)\n"
+	    "      return 0.0;\n"
+	    "   if (dLog >= uMaxSat)\n"
+	    "      return 1.0;\n"
+	    "   return (dLog - uMinSat) / uSatRange;\n"
+	    "}\n";
+
+	static const char* VertexProgMainStartSrc =
+	    "void main()\n"
+	    "{\n";
+
+	static const char* VertexProgMainUseDefaultGLColorSrc =
+	    "    vColor = gl_Color;\n";
+
+	static const char* VertexProgMainUseInputColorSrc =
+	    "    vColor = aColor;\n";
+
+	static const char* VertexProgMainFetchSFColorSrc =
+	    "   if (aSFValue >= uMinVal && aSFValue <= uMaxVal)\n"
+	    "   {\n"
+	    "      vColor = fetchColorFromTex(aSFValue);\n"
+	    "   }\n"
+	    "   else\n"
+	    "   {\n"
+	    "      vColor = vec4(uOutOfRangeGreyScale, uOutOfRangeGreyScale, uOutOfRangeGreyScale, 1.0);\n"
+	    "   }\n";
+
+	static const char* VertexProgMainFetchSFColorHideNaNSrc =
+	    "   if (aSFValue >= uMinVal && aSFValue <= uMaxVal)\n"
+	    "   {\n"
+	    "      vColor = fetchColorFromTex(aSFValue);\n"
+	    "   }\n"
+	    "   else\n"
+	    "   {\n"
+	    "      gl_Position = vec4(0, 0, 0, -1.0);\n" // impossible position, should be discarded by the GPU
+	    "      return;\n"
+	    "   }\n";
+
+	static const char* VertexProgMainTestVisibilitySrc =
+	    "   if (aVisib > 0.0)\n" // CCCoreLib::POINT_VISIBLE = 0
+	    "   {\n"
+	    "      gl_Position = vec4(0, 0, 0, -1.0);\n" // impossible position, should be discarded by the GPU
+	    "      return;\n"
+	    "   }\n";
+
+	static const char* VertexProgMainFetchNormalSrc =
+	    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n";
+
+	static const char* VertexProgMainClippingSrc =
+	    "    gl_ClipVertex = gl_ModelViewMatrix * vec4(aPosition, 1.0);\n";
+
+	static const char* VertexProgMainEndSrc =
+	    "    vVertexPos = gl_ModelViewMatrix * vec4(aPosition, 1.0);\n"
+	    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
+	    "}\n";
+
+	// Fragment programs
+	static const char* ColorOnlyFragmentProgSrc =
+	    "#version 120\n"
+	    "varying vec4 vColor;\n"
+	    "void main()\n"
+	    "{\n"
+	    "    gl_FragColor = vColor;\n"
+	    "}\n";
+
+	static const char* ColorAndNormalFragmentProgSrc =
+	    "#version 120\n"
+	    "varying vec4 vColor;\n"
+	    "varying vec3 vNormal;\n"
+	    "varying vec4 vVertexPos;\n"
+	    "uniform int uLight0Enabled;\n"
+	    "uniform int uLight1Enabled;\n"
+	    "void main()\n"
+	    "{\n"
+	    "   gl_FragColor = gl_FrontLightModelProduct.sceneColor;\n"
+	    "   if (uLight0Enabled == 1)\n"
+		"   {\n"
+		"       vec3 L = normalize(gl_LightSource[0].position.xyz - vVertexPos.xyz);\n" // we are in Eye Coordinates, so EyePos is (0,0,0)
+		"       vec3 E = normalize(-vVertexPos.xyz);\n"
+		"       vec3 R = normalize(-reflect(L,vNormal));\n"
+		"       vec4 Iamb = gl_FrontLightProduct[0].ambient;\n" //calculate Ambient Term:
+		"       vec4 Idiff = gl_FrontLightProduct[0].diffuse * max(dot(vNormal,L), 0.0);\n" //calculate Diffuse Term
+		"       vec4 Ispec = gl_FrontLightProduct[0].specular * pow(max(dot(R,E), 0.0), gl_FrontMaterial.shininess);\n" // calculate Specular Term
+		"       gl_FragColor += Iamb + Idiff + Ispec;\n" // write Total Color
+	    "   }\n"
+	    "   if (uLight1Enabled == 1)\n"
+	    "   {\n"
+		"       vec3 L = normalize(gl_LightSource[1].position.xyz - vVertexPos.xyz);\n" // we are in Eye Coordinates, so EyePos is (0,0,0)
+		"       vec3 E = normalize(-vVertexPos.xyz);\n"
+		"       vec3 R = normalize(-reflect(L,vNormal));\n"
+		"       vec4 Iamb = gl_FrontLightProduct[1].ambient;\n" //calculate Ambient Term:
+		"       vec4 Idiff = gl_FrontLightProduct[1].diffuse * max(dot(vNormal,L), 0.0);\n" //calculate Diffuse Term
+		"       vec4 Ispec = gl_FrontLightProduct[1].specular * pow(max(dot(R,E), 0.0), gl_FrontMaterial.shininess);\n" // calculate Specular Term
+		"       gl_FragColor += Iamb + Idiff + Ispec;\n" // write Total Color
+	    "   }\n"
+	    "   gl_FragColor = vColor * gl_FragColor;\n"
+	    "}\n";
+
+	QString vertexProgSrc = VertexProgHeaderSrc;
+	{
+		// add attributes
+		if (attributes & ATTR_SF)
+			vertexProgSrc += VertexProgSFAttributesSrc;
+		else if (attributes & ATTR_COL)
+			vertexProgSrc += VertexProgColorAttributesSrc;
+		if (attributes & ATTR_NOR)
+			vertexProgSrc += VertexProgNormAttributesSrc;
+		if (attributes & ATTR_VIS)
+			vertexProgSrc += VertexProgVisibilityAttributesSrc;
+
+		// add special functions
+		if (attributes & ATTR_SF)
+		{
+			if (attributes & ATTR_LOG_SCALE)
+			{
+				vertexProgSrc += NormalizeValueLogScaleFuncSrc;
+			}
+			else
+			{
+				vertexProgSrc += ((attributes & ATTR_SYM_SCALE) ? NormalizeSymmetricalValueFuncSrc : NormalizeNonSymmetricalValueFuncSrc);
+			}
+			vertexProgSrc += VertexProgFetchSFColorFuncSrc;
+		}
+
+		if (attributes & ATTR_NOR)
+		{
+			vertexProgSrc += VertexProgFetchNormFuncSrc;
+		}
+
+		// main function
+		{
+			vertexProgSrc += VertexProgMainStartSrc;
+
+			if (attributes & ATTR_VIS)
+			{
+				vertexProgSrc += VertexProgMainTestVisibilitySrc;
+			}
+
+			// color transfer
+			if (attributes & ATTR_SF)
+			{
+				vertexProgSrc += ((attributes & ATTR_HIDDEN_VAL) ? VertexProgMainFetchSFColorHideNaNSrc : VertexProgMainFetchSFColorSrc);
+			}
+			else if (attributes & ATTR_COL)
+			{
+				vertexProgSrc += VertexProgMainUseInputColorSrc;
+			}
+			else
+			{
+				vertexProgSrc += VertexProgMainUseDefaultGLColorSrc;
+			}
+
+			// normal transfer (if any)
+			if (attributes & ATTR_NOR)
+			{
+				vertexProgSrc += VertexProgMainFetchNormalSrc;
+			}
+
+			if (attributes & ATTR_CLIP)
+			{
+				vertexProgSrc += VertexProgMainClippingSrc;
+			}
+
+			vertexProgSrc += VertexProgMainEndSrc;
+		}
+	}
+
+	QString fragmentProgSrc = (attributes & ATTR_NOR ? ColorAndNormalFragmentProgSrc : ColorOnlyFragmentProgSrc);
+
+	QOpenGLShader vertexShader(QOpenGLShader::Vertex);
+	if (false == vertexShader.compileSourceCode(vertexProgSrc))
+	{
+		ccLog::Warning(QString("[BuildDisplayProgram] Vertex shader compilation failed: ") + vertexShader.log());
+		return nullptr;
+	}
+	QOpenGLShader fragmentShader(QOpenGLShader::Fragment);
+	if (false == fragmentShader.compileSourceCode(fragmentProgSrc))
+	{
+		ccLog::Warning(QString("[BuildDisplayProgram] Fragment shader compilation failed: ") + fragmentShader.log());
+		return nullptr;
+	}
+	QSharedPointer<QOpenGLShaderProgram> program(new QOpenGLShaderProgram);
+	program->addShader(&vertexShader);
+	program->addShader(&fragmentShader);
+
+	// bind attribute locations before linking for stable locations
+	program->bindAttributeLocation("aPosition", ATTR_POS);
+	if (attributes & ATTR_VIS)
+	{
+		program->bindAttributeLocation("aVisib", ATTR_VIS);
+	}
+	if (attributes & ATTR_SF)
+	{
+		assert((attributes & ATTR_COL) == 0);
+		program->bindAttributeLocation("aSFValue", ATTR_SF);
+	}
+	else if (attributes & ATTR_COL)
+	{
+		assert((attributes & ATTR_SF) == 0);
+		program->bindAttributeLocation("aColor", ATTR_COL);
+	}
+	if (attributes & ATTR_NOR)
+	{
+		program->bindAttributeLocation("aNormalIndex", ATTR_NOR);
+	}
+
+	if (false == program->link())
+	{
+		ccLog::Warning(QString("[BuildDisplayProgram] Shader program linking failed: ") + program->log());
+		return nullptr;
+	}
+
+	s_programs[attributes] = program;
+
+	return program;
+}

--- a/libs/qCC_db/src/ccGLSLHelper.cpp
+++ b/libs/qCC_db/src/ccGLSLHelper.cpp
@@ -182,7 +182,7 @@ QSharedPointer<QOpenGLShaderProgram> ccGLSL::BuildDisplayProgram(QOpenGLFunction
 	static const char* NormalizeValueLogScaleFuncSrc =
 	    "float normalizeSFVal(float sfVal)\n"
 	    "{\n"
-	    " 	float dLog = log(max(abs(d), 0.00001)) / log(10.0);\n"
+	    " 	float dLog = log(max(abs(sfVal), 0.00001)) / log(10.0);\n"
 	    "   if (dLog <= uMinSat)\n"
 	    "      return 0.0;\n"
 	    "   if (dLog >= uMaxSat)\n"

--- a/libs/qCC_db/src/ccGLSLHelper.cpp
+++ b/libs/qCC_db/src/ccGLSLHelper.cpp
@@ -18,6 +18,8 @@
 #include "../include/ccGLSLHelper.h"
 
 // Local
+#include "../include/ccMaterialDB.h"
+#include "../include/ccNormalVectors.h"
 #include "../include/ccScalarField.h"
 
 // Qt
@@ -257,24 +259,24 @@ QSharedPointer<QOpenGLShaderProgram> ccGLSL::BuildDisplayProgram(QOpenGLFunction
 	    "{\n"
 	    "   gl_FragColor = gl_FrontLightModelProduct.sceneColor;\n"
 	    "   if (uLight0Enabled == 1)\n"
-		"   {\n"
-		"       vec3 L = normalize(gl_LightSource[0].position.xyz - vVertexPos.xyz);\n" // we are in Eye Coordinates, so EyePos is (0,0,0)
-		"       vec3 E = normalize(-vVertexPos.xyz);\n"
-		"       vec3 R = normalize(-reflect(L,vNormal));\n"
-		"       vec4 Iamb = gl_FrontLightProduct[0].ambient;\n" //calculate Ambient Term:
-		"       vec4 Idiff = gl_FrontLightProduct[0].diffuse * max(dot(vNormal,L), 0.0);\n" //calculate Diffuse Term
-		"       vec4 Ispec = gl_FrontLightProduct[0].specular * pow(max(dot(R,E), 0.0), gl_FrontMaterial.shininess);\n" // calculate Specular Term
-		"       gl_FragColor += Iamb + Idiff + Ispec;\n" // write Total Color
+	    "   {\n"
+	    "       vec3 L = normalize(gl_LightSource[0].position.xyz - vVertexPos.xyz);\n" // we are in Eye Coordinates, so EyePos is (0,0,0)
+	    "       vec3 E = normalize(-vVertexPos.xyz);\n"
+	    "       vec3 R = normalize(-reflect(L,vNormal));\n"
+	    "       vec4 Iamb = gl_FrontLightProduct[0].ambient;\n"                                                         // calculate Ambient Term:
+	    "       vec4 Idiff = gl_FrontLightProduct[0].diffuse * max(dot(vNormal,L), 0.0);\n"                             // calculate Diffuse Term
+	    "       vec4 Ispec = gl_FrontLightProduct[0].specular * pow(max(dot(R,E), 0.0), gl_FrontMaterial.shininess);\n" // calculate Specular Term
+	    "       gl_FragColor += Iamb + Idiff + Ispec;\n"                                                                // write Total Color
 	    "   }\n"
 	    "   if (uLight1Enabled == 1)\n"
 	    "   {\n"
-		"       vec3 L = normalize(gl_LightSource[1].position.xyz - vVertexPos.xyz);\n" // we are in Eye Coordinates, so EyePos is (0,0,0)
-		"       vec3 E = normalize(-vVertexPos.xyz);\n"
-		"       vec3 R = normalize(-reflect(L,vNormal));\n"
-		"       vec4 Iamb = gl_FrontLightProduct[1].ambient;\n" //calculate Ambient Term:
-		"       vec4 Idiff = gl_FrontLightProduct[1].diffuse * max(dot(vNormal,L), 0.0);\n" //calculate Diffuse Term
-		"       vec4 Ispec = gl_FrontLightProduct[1].specular * pow(max(dot(R,E), 0.0), gl_FrontMaterial.shininess);\n" // calculate Specular Term
-		"       gl_FragColor += Iamb + Idiff + Ispec;\n" // write Total Color
+	    "       vec3 L = normalize(gl_LightSource[1].position.xyz - vVertexPos.xyz);\n" // we are in Eye Coordinates, so EyePos is (0,0,0)
+	    "       vec3 E = normalize(-vVertexPos.xyz);\n"
+	    "       vec3 R = normalize(-reflect(L,vNormal));\n"
+	    "       vec4 Iamb = gl_FrontLightProduct[1].ambient;\n"                                                         // calculate Ambient Term:
+	    "       vec4 Idiff = gl_FrontLightProduct[1].diffuse * max(dot(vNormal,L), 0.0);\n"                             // calculate Diffuse Term
+	    "       vec4 Ispec = gl_FrontLightProduct[1].specular * pow(max(dot(R,E), 0.0), gl_FrontMaterial.shininess);\n" // calculate Specular Term
+	    "       gl_FragColor += Iamb + Idiff + Ispec;\n"                                                                // write Total Color
 	    "   }\n"
 	    "   gl_FragColor = vColor * gl_FragColor;\n"
 	    "}\n";
@@ -396,4 +398,156 @@ QSharedPointer<QOpenGLShaderProgram> ccGLSL::BuildDisplayProgram(QOpenGLFunction
 	s_programs[attributes] = program;
 
 	return program;
+}
+
+QSharedPointer<QOpenGLTexture> ccGLSL::CreateNormalLUTTexture(QOpenGLFunctions_2_1* glFunc)
+{
+	if (!glFunc)
+	{
+		assert(false);
+		return nullptr;
+	}
+
+	const unsigned totalNormals = ccNormalCompressor::MAX_VALID_NORM_CODE + 1; // number of valid codes
+	// Query max texture size
+	GLint maxTexSize = 0;
+	glFunc->glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTexSize);
+	if (maxTexSize <= 0)
+	{
+		return nullptr;
+	}
+
+	// choose width as large as possible (but <= maxTexSize) to minimize height
+	int width  = std::min(static_cast<int>(totalNormals), maxTexSize);
+	int height = static_cast<int>(std::ceil(static_cast<float>(totalNormals) / float(width)));
+
+	const size_t texels = static_cast<size_t>(width) * static_cast<size_t>(height);
+
+	// buffer RGB unsigned bytes
+	std::vector<unsigned char> pixels;
+	try
+	{
+		pixels.resize(texels * 3);
+	}
+	catch (const std::bad_alloc&)
+	{
+		ccLog::Warning("[ccMesh::CreateNormalLUTTexture] Not enough memory");
+		return nullptr;
+	}
+
+	// fill: for each index, call ccNormalCompressor::Decompress
+	for (unsigned i = 0; i < totalNormals; ++i)
+	{
+		CCVector3 n = ccNormalVectors::GetNormal(i);
+
+		// map [-1,1] -> [0,255]
+		// handle NULL_NORM_CODE: Decompress sets to 0, so it becomes 127 -> you can change if needed
+		pixels[i * 3 + 0] = static_cast<unsigned char>(std::round(std::clamp((n.x * 0.5 + 0.5), 0.0, 1.0) * 255.0));
+		pixels[i * 3 + 1] = static_cast<unsigned char>(std::round(std::clamp((n.y * 0.5 + 0.5), 0.0, 1.0) * 255.0));
+		pixels[i * 3 + 2] = static_cast<unsigned char>(std::round(std::clamp((n.z * 0.5 + 0.5), 0.0, 1.0) * 255.0));
+	}
+
+	// generate GL texture
+	QSharedPointer<QOpenGLTexture> tex(new QOpenGLTexture(QOpenGLTexture::Target2D));
+
+	// configure texture
+	tex->setFormat(QOpenGLTexture::RGB8_UNorm);
+	tex->setSize(width, height);
+	tex->allocateStorage();
+	tex->setWrapMode(QOpenGLTexture::ClampToEdge);
+	tex->setMinificationFilter(QOpenGLTexture::Nearest);
+	tex->setMagnificationFilter(QOpenGLTexture::Nearest);
+
+	// upload data
+	tex->setData(QOpenGLTexture::RGB, QOpenGLTexture::UInt8, pixels.data());
+
+	return tex;
+}
+
+QSharedPointer<QOpenGLTexture> ccGLSL::GetNormalLUTTexture(QOpenGLFunctions_2_1* glFunc)
+{
+	// If not done already, create the LUT texture and bind it to unit 0
+	if (nullptr == ccMaterial::GetTextureDB())
+	{
+		assert(false);
+		return nullptr;
+	}
+
+	QSharedPointer<QOpenGLTexture> lutTex = ccMaterial::GetTextureDB()->getOpenGLTexture("CompressedNormalsLUT");
+	if (!lutTex.isNull())
+	{
+		return lutTex;
+	}
+
+	// try to create it if necessary
+	lutTex = CreateNormalLUTTexture(glFunc);
+	if (!lutTex.isNull())
+	{
+		ccMaterial::GetTextureDB()->addOpenGLTexture("CompressedNormalsLUT", lutTex);
+	}
+
+	return lutTex;
+}
+
+void ccGLSL::SetLUTTextureUniforms(QOpenGLFunctions_2_1* glFunc,
+                                   QOpenGLShaderProgram* prog,
+                                   QOpenGLTexture*       lutTex)
+{
+	if (!glFunc || !prog || !lutTex)
+	{
+		assert(false);
+		return;
+	}
+	// set sampler uniform to unit 0
+	glFunc->glUniform1i(prog->uniformLocation("uNormalLUT"), 0);
+	// set LUT dimensions
+	glFunc->glUniform1i(prog->uniformLocation("uLUTWidth"), lutTex->width());
+	glFunc->glUniform1i(prog->uniformLocation("uLUTHeight"), lutTex->height());
+}
+
+void ccGLSL::SetSFTextureUniforms(QOpenGLFunctions_2_1* glFunc,
+                                  QOpenGLShaderProgram* prog,
+                                  QOpenGLTexture*       sfTex,
+                                  ccScalarField*        sf)
+{
+	if (!glFunc || !prog || !sfTex || !sf)
+	{
+		assert(false);
+		return;
+	}
+	// set sampler uniform to unit 1
+	glFunc->glUniform1i(prog->uniformLocation("uColorScaleTex"), 1);
+	// set texture dimensions
+	glFunc->glUniform1i(prog->uniformLocation("uTexWidth"), sfTex->width());
+	glFunc->glUniform1i(prog->uniformLocation("uTexHeight"), sfTex->height());
+
+	auto   colorScale = sf->getColorScale();
+	double offset     = sf->getOffset();
+
+	float minVal              = static_cast<float>(sf->displayRange().start() - offset);
+	float maxVal              = static_cast<float>(sf->displayRange().stop() - offset);
+	float minSat              = static_cast<float>(sf->saturationRange().start() - offset);
+	float maxSat              = static_cast<float>(sf->saturationRange().stop() - offset);
+	float satRange            = static_cast<float>(sf->saturationRange().range());
+	float outOfRangeGreyScale = ccColor::lightGreyRGB.r / 255.0f;
+
+	glFunc->glUniform1f(prog->uniformLocation("uMinVal"), minVal);
+	glFunc->glUniform1f(prog->uniformLocation("uMaxVal"), maxVal);
+	glFunc->glUniform1f(prog->uniformLocation("uMinSat"), minSat);
+	glFunc->glUniform1f(prog->uniformLocation("uMaxSat"), maxSat);
+	glFunc->glUniform1f(prog->uniformLocation("uSatRange"), satRange);
+	glFunc->glUniform1f(prog->uniformLocation("uOutOfRangeGreyScale"), outOfRangeGreyScale);
+}
+
+void ccGLSL::SetLightUniforms(QOpenGLFunctions_2_1* glFunc,
+                                   QOpenGLShaderProgram* prog)
+{
+	if (!glFunc || !prog)
+	{
+		assert(false);
+		return;
+	}
+
+	glFunc->glUniform1i(prog->uniformLocation("uLight0Enabled"), glFunc->glIsEnabled(GL_LIGHT0) ? 1 : 0);
+	glFunc->glUniform1i(prog->uniformLocation("uLight1Enabled"), glFunc->glIsEnabled(GL_LIGHT1) ? 1 : 0);
 }

--- a/libs/qCC_db/src/ccGLSLHelper.cpp
+++ b/libs/qCC_db/src/ccGLSLHelper.cpp
@@ -25,20 +25,6 @@
 // Qt
 #include <QOpenGLFunctions_2_1>
 
-// enum Attribute
-//{
-//	ATTR_POS  = 0,
-//	ATTR_NOR  = 1,
-//	ATTR_COL  = 2,
-//	ATTR_SF   = 4,
-//	ATTR_VIS  = 8,
-//	ATTR_CLIP = 16,
-//	// For internal use only
-//	ATTR_LOG_SCALE  = 32,
-//	ATTR_SYM_SCALE  = 64,
-//	ATTR_HIDDEN_VAL = 128
-// };
-
 //! Map or already built shader programs
 static QMap<int, QSharedPointer<QOpenGLShaderProgram>> s_programs;
 
@@ -229,14 +215,12 @@ QSharedPointer<QOpenGLShaderProgram> ccGLSL::BuildDisplayProgram(QOpenGLFunction
 	    "   }\n";
 
 	static const char* VertexProgMainFetchNormalSrc =
-	    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n";
-
-	static const char* VertexProgMainClippingSrc =
-	    "    gl_ClipVertex = gl_ModelViewMatrix * vec4(aPosition, 1.0);\n";
+	    "   vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n";
 
 	static const char* VertexProgMainEndSrc =
-	    "    vVertexPos = gl_ModelViewMatrix * vec4(aPosition, 1.0);\n"
-	    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
+	    "   gl_ClipVertex = gl_ModelViewMatrix * vec4(aPosition, 1.0);\n"
+	    "   vVertexPos = gl_ClipVertex;\n"
+	    "   gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
 	    "}\n";
 
 	// Fragment programs
@@ -339,11 +323,6 @@ QSharedPointer<QOpenGLShaderProgram> ccGLSL::BuildDisplayProgram(QOpenGLFunction
 			if (attributes & ATTR_NOR)
 			{
 				vertexProgSrc += VertexProgMainFetchNormalSrc;
-			}
-
-			if (attributes & ATTR_CLIP)
-			{
-				vertexProgSrc += VertexProgMainClippingSrc;
 			}
 
 			vertexProgSrc += VertexProgMainEndSrc;

--- a/libs/qCC_db/src/ccGLSLHelper.cpp
+++ b/libs/qCC_db/src/ccGLSLHelper.cpp
@@ -540,7 +540,7 @@ void ccGLSL::SetSFTextureUniforms(QOpenGLFunctions_2_1* glFunc,
 }
 
 void ccGLSL::SetLightUniforms(QOpenGLFunctions_2_1* glFunc,
-                                   QOpenGLShaderProgram* prog)
+                              QOpenGLShaderProgram* prog)
 {
 	if (!glFunc || !prog)
 	{

--- a/libs/qCC_db/src/ccMaterial.cpp
+++ b/libs/qCC_db/src/ccMaterial.cpp
@@ -29,6 +29,11 @@
 // Textures DB
 static ccMaterialDB s_materialDB;
 
+ccMaterialDB* ccMaterial::GetTextureDB()
+{
+	return &s_materialDB;
+}
+
 ccMaterial::ccMaterial(const QString& name)
     : m_name(name)
     , m_uniqueID(QUuid::createUuid().toString())
@@ -193,11 +198,7 @@ GLuint ccMaterial::getTextureID() const
 		{
 			return 0;
 		}
-		QSharedPointer<QOpenGLTexture> tex;
-		if (s_materialDB.openGLTextures.contains(m_textureFilename))
-		{
-			tex = s_materialDB.openGLTextures[m_textureFilename];
-		}
+		QSharedPointer<QOpenGLTexture> tex = s_materialDB.getOpenGLTexture(m_textureFilename);
 
 		if (!tex)
 		{
@@ -207,7 +208,7 @@ GLuint ccMaterial::getTextureID() const
 			tex->setFormat(QOpenGLTexture::RGB8_UNorm);
 			tex->setData(getTexture(), QOpenGLTexture::DontGenerateMipMaps);
 			tex->create();
-			s_materialDB.openGLTextures[m_textureFilename] = tex;
+			s_materialDB.addOpenGLTexture(m_textureFilename, tex);
 		}
 		return tex->textureId();
 	}
@@ -275,7 +276,7 @@ void ccMaterial::ReleaseTextures()
 		return;
 	}
 
-	s_materialDB.openGLTextures.clear();
+	s_materialDB.releaseAllOpenGLTextures();
 }
 
 void ccMaterial::releaseTexture()
@@ -389,10 +390,10 @@ void ccMaterial::setTextureMinMagFilters(QOpenGLTexture::Filter minificationFilt
 		m_texMinificationFilter  = minificationFilter;
 		m_texMagnificationFilter = magnificationFilter;
 
-		if (!m_textureFilename.isEmpty() && s_materialDB.openGLTextures.contains(m_textureFilename))
+		if (!m_textureFilename.isEmpty())
 		{
 			// remove the existing texture (if any) so that it's initialized again next time
-			s_materialDB.openGLTextures.remove(m_textureFilename);
+			s_materialDB.removeOpenGLTexture(m_textureFilename);
 		}
 	}
 }

--- a/libs/qCC_db/src/ccMesh.cpp
+++ b/libs/qCC_db/src/ccMesh.cpp
@@ -26,7 +26,6 @@
 #include "ccGenericGLDisplay.h"
 #include "ccGenericPointCloud.h"
 #include "ccHObjectCaster.h"
-#include "ccMaterialDB.h"
 #include "ccMaterialSet.h"
 #include "ccNormalVectors.h"
 #include "ccPointCloud.h"
@@ -1721,71 +1720,6 @@ void ccMesh::ReleaseOpenGLRessources()
 	}
 }
 
-// create a 2D texture containing all the normals (for OpenGL 2.1)
-static QSharedPointer<QOpenGLTexture> CreateNormalLUTTexture(QOpenGLFunctions_2_1* gl)
-{
-	if (!gl)
-	{
-		assert(false);
-		return nullptr;
-	}
-
-	const unsigned totalNormals = ccNormalCompressor::MAX_VALID_NORM_CODE + 1; // number of valid codes
-	// Query max texture size
-	GLint maxTexSize = 0;
-	gl->glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTexSize);
-	if (maxTexSize <= 0)
-	{
-		return nullptr;
-	}
-
-	// choose width as large as possible (but <= maxTexSize) to minimize height
-	int width  = std::min(static_cast<int>(totalNormals), maxTexSize);
-	int height = static_cast<int>(std::ceil(static_cast<float>(totalNormals) / float(width)));
-
-	const size_t texels = static_cast<size_t>(width) * static_cast<size_t>(height);
-
-	// buffer RGB unsigned bytes
-	std::vector<unsigned char> pixels;
-	try
-	{
-		pixels.resize(texels * 3);
-	}
-	catch (const std::bad_alloc&)
-	{
-		ccLog::Warning("[ccMesh::CreateNormalLUTTexture] Not enough memory");
-		return nullptr;
-	}
-
-	// fill: for each index, call ccNormalCompressor::Decompress
-	for (unsigned i = 0; i < totalNormals; ++i)
-	{
-		CCVector3 n = ccNormalVectors::GetNormal(i);
-
-		// map [-1,1] -> [0,255]
-		// handle NULL_NORM_CODE: Decompress sets to 0, so it becomes 127 -> you can change if needed
-		pixels[i * 3 + 0] = static_cast<unsigned char>(std::round(std::clamp((n.x * 0.5 + 0.5), 0.0, 1.0) * 255.0));
-		pixels[i * 3 + 1] = static_cast<unsigned char>(std::round(std::clamp((n.y * 0.5 + 0.5), 0.0, 1.0) * 255.0));
-		pixels[i * 3 + 2] = static_cast<unsigned char>(std::round(std::clamp((n.z * 0.5 + 0.5), 0.0, 1.0) * 255.0));
-	}
-
-	// generate GL texture
-	QSharedPointer<QOpenGLTexture> tex(new QOpenGLTexture(QOpenGLTexture::Target2D));
-
-	// configure texture
-	tex->setFormat(QOpenGLTexture::RGB8_UNorm);
-	tex->setSize(width, height);
-	tex->allocateStorage();
-	tex->setWrapMode(QOpenGLTexture::ClampToEdge);
-	tex->setMinificationFilter(QOpenGLTexture::Nearest);
-	tex->setMagnificationFilter(QOpenGLTexture::Nearest);
-
-	// upload data
-	tex->setData(QOpenGLTexture::RGB, QOpenGLTexture::UInt8, pixels.data());
-
-	return tex;
-}
-
 // Simple program builder (GLSL 1.20) for mesh rendering (position, normal, color)
 static QSharedPointer<QOpenGLShaderProgram> BuildSimpleMeshProgram(QOpenGLFunctions_2_1* glFunc, int attributes)
 {
@@ -1959,6 +1893,8 @@ static QSharedPointer<QOpenGLShaderProgram> BuildSimpleMeshProgram(QOpenGLFuncti
 	}
 
 	s_programs[attributes] = program;
+
+	ccGLDrawContext::CatchGLErrors(glFunc->glGetError(), "ccMesh::shader.program.build");
 
 	return program;
 }
@@ -2146,10 +2082,19 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 		EnableGLStippleMask(context.qGLContext, true);
 	}
 
-	if (!visFiltering && !(applyMaterials || showTextures) && (!glParams.showSF || !sfMayHaveHiddenValues) && !MACRO_NoShader(context))
-	{
-		assert(!entityPickingMode || !glParams.showSF);
+	// normal acceleration texture (for fast normals display)
+	static bool s_normalLUTTextureFailed = false;
+	QSharedPointer<QOpenGLTexture> lutTex;
 
+	bool fallBackDisplay = (visFiltering
+	                        || (applyMaterials || showTextures)
+	                        || (glParams.showSF && sfMayHaveHiddenValues)
+	                        || (glParams.showNorms && s_normalLUTTextureFailed))
+	                       || MACRO_NoShader(context);
+
+	QSharedPointer<QOpenGLShaderProgram> prog;
+	if (!fallBackDisplay)
+	{
 		// get GL program
 		int attributes = ATTR_POS;
 		if (glParams.showNorms)
@@ -2161,244 +2106,242 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 			attributes |= ATTR_COL;
 		}
 
-		QSharedPointer<QOpenGLShaderProgram> prog = BuildSimpleMeshProgram(glFunc, attributes);
-		if (prog)
+		prog = BuildSimpleMeshProgram(glFunc, attributes);
+		if (prog.isNull())
 		{
-			ccGLDrawContext::CatchGLErrors(glFunc->glGetError(), "ccMesh::shader.program.build");
+			fallBackDisplay = true;
+		}
+		else if (glParams.showNorms)
+		{
+			assert(!s_normalLUTTextureFailed);
+
+			// create or retrieve the LUT texture
+			lutTex = ccNormalVectors::GetNormalLUTTexture(glFunc);
+			if (lutTex.isNull())
+			{
+				ccLog::Warning("Failed to create normals LUT texture! Cannot render fast normals.");
+				s_normalLUTTextureFailed = true;
+				fallBackDisplay          = true;
+			}
+		}
+	}
+
+	if (!fallBackDisplay)
+	{
+		assert(!entityPickingMode || !glParams.showSF);
+		assert(prog.isNull() == false);	
 
 			// static VBO handles reused between calls
-			if (s_vboVertex == 0)
+		if (s_vboVertex == 0)
+		{
+			glFunc->glGenBuffers(1, &s_vboVertex);
+		}
+
+		if (glParams.showNorms && s_vboNormals == 0)
+		{
+			glFunc->glGenBuffers(1, &s_vboNormals);
+		}
+
+		if ((glParams.showColors || glParams.showSF) && s_vboColor == 0)
+		{
+			glFunc->glGenBuffers(1, &s_vboColor);
+		}
+
+		auto   vertices  = GetVertexBuffer();
+		float* normals   = reinterpret_cast<float*>(GetNormalsBuffer());
+		auto   rgbColors = GetColorsBuffer();
+
+		// we can scan and process each chunk separately in an optimized way
+		size_t chunkCount = ccChunk::Count(m_triVertIndexes->size());
+		for (size_t k = 0; k < chunkCount; ++k)
+		{
+			const size_t                      chunkSize               = ccChunk::Size(k, m_triVertIndexes->size());
+			const CCCoreLib::VerticesIndexes* _vertIndexesChunkOrigin = ccChunk::Start(*m_triVertIndexes, k);
+
+			// vertices
+			size_t vertexCount = 0;
 			{
-				glFunc->glGenBuffers(1, &s_vboVertex);
+				const CCCoreLib::VerticesIndexes* _vertIndexes = _vertIndexesChunkOrigin;
+				CCVector3*                        _vertices    = vertices;
+				for (size_t n = 0; n < chunkSize; n += decimStep, _vertIndexes += decimStep)
+				{
+					assert(_vertIndexes->i1 < cloud->size());
+					assert(_vertIndexes->i2 < cloud->size());
+					assert(_vertIndexes->i3 < cloud->size());
+					*_vertices++ = *cloud->getPoint(_vertIndexes->i1);
+					*_vertices++ = *cloud->getPoint(_vertIndexes->i2);
+					*_vertices++ = *cloud->getPoint(_vertIndexes->i3);
+					vertexCount += 3;
+				}
 			}
 
-			if (glParams.showNorms && s_vboNormals == 0)
+			// scalar field
+			size_t rgbColorCount = 0;
+			if (glParams.showSF)
 			{
-				glFunc->glGenBuffers(1, &s_vboNormals);
+				const CCCoreLib::VerticesIndexes* _vertIndexes = _vertIndexesChunkOrigin;
+				ccColor::Rgb*                     _rgbColors   = reinterpret_cast<ccColor::Rgb*>(rgbColors);
+				assert(colorScale);
+
+				for (size_t n = 0; n < chunkSize; n += decimStep, _vertIndexes += decimStep)
+				{
+					assert(_vertIndexes->i1 < currentDisplayedScalarField->size());
+					assert(_vertIndexes->i2 < currentDisplayedScalarField->size());
+					assert(_vertIndexes->i3 < currentDisplayedScalarField->size());
+					*_rgbColors++ = *currentDisplayedScalarField->getValueColor(_vertIndexes->i1);
+					*_rgbColors++ = *currentDisplayedScalarField->getValueColor(_vertIndexes->i2);
+					*_rgbColors++ = *currentDisplayedScalarField->getValueColor(_vertIndexes->i3);
+					rgbColorCount += 3;
+				}
+			}
+			else if (glParams.showColors) // colors
+			{
+				const CCCoreLib::VerticesIndexes* _vertIndexes = _vertIndexesChunkOrigin;
+				ccColor::Rgba*                    _rgbaColors  = reinterpret_cast<ccColor::Rgba*>(rgbColors);
+				for (size_t n = 0; n < chunkSize; n += decimStep, _vertIndexes += decimStep)
+				{
+					assert(_vertIndexes->i1 < rgbaColorsTable->size());
+					assert(_vertIndexes->i2 < rgbaColorsTable->size());
+					assert(_vertIndexes->i3 < rgbaColorsTable->size());
+					*(_rgbaColors)++ = rgbaColorsTable->at(_vertIndexes->i1);
+					*(_rgbaColors)++ = rgbaColorsTable->at(_vertIndexes->i2);
+					*(_rgbaColors)++ = rgbaColorsTable->at(_vertIndexes->i3);
+					rgbColorCount += 3;
+				}
 			}
 
-			if ((glParams.showColors || glParams.showSF) && s_vboColor == 0)
+			// normals
+			size_t normalCount = 0;
+			if (glParams.showNorms)
 			{
-				glFunc->glGenBuffers(1, &s_vboColor);
-			}
-
-			auto   vertices  = GetVertexBuffer();
-			float* normals   = reinterpret_cast<float*>(GetNormalsBuffer());
-			auto   rgbColors = GetColorsBuffer();
-
-			// we can scan and process each chunk separately in an optimized way
-			size_t chunkCount = ccChunk::Count(m_triVertIndexes->size());
-			for (size_t k = 0; k < chunkCount; ++k)
-			{
-				const size_t                      chunkSize               = ccChunk::Size(k, m_triVertIndexes->size());
-				const CCCoreLib::VerticesIndexes* _vertIndexesChunkOrigin = ccChunk::Start(*m_triVertIndexes, k);
-
-				// vertices
-				size_t vertexCount = 0;
+				float* _normals = normals;
+				if (showTriNormals)
 				{
-					const CCCoreLib::VerticesIndexes* _vertIndexes = _vertIndexesChunkOrigin;
-					CCVector3*                        _vertices    = vertices;
-					for (size_t n = 0; n < chunkSize; n += decimStep, _vertIndexes += decimStep)
+					assert(m_triNormalIndexes);
+					const Tuple3i* _triNormalIndexes = ccChunk::Start(*m_triNormalIndexes, k);
+					for (size_t n = 0; n < chunkSize; n += decimStep, _triNormalIndexes += decimStep)
 					{
-						assert(_vertIndexes->i1 < cloud->size());
-						assert(_vertIndexes->i2 < cloud->size());
-						assert(_vertIndexes->i3 < cloud->size());
-						*_vertices++ = *cloud->getPoint(_vertIndexes->i1);
-						*_vertices++ = *cloud->getPoint(_vertIndexes->i2);
-						*_vertices++ = *cloud->getPoint(_vertIndexes->i3);
-						vertexCount += 3;
+						assert(_triNormalIndexes->u[0] < static_cast<int>(m_triNormals->size()));
+						assert(_triNormalIndexes->u[1] < static_cast<int>(m_triNormals->size()));
+						assert(_triNormalIndexes->u[2] < static_cast<int>(m_triNormals->size()));
+
+						*_normals++ = static_cast<float>(_triNormalIndexes->u[0] >= 0 ? m_triNormals->at(_triNormalIndexes->u[0]) : 0);
+						*_normals++ = static_cast<float>(_triNormalIndexes->u[1] >= 0 ? m_triNormals->at(_triNormalIndexes->u[1]) : 0);
+						*_normals++ = static_cast<float>(_triNormalIndexes->u[2] >= 0 ? m_triNormals->at(_triNormalIndexes->u[2]) : 0);
+
+						normalCount += 3;
 					}
-				}
-
-				// scalar field
-				size_t rgbColorCount = 0;
-				if (glParams.showSF)
-				{
-					const CCCoreLib::VerticesIndexes* _vertIndexes = _vertIndexesChunkOrigin;
-					ccColor::Rgb*                     _rgbColors   = reinterpret_cast<ccColor::Rgb*>(rgbColors);
-					assert(colorScale);
-
-					for (size_t n = 0; n < chunkSize; n += decimStep, _vertIndexes += decimStep)
-					{
-						assert(_vertIndexes->i1 < currentDisplayedScalarField->size());
-						assert(_vertIndexes->i2 < currentDisplayedScalarField->size());
-						assert(_vertIndexes->i3 < currentDisplayedScalarField->size());
-						*_rgbColors++ = *currentDisplayedScalarField->getValueColor(_vertIndexes->i1);
-						*_rgbColors++ = *currentDisplayedScalarField->getValueColor(_vertIndexes->i2);
-						*_rgbColors++ = *currentDisplayedScalarField->getValueColor(_vertIndexes->i3);
-						rgbColorCount += 3;
-					}
-				}
-				else if (glParams.showColors) // colors
-				{
-					const CCCoreLib::VerticesIndexes* _vertIndexes = _vertIndexesChunkOrigin;
-					ccColor::Rgba*                    _rgbaColors  = reinterpret_cast<ccColor::Rgba*>(rgbColors);
-					for (size_t n = 0; n < chunkSize; n += decimStep, _vertIndexes += decimStep)
-					{
-						assert(_vertIndexes->i1 < rgbaColorsTable->size());
-						assert(_vertIndexes->i2 < rgbaColorsTable->size());
-						assert(_vertIndexes->i3 < rgbaColorsTable->size());
-						*(_rgbaColors)++ = rgbaColorsTable->at(_vertIndexes->i1);
-						*(_rgbaColors)++ = rgbaColorsTable->at(_vertIndexes->i2);
-						*(_rgbaColors)++ = rgbaColorsTable->at(_vertIndexes->i3);
-						rgbColorCount += 3;
-					}
-				}
-
-				// normals
-				size_t normalCount = 0;
-				if (glParams.showNorms)
-				{
-					float* _normals = normals;
-					if (showTriNormals)
-					{
-						assert(m_triNormalIndexes);
-						const Tuple3i* _triNormalIndexes = ccChunk::Start(*m_triNormalIndexes, k);
-						for (size_t n = 0; n < chunkSize; n += decimStep, _triNormalIndexes += decimStep)
-						{
-							assert(_triNormalIndexes->u[0] < static_cast<int>(m_triNormals->size()));
-							assert(_triNormalIndexes->u[1] < static_cast<int>(m_triNormals->size()));
-							assert(_triNormalIndexes->u[2] < static_cast<int>(m_triNormals->size()));
-
-							*_normals++ = static_cast<float>(_triNormalIndexes->u[0] >= 0 ? m_triNormals->at(_triNormalIndexes->u[0]) : 0);
-							*_normals++ = static_cast<float>(_triNormalIndexes->u[1] >= 0 ? m_triNormals->at(_triNormalIndexes->u[1]) : 0);
-							*_normals++ = static_cast<float>(_triNormalIndexes->u[2] >= 0 ? m_triNormals->at(_triNormalIndexes->u[2]) : 0);
-
-							normalCount += 3;
-						}
-					}
-					else
-					{
-						const CCCoreLib::VerticesIndexes* _vertIndexes = _vertIndexesChunkOrigin;
-						for (size_t n = 0; n < chunkSize; n += decimStep, _vertIndexes += decimStep)
-						{
-							assert(_vertIndexes->i1 < normalsIndexesTable->size());
-							assert(_vertIndexes->i2 < normalsIndexesTable->size());
-							assert(_vertIndexes->i3 < normalsIndexesTable->size());
-							*_normals++ = static_cast<float>(normalsIndexesTable->at(_vertIndexes->i1));
-							*_normals++ = static_cast<float>(normalsIndexesTable->at(_vertIndexes->i2));
-							*_normals++ = static_cast<float>(normalsIndexesTable->at(_vertIndexes->i3));
-
-							normalCount += 3;
-						}
-					}
-				}
-
-				// Upload to VBOs and draw with shader
-				prog->bind();
-
-				// Normals
-				if (glParams.showNorms)
-				{
-					// If not done already, create the LUT texture and bind it to unit 0
-					assert(ccMaterial::GetTextureDB());
-					QSharedPointer<QOpenGLTexture> lutTex = ccMaterial::GetTextureDB()->getOpenGLTexture("CompressedNormalsLUT");
-					if (lutTex.isNull())
-					{
-						lutTex = CreateNormalLUTTexture(glFunc);
-						if (lutTex)
-						{
-							ccMaterial::GetTextureDB()->addOpenGLTexture("CompressedNormalsLUT", lutTex);
-						}
-						else
-						{
-							static bool errorAlreadyDisplayed = false;
-							if (!errorAlreadyDisplayed)
-							{
-								ccLog::Error("Failed to create normals LUT texture! Cannot render with normals.");
-								errorAlreadyDisplayed = true;
-							}
-						}
-					}
-
-					// bind texture to unit 0
-					if (!lutTex.isNull())
-					{
-						glFunc->glActiveTexture(GL_TEXTURE0);
-						glFunc->glBindTexture(GL_TEXTURE_2D, lutTex->textureId());
-					}
-
-					// set sampler uniform to unit 0
-					int locSampler = prog->uniformLocation("uNormalLUT");
-					if (locSampler >= 0)
-					{
-						glFunc->glUniform1i(locSampler, 0);
-					}
-					// set LUT dimensions
-					int locW = prog->uniformLocation("uLUTWidth");
-					if (locW >= 0)
-					{
-						glFunc->glUniform1i(locW, lutTex->width());
-					}
-					int locH = prog->uniformLocation("uLUTHeight");
-					if (locH >= 0)
-					{
-						glFunc->glUniform1i(locH, lutTex->height());
-					}
-
-					glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboNormals);
-					glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(normalCount * sizeof(float)), normals, GL_DYNAMIC_DRAW);
-					glFunc->glEnableVertexAttribArray(ATTR_NOR);
-					glFunc->glVertexAttribPointer(ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, reinterpret_cast<void*>(0));
-				}
-
-				// Vertex buffer
-				{
-					glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVertex);
-					glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(vertexCount * 3 * sizeof(PointCoordinateType)), vertices, GL_DYNAMIC_DRAW);
-					glFunc->glEnableVertexAttribArray(ATTR_POS);
-					glFunc->glVertexAttribPointer(ATTR_POS, 3, sizeof(PointCoordinateType) == 4 ? GL_FLOAT : GL_DOUBLE, GL_FALSE, 0, reinterpret_cast<void*>(0));
-				}
-
-				// Colors
-				if (glParams.showSF)
-				{
-					// colors are RGB unsigned bytes (3 components)
-					glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
-					glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCount * 3 * sizeof(unsigned char)), rgbColors, GL_DYNAMIC_DRAW);
-					glFunc->glEnableVertexAttribArray(ATTR_COL);
-					// we upload 3-component unsigned bytes; align to vec4 in shader by setting alpha = 1.0 via glVertexAttrib4f if needed
-					glFunc->glVertexAttribPointer(ATTR_COL, 3, GL_UNSIGNED_BYTE, GL_TRUE, 0, reinterpret_cast<void*>(0));
-					// ensure alpha = 1.0 for all vertices
-					// Note: can't set alpha per-vertex when only 3 components provided; shader expects vec4 but attribute with 3 components will get implicit 1.0 as 4th component
-				}
-				else if (glParams.showColors)
-				{
-					// colors are RGBA unsigned bytes
-					glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
-					glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCount * 4 * sizeof(unsigned char)), rgbColors, GL_DYNAMIC_DRAW);
-					glFunc->glEnableVertexAttribArray(ATTR_COL);
-					glFunc->glVertexAttribPointer(ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, reinterpret_cast<void*>(0));
-				}
-
-				// draw
-				if (!showWired)
-				{
-					glFunc->glDrawArrays(lodEnabled ? GL_POINTS : GL_TRIANGLES, 0, static_cast<GLint>(vertexCount));
 				}
 				else
 				{
-					glFunc->glDrawElements(GL_LINES, (static_cast<int>(chunkSize) / decimStep) * 6, GL_UNSIGNED_INT, GetWireVertexIndexes());
-				}
+					const CCCoreLib::VerticesIndexes* _vertIndexes = _vertIndexesChunkOrigin;
+					for (size_t n = 0; n < chunkSize; n += decimStep, _vertIndexes += decimStep)
+					{
+						assert(_vertIndexes->i1 < normalsIndexesTable->size());
+						assert(_vertIndexes->i2 < normalsIndexesTable->size());
+						assert(_vertIndexes->i3 < normalsIndexesTable->size());
+						*_normals++ = static_cast<float>(normalsIndexesTable->at(_vertIndexes->i1));
+						*_normals++ = static_cast<float>(normalsIndexesTable->at(_vertIndexes->i2));
+						*_normals++ = static_cast<float>(normalsIndexesTable->at(_vertIndexes->i3));
 
-				// cleanup per-chunk state
-				glFunc->glDisableVertexAttribArray(ATTR_POS);
-				if (glParams.showNorms)
-				{
-					glFunc->glDisableVertexAttribArray(ATTR_NOR);
-					glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+						normalCount += 3;
+					}
 				}
-				if (glParams.showSF || glParams.showColors)
-				{
-					glFunc->glDisableVertexAttribArray(ATTR_COL);
-				}
-
-				// unbind array buffer
-				glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);
-				prog->release();
-
-				ccGLDrawContext::CatchGLErrors(glFunc->glGetError(), "ccMesh::shader.program.end");
 			}
+
+			// Upload to VBOs and draw with shader
+			prog->bind();
+
+			// Normals
+			if (glParams.showNorms)
+			{
+				// If not done already, create the LUT texture and bind it to unit 0
+				assert(!lutTex.isNull());
+
+				// bind texture to unit 0
+				glFunc->glActiveTexture(GL_TEXTURE0);
+				glFunc->glBindTexture(GL_TEXTURE_2D, lutTex->textureId());
+
+				// set sampler uniform to unit 0
+				int locSampler = prog->uniformLocation("uNormalLUT");
+				if (locSampler >= 0)
+				{
+					glFunc->glUniform1i(locSampler, 0);
+				}
+				// set LUT dimensions
+				int locW = prog->uniformLocation("uLUTWidth");
+				if (locW >= 0)
+				{
+					glFunc->glUniform1i(locW, lutTex->width());
+				}
+				int locH = prog->uniformLocation("uLUTHeight");
+				if (locH >= 0)
+				{
+					glFunc->glUniform1i(locH, lutTex->height());
+				}
+
+				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboNormals);
+				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(normalCount * sizeof(float)), normals, GL_DYNAMIC_DRAW);
+				glFunc->glEnableVertexAttribArray(ATTR_NOR);
+				glFunc->glVertexAttribPointer(ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, reinterpret_cast<void*>(0));
+			}
+
+			// Vertex buffer
+			{
+				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVertex);
+				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(vertexCount * 3 * sizeof(PointCoordinateType)), vertices, GL_DYNAMIC_DRAW);
+				glFunc->glEnableVertexAttribArray(ATTR_POS);
+				glFunc->glVertexAttribPointer(ATTR_POS, 3, sizeof(PointCoordinateType) == 4 ? GL_FLOAT : GL_DOUBLE, GL_FALSE, 0, reinterpret_cast<void*>(0));
+			}
+
+			// Colors
+			if (glParams.showSF)
+			{
+				// colors are RGB unsigned bytes (3 components)
+				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
+				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCount * 3 * sizeof(unsigned char)), rgbColors, GL_DYNAMIC_DRAW);
+				glFunc->glEnableVertexAttribArray(ATTR_COL);
+				// we upload 3-component unsigned bytes; align to vec4 in shader by setting alpha = 1.0 via glVertexAttrib4f if needed
+				glFunc->glVertexAttribPointer(ATTR_COL, 3, GL_UNSIGNED_BYTE, GL_TRUE, 0, reinterpret_cast<void*>(0));
+				// ensure alpha = 1.0 for all vertices
+				// Note: can't set alpha per-vertex when only 3 components provided; shader expects vec4 but attribute with 3 components will get implicit 1.0 as 4th component
+			}
+			else if (glParams.showColors)
+			{
+				// colors are RGBA unsigned bytes
+				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
+				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCount * 4 * sizeof(unsigned char)), rgbColors, GL_DYNAMIC_DRAW);
+				glFunc->glEnableVertexAttribArray(ATTR_COL);
+				glFunc->glVertexAttribPointer(ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, reinterpret_cast<void*>(0));
+			}
+
+			// draw
+			if (!showWired)
+			{
+				glFunc->glDrawArrays(lodEnabled ? GL_POINTS : GL_TRIANGLES, 0, static_cast<GLint>(vertexCount));
+			}
+			else
+			{
+				glFunc->glDrawElements(GL_LINES, (static_cast<int>(chunkSize) / decimStep) * 6, GL_UNSIGNED_INT, GetWireVertexIndexes());
+			}
+
+			// cleanup per-chunk state
+			glFunc->glDisableVertexAttribArray(ATTR_POS);
+			if (glParams.showNorms)
+			{
+				glFunc->glDisableVertexAttribArray(ATTR_NOR);
+				glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+			}
+			if (glParams.showSF || glParams.showColors)
+			{
+				glFunc->glDisableVertexAttribArray(ATTR_COL);
+			}
+
+			// unbind array buffer
+			glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);
+			prog->release();
+
+			ccGLDrawContext::CatchGLErrors(glFunc->glGetError(), "ccMesh::shader.program.end");
 		}
 	}
 	else

--- a/libs/qCC_db/src/ccMesh.cpp
+++ b/libs/qCC_db/src/ccMesh.cpp
@@ -1671,10 +1671,208 @@ CCCoreLib::VerticesIndexes* ccMesh::getNextTriangleVertIndexes()
 	return nullptr;
 }
 
+// attribute indexes that we bound when creating the program
+static const GLuint ATTR_POS = 0;
+static const GLuint ATTR_NOR = 1;
+static const GLuint ATTR_COL = 2;
+
+// create a 2D texture containing all the normals (for OpenGL 2.1)
+static bool CreateNormalLUTTexture(QOpenGLFunctions_2_1* gl, GLuint& outTex, int& width, int& height)
+{
+	width = 0;
+	height = 0;
+	if (!gl)
+	{
+		return false;
+	}
+
+	const unsigned totalNormals = ccNormalCompressor::MAX_VALID_NORM_CODE + 1; // number of valid codes
+	// Query max texture size
+	GLint maxTexSize = 0;
+	gl->glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTexSize);
+	if (maxTexSize <= 0)
+	{
+		return false;
+	}
+
+	// choose width as large as possible (but <= maxTexSize) to minimize height
+	width  = std::min(static_cast<int>(totalNormals), maxTexSize);
+	height = static_cast<int>(std::ceil(static_cast<float>(totalNormals) / float(width)));
+
+	const size_t texels = static_cast<size_t>(width) * static_cast<size_t>(height);
+
+	// buffer RGB unsigned bytes
+	std::vector<unsigned char> pixels;
+	try
+	{
+		pixels.resize(texels * 3);
+	}
+	catch (const std::bad_alloc&)
+	{
+		ccLog::Warning("[ccMesh::CreateNormalLUTTexture] Not enough memory");
+		return false;
+	}
+
+	// fill: for each index, call ccNormalCompressor::Decompress
+	for (unsigned i = 0; i < totalNormals; ++i)
+	{
+		CCVector3 n = ccNormalVectors::GetNormal(i);
+
+		// map [-1,1] -> [0,255]
+		// handle NULL_NORM_CODE: Decompress sets to 0, so it becomes 127 -> you can change if needed
+		unsigned char r = static_cast<unsigned char>(std::round(std::clamp((n.x * 0.5 + 0.5), 0.0, 1.0) * 255.0));
+		unsigned char g = static_cast<unsigned char>(std::round(std::clamp((n.y * 0.5 + 0.5), 0.0, 1.0) * 255.0));
+		unsigned char b = static_cast<unsigned char>(std::round(std::clamp((n.z * 0.5 + 0.5), 0.0, 1.0) * 255.0));
+
+		size_t idx          = static_cast<size_t>(i);
+		pixels[idx * 3 + 0] = r;
+		pixels[idx * 3 + 1] = g;
+		pixels[idx * 3 + 2] = b;
+	}
+
+	// generate or update GL texture
+	if (outTex == 0)
+	{
+		gl->glGenTextures(1, &outTex);
+	}
+
+	gl->glBindTexture(GL_TEXTURE_2D, outTex);
+	gl->glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+	gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+	// upload as GL_RGB/GL_UNSIGNED_BYTE
+	gl->glTexImage2D(GL_TEXTURE_2D,
+	                 0,
+	                 GL_RGB,
+	                 width,
+	                 height,
+	                 0,
+	                 GL_RGB,
+	                 GL_UNSIGNED_BYTE,
+	                 pixels.data());
+
+	gl->glBindTexture(GL_TEXTURE_2D, 0);
+	return true;
+}
+
+// Simple program builder (GLSL 1.20) for mesh rendering (position, normal, color)
+static GLuint BuildSimpleMeshProgram(QOpenGLFunctions_2_1* glFunc)
+{
+	if (!glFunc)
+		return 0;
+
+	static GLuint s_program = 0;
+	if (s_program != 0)
+		return s_program;
+
+	const char* vertSrc =
+	    "#version 120\n"
+	    "attribute vec3 aPosition;\n"
+	    "attribute float aNormalIndex;\n"
+	    "attribute vec4 aColor;\n"
+	    "varying vec4 vColor;\n"
+	    "varying vec3 vNormal;\n"
+		"uniform sampler2D uNormalLUT;\n"
+		"uniform int uLUTWidth;\n"
+		"uniform int uLUTHeight;\n"
+		"vec3 fetchNormalFromLUT(float fi)\n"
+		"{\n"
+		"	float w  = float(uLUTWidth);\n"
+		"	float h  = float(uLUTHeight);\n"
+		"	float tx = mod(fi, w);\n"
+		"	float ty = floor(fi / w);\n"
+		"	vec2 uv = vec2((tx + 0.5) / w, (ty + 0.5) / h);\n"
+		"	vec3 enc = texture2D(uNormalLUT, uv).rgb;\n"
+		"	vec3 n = enc * 2.0 - 1.0;\n"
+		"	return normalize(n);\n"
+		"}\n"
+	    "void main()\n"
+	    "{\n"
+	    "    vColor = aColor;\n"
+	    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n"
+	    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
+	    "}\n";
+
+	const char* fragSrc =
+	    "#version 120\n"
+	    "varying vec4 vColor;\n"
+	    "varying vec3 vNormal;\n"
+	    "void main()\n"
+	    "{\n"
+	    "    vec3 n = normalize(vNormal);\n"
+	    "    vec3 lightDir = normalize(vec3(0.0,0.0,1.0));\n"
+	    "    float diff = max(dot(n, lightDir), 0.0);\n"
+	    "    vec4 base = vColor;\n"
+	    "    gl_FragColor = vec4(base.rgb * diff, base.a);\n"
+	    "}\n";
+
+	GLuint vert = glFunc->glCreateShader(GL_VERTEX_SHADER);
+	GLuint frag = glFunc->glCreateShader(GL_FRAGMENT_SHADER);
+
+	glFunc->glShaderSource(vert, 1, &vertSrc, nullptr);
+	glFunc->glCompileShader(vert);
+	GLint compiled = 0;
+	glFunc->glGetShaderiv(vert, GL_COMPILE_STATUS, &compiled);
+	if (!compiled)
+	{
+		// optionally retrieve log with glGetShaderInfoLog
+		GLchar buffer[1024];
+		glFunc->glGetShaderInfoLog(vert, 1024, nullptr, buffer);
+		ccLog::Warning(QString("[BuildSimpleMeshProgram] Vertex shader compilation failed:\n%1").arg(QString(buffer)));
+		glFunc->glDeleteShader(vert);
+		return 0;
+	}
+
+	glFunc->glShaderSource(frag, 1, &fragSrc, nullptr);
+	glFunc->glCompileShader(frag);
+	glFunc->glGetShaderiv(frag, GL_COMPILE_STATUS, &compiled);
+	if (!compiled)
+	{
+		glFunc->glDeleteShader(vert);
+		glFunc->glDeleteShader(frag);
+		return 0;
+	}
+
+	s_program = glFunc->glCreateProgram();
+	glFunc->glAttachShader(s_program, vert);
+	glFunc->glAttachShader(s_program, frag);
+
+	// Bind attribute locations before linking for stable locations
+	glFunc->glBindAttribLocation(s_program, ATTR_POS, "aPosition");
+	glFunc->glBindAttribLocation(s_program, ATTR_NOR, "aNormalIndex");
+	glFunc->glBindAttribLocation(s_program, ATTR_COL, "aColor");
+
+	glFunc->glLinkProgram(s_program);
+	GLint linked = 0;
+	glFunc->glGetProgramiv(s_program, GL_LINK_STATUS, &linked);
+	if (!linked)
+	{
+		// cleanup on failure
+		glFunc->glDeleteProgram(s_program);
+		s_program = 0;
+		glFunc->glDeleteShader(vert);
+		glFunc->glDeleteShader(frag);
+		return 0;
+	}
+
+	// shaders can be deleted after linking
+	glFunc->glDeleteShader(vert);
+	glFunc->glDeleteShader(frag);
+
+	return s_program;
+}
+
 void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 {
-	if (!m_associatedCloud)
+	if (!m_associatedCloud || !m_associatedCloud->isA(CC_TYPES::POINT_CLOUD))
+	{
 		return;
+	}
+
+	ccPointCloud* cloud = static_cast<ccPointCloud*>(m_associatedCloud);
 
 	handleColorRamp(context);
 
@@ -1706,8 +1904,8 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 		getDrawingParameters(glParams);
 
 		// vertices visibility
-		const ccGenericPointCloud::VisibilityTableType& verticesVisibility = m_associatedCloud->getTheVisibilityArray();
-		bool                                            visFiltering       = (verticesVisibility.size() >= m_associatedCloud->size());
+		const ccGenericPointCloud::VisibilityTableType& verticesVisibility = cloud->getTheVisibilityArray();
+		bool                                            visFiltering       = (verticesVisibility.size() >= cloud->size());
 
 		// wireframe ? (not compatible with LOD)
 		bool showWired = isShownAsWire() && !lodEnabled;
@@ -1715,7 +1913,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 		// per-triangle normals?
 		bool showTriNormals = (hasTriNormals() && triNormsShown());
 		// fix 'showNorms'
-		glParams.showNorms = showTriNormals || (m_associatedCloud->hasNormals() && m_normalsDisplayed);
+		glParams.showNorms = showTriNormals || (cloud->hasNormals() && m_normalsDisplayed);
 		// no normals shading without light!
 		bool entityPickingMode = MACRO_EntityPicking(context);
 		bool lightIsEnabled    = ((m_forceSunLightOn && !entityPickingMode) || MACRO_LightIsEnabled(context));
@@ -1757,8 +1955,6 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 		if (glParams.showSF)
 		{
-			assert(m_associatedCloud->isA(CC_TYPES::POINT_CLOUD));
-			ccPointCloud* cloud         = static_cast<ccPointCloud*>(m_associatedCloud);
 			currentDisplayedScalarField = cloud->getCurrentDisplayedScalarField();
 			sfMayHaveHiddenValues       = currentDisplayedScalarField ? currentDisplayedScalarField->mayHaveHiddenValues() : false;
 
@@ -1810,8 +2006,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 			}
 			else
 			{
-				assert(m_associatedCloud->isA(CC_TYPES::POINT_CLOUD));
-				rgbaColorsTable = static_cast<ccPointCloud*>(m_associatedCloud)->rgbaColors();
+				rgbaColorsTable = cloud->rgbaColors();
 			}
 		}
 		else if (entityPickingMode)
@@ -1840,8 +2035,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 		ccNormalVectors*       compressedNormals   = nullptr;
 		if (glParams.showNorms)
 		{
-			assert(m_associatedCloud->isA(CC_TYPES::POINT_CLOUD));
-			normalsIndexesTable = static_cast<ccPointCloud*>(m_associatedCloud)->normals();
+			normalsIndexesTable = cloud->normals();
 			compressedNormals   = ccNormalVectors::GetUniqueInstance();
 		}
 
@@ -1855,27 +2049,27 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 		if (!visFiltering && !(applyMaterials || showTextures) && (!glParams.showSF || !sfMayHaveHiddenValues))
 		{
 			assert(!entityPickingMode || !glParams.showSF);
+
 			// the GL type depends on the PointCoordinateType 'size' (float or double)
 			GLenum GL_COORD_TYPE = sizeof(PointCoordinateType) == 4 ? GL_FLOAT : GL_DOUBLE;
 
-			glFunc->glEnableClientState(GL_VERTEX_ARRAY);
-			glFunc->glVertexPointer(3, GL_COORD_TYPE, 0, GetVertexBuffer());
+			// get GL program
+			GLuint prog = BuildSimpleMeshProgram(glFunc);
 
-			if (glParams.showNorms)
-			{
-				glFunc->glEnableClientState(GL_NORMAL_ARRAY);
-				glFunc->glNormalPointer(GL_COORD_TYPE, 0, GetNormalsBuffer());
-			}
-			if (glParams.showSF)
-			{
-				glFunc->glEnableClientState(GL_COLOR_ARRAY);
-				glFunc->glColorPointer(3, GL_UNSIGNED_BYTE, 0, GetColorsBuffer());
-			}
-			else if (glParams.showColors)
-			{
-				glFunc->glEnableClientState(GL_COLOR_ARRAY);
-				glFunc->glColorPointer(4, GL_UNSIGNED_BYTE, 0, GetColorsBuffer());
-			}
+			// static VBO handles reused between calls
+			static GLuint s_vboV = 0;
+			static GLuint s_vboN = 0;
+			static GLuint s_vboC = 0;
+			if (s_vboV == 0)
+				glFunc->glGenBuffers(1, &s_vboV);
+			if (s_vboN == 0)
+				glFunc->glGenBuffers(1, &s_vboN);
+			if (s_vboC == 0)
+				glFunc->glGenBuffers(1, &s_vboC);
+
+			auto   vertices  = GetVertexBuffer();
+			float* normals   = reinterpret_cast<float*>(GetNormalsBuffer());
+			auto   rgbColors = GetColorsBuffer();
 
 			// we can scan and process each chunk separately in an optimized way
 			size_t chunkCount = ccChunk::Count(m_triVertIndexes->size());
@@ -1884,18 +2078,23 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 				const size_t                      chunkSize               = ccChunk::Size(k, m_triVertIndexes->size());
 				const CCCoreLib::VerticesIndexes* _vertIndexesChunkOrigin = ccChunk::Start(*m_triVertIndexes, k);
 
+				size_t vertexCount       = 0;
+				size_t normalCount       = 0;
+				size_t rgbColorCompCount = 0;
+
 				// vertices
 				{
 					const CCCoreLib::VerticesIndexes* _vertIndexes = _vertIndexesChunkOrigin;
-					CCVector3*                        _vertices    = GetVertexBuffer();
+					CCVector3*                        _vertices    = vertices;
 					for (size_t n = 0; n < chunkSize; n += decimStep, _vertIndexes += decimStep)
 					{
-						assert(_vertIndexes->i1 < m_associatedCloud->size());
-						assert(_vertIndexes->i2 < m_associatedCloud->size());
-						assert(_vertIndexes->i3 < m_associatedCloud->size());
-						*_vertices++ = *m_associatedCloud->getPoint(_vertIndexes->i1);
-						*_vertices++ = *m_associatedCloud->getPoint(_vertIndexes->i2);
-						*_vertices++ = *m_associatedCloud->getPoint(_vertIndexes->i3);
+						assert(_vertIndexes->i1 < cloud->size());
+						assert(_vertIndexes->i2 < cloud->size());
+						assert(_vertIndexes->i3 < cloud->size());
+						*_vertices++ = *cloud->getPoint(_vertIndexes->i1);
+						*_vertices++ = *cloud->getPoint(_vertIndexes->i2);
+						*_vertices++ = *cloud->getPoint(_vertIndexes->i3);
+						vertexCount += 3;
 					}
 				}
 
@@ -1903,7 +2102,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 				if (glParams.showSF)
 				{
 					const CCCoreLib::VerticesIndexes* _vertIndexes = _vertIndexesChunkOrigin;
-					ccColor::Rgb*                     _rgbColors   = reinterpret_cast<ccColor::Rgb*>(GetColorsBuffer());
+					ccColor::Rgb*                     _rgbColors   = reinterpret_cast<ccColor::Rgb*>(rgbColors);
 					assert(colorScale);
 
 					for (size_t n = 0; n < chunkSize; n += decimStep, _vertIndexes += decimStep)
@@ -1914,13 +2113,14 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 						*_rgbColors++ = *currentDisplayedScalarField->getValueColor(_vertIndexes->i1);
 						*_rgbColors++ = *currentDisplayedScalarField->getValueColor(_vertIndexes->i2);
 						*_rgbColors++ = *currentDisplayedScalarField->getValueColor(_vertIndexes->i3);
+						rgbColorCompCount += 9; // 3 components per vertex
 					}
 				}
 				// colors
 				else if (glParams.showColors)
 				{
 					const CCCoreLib::VerticesIndexes* _vertIndexes = _vertIndexesChunkOrigin;
-					ccColor::Rgba*                    _rgbaColors  = reinterpret_cast<ccColor::Rgba*>(GetColorsBuffer());
+					ccColor::Rgba*                    _rgbaColors  = reinterpret_cast<ccColor::Rgba*>(rgbColors);
 					for (size_t n = 0; n < chunkSize; n += decimStep, _vertIndexes += decimStep)
 					{
 						assert(_vertIndexes->i1 < rgbaColorsTable->size());
@@ -1929,13 +2129,14 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 						*(_rgbaColors)++ = rgbaColorsTable->at(_vertIndexes->i1);
 						*(_rgbaColors)++ = rgbaColorsTable->at(_vertIndexes->i2);
 						*(_rgbaColors)++ = rgbaColorsTable->at(_vertIndexes->i3);
+						rgbColorCompCount += 12; // 4 components per vertex
 					}
 				}
 
 				// normals
 				if (glParams.showNorms)
 				{
-					CCVector3* _normals = GetNormalsBuffer();
+					float* _normals = normals;
 					if (showTriNormals)
 					{
 						assert(m_triNormalIndexes);
@@ -1946,9 +2147,11 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 							assert(_triNormalIndexes->u[1] < static_cast<int>(m_triNormals->size()));
 							assert(_triNormalIndexes->u[2] < static_cast<int>(m_triNormals->size()));
 
-							*_normals++ = (_triNormalIndexes->u[0] >= 0 ? compressedNormals->getNormal(m_triNormals->at(_triNormalIndexes->u[0])) : s_blankNorm);
-							*_normals++ = (_triNormalIndexes->u[1] >= 0 ? compressedNormals->getNormal(m_triNormals->at(_triNormalIndexes->u[1])) : s_blankNorm);
-							*_normals++ = (_triNormalIndexes->u[2] >= 0 ? compressedNormals->getNormal(m_triNormals->at(_triNormalIndexes->u[2])) : s_blankNorm);
+							*_normals++ = static_cast<float>(_triNormalIndexes->u[0] >= 0 ? m_triNormals->at(_triNormalIndexes->u[0]) : 0);
+							*_normals++ = static_cast<float>(_triNormalIndexes->u[1] >= 0 ? m_triNormals->at(_triNormalIndexes->u[1]) : 0);
+							*_normals++ = static_cast<float>(_triNormalIndexes->u[2] >= 0 ? m_triNormals->at(_triNormalIndexes->u[2]) : 0);
+
+							normalCount += 3;
 						}
 					}
 					else
@@ -1959,29 +2162,122 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 							assert(_vertIndexes->i1 < normalsIndexesTable->size());
 							assert(_vertIndexes->i2 < normalsIndexesTable->size());
 							assert(_vertIndexes->i3 < normalsIndexesTable->size());
-							*_normals++ = compressedNormals->getNormal(normalsIndexesTable->at(_vertIndexes->i1));
-							*_normals++ = compressedNormals->getNormal(normalsIndexesTable->at(_vertIndexes->i2));
-							*_normals++ = compressedNormals->getNormal(normalsIndexesTable->at(_vertIndexes->i3));
+							*_normals++ = static_cast<float>(normalsIndexesTable->at(_vertIndexes->i1));
+							*_normals++ = static_cast<float>(normalsIndexesTable->at(_vertIndexes->i2));
+							*_normals++ = static_cast<float>(normalsIndexesTable->at(_vertIndexes->i3));
+
+							normalCount += 3;
 						}
 					}
 				}
 
+				// Upload to VBOs and draw with shader
+				// Bind program if available, else fallback to client arrays (safe fallback)
+				glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+				if (prog != 0)
+				{
+					glFunc->glUseProgram(prog);
+				}
+
+				static GLuint lutTex;
+				static int lutWidth = 0;
+				static int lutHeight = 0;
+				if (lutTex == 0)
+				{
+					CreateNormalLUTTexture(glFunc, lutTex, lutWidth, lutHeight);
+				}
+
+				// bind texture to unit 0
+				glFunc->glActiveTexture(GL_TEXTURE0);
+				glFunc->glBindTexture(GL_TEXTURE_2D, lutTex);
+
+				// set sampler uniform to unit 0
+				GLint locSampler = glFunc->glGetUniformLocation(prog, "uNormalLUT");
+				if (locSampler >= 0)
+					glFunc->glUniform1i(locSampler, 0);
+
+				// set LUT dimensions
+				GLint locW = glFunc->glGetUniformLocation(prog, "uLUTWidth");
+				if (locW >= 0)
+					glFunc->glUniform1i(locW, lutWidth);
+				GLint locH = glFunc->glGetUniformLocation(prog, "uLUTHeight");
+				if (locH >= 0)
+					glFunc->glUniform1i(locH, lutHeight);
+
+				// Vertex buffer
+				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboV);
+				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(vertexCount * 3 * sizeof(PointCoordinateType)), vertices, GL_DYNAMIC_DRAW);
+				glFunc->glEnableVertexAttribArray(ATTR_POS);
+				glFunc->glVertexAttribPointer(ATTR_POS, 3, GL_COORD_TYPE, GL_FALSE, 0, reinterpret_cast<void*>(0));
+
+				// Normals
+				if (glParams.showNorms)
+				{
+					glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboN);
+					glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(normalCount * sizeof(float)), normals, GL_DYNAMIC_DRAW);
+					glFunc->glEnableVertexAttribArray(ATTR_NOR);
+					glFunc->glVertexAttribPointer(ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, reinterpret_cast<void*>(0));
+				}
+				else
+				{
+					// set default normal to +Z
+					glFunc->glDisableVertexAttribArray(ATTR_NOR);
+					glFunc->glVertexAttrib3f(ATTR_NOR, 0.0f, 0.0f, 1.0f);
+				}
+
+				// Colors
+				if (glParams.showSF)
+				{
+					// colors are RGB unsigned bytes (3 components)
+					glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboC);
+					glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCompCount * sizeof(unsigned char)), rgbColors, GL_DYNAMIC_DRAW);
+					glFunc->glEnableVertexAttribArray(ATTR_COL);
+					// we upload 3-component unsigned bytes; align to vec4 in shader by setting alpha = 1.0 via glVertexAttrib4f if needed
+					glFunc->glVertexAttribPointer(ATTR_COL, 3, GL_UNSIGNED_BYTE, GL_TRUE, 0, reinterpret_cast<void*>(0));
+					// ensure alpha = 1.0 for all vertices
+					// Note: can't set alpha per-vertex when only 3 components provided; shader expects vec4 but attribute with 3 components will get implicit 1.0 as 4th component
+				}
+				else if (glParams.showColors)
+				{
+					// colors are RGBA unsigned bytes
+					glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboC);
+					glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCompCount * sizeof(unsigned char)), rgbColors, GL_DYNAMIC_DRAW);
+					glFunc->glEnableVertexAttribArray(ATTR_COL);
+					glFunc->glVertexAttribPointer(ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, reinterpret_cast<void*>(0));
+				}
+				else
+				{
+					// use default material diffuse front (converted to 0..1)
+					glFunc->glDisableVertexAttribArray(ATTR_COL);
+					const ccColor::Rgbaf& def = context.defaultMat->getDiffuseFront();
+					glFunc->glVertexAttrib4fv(ATTR_COL, def.rgba);
+				}
+
+				// draw
 				if (!showWired)
 				{
-					glFunc->glDrawArrays(lodEnabled ? GL_POINTS : GL_TRIANGLES, 0, (static_cast<int>(chunkSize) / decimStep) * 3);
+					glFunc->glDrawArrays(lodEnabled ? GL_POINTS : GL_TRIANGLES, 0, static_cast<GLint>(vertexCount));
 				}
 				else
 				{
 					glFunc->glDrawElements(GL_LINES, (static_cast<int>(chunkSize) / decimStep) * 6, GL_UNSIGNED_INT, GetWireVertexIndexes());
 				}
-			}
 
-			// disable arrays
-			glFunc->glDisableClientState(GL_VERTEX_ARRAY);
-			if (glParams.showNorms)
-				glFunc->glDisableClientState(GL_NORMAL_ARRAY);
-			if (glParams.showSF || glParams.showColors)
-				glFunc->glDisableClientState(GL_COLOR_ARRAY);
+				// cleanup per-chunk state
+				glFunc->glDisableVertexAttribArray(ATTR_POS);
+				if (glParams.showNorms)
+					glFunc->glDisableVertexAttribArray(ATTR_NOR);
+				if (glParams.showSF || glParams.showColors)
+					glFunc->glDisableVertexAttribArray(ATTR_COL);
+
+				// unbind array buffer
+				glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);
+				glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+				if (prog != 0)
+				{
+					glFunc->glUseProgram(0);
+				}
+			}
 		}
 		else
 		{
@@ -2162,7 +2458,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 					ccGL::Color(glFunc, *rgba1);
 				if (Tx1)
 					glFunc->glTexCoord2fv(Tx1->t);
-				ccGL::Vertex3v(glFunc, m_associatedCloud->getPoint(tsi.i1)->u);
+				ccGL::Vertex3v(glFunc, cloud->getPoint(tsi.i1)->u);
 
 				// vertex 2
 				if (N2)
@@ -2173,7 +2469,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 					ccGL::Color(glFunc, *rgba2);
 				if (Tx2)
 					glFunc->glTexCoord2fv(Tx2->t);
-				ccGL::Vertex3v(glFunc, m_associatedCloud->getPoint(tsi.i2)->u);
+				ccGL::Vertex3v(glFunc, cloud->getPoint(tsi.i2)->u);
 
 				// vertex 3
 				if (N3)
@@ -2184,7 +2480,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 					ccGL::Color(glFunc, *rgba3);
 				if (Tx3)
 					glFunc->glTexCoord2fv(Tx3->t);
-				ccGL::Vertex3v(glFunc, m_associatedCloud->getPoint(tsi.i3)->u);
+				ccGL::Vertex3v(glFunc, cloud->getPoint(tsi.i3)->u);
 			}
 
 			glFunc->glEnd();

--- a/libs/qCC_db/src/ccMesh.cpp
+++ b/libs/qCC_db/src/ccMesh.cpp
@@ -26,6 +26,7 @@
 #include "ccGenericGLDisplay.h"
 #include "ccGenericPointCloud.h"
 #include "ccHObjectCaster.h"
+#include "ccMaterialDB.h"
 #include "ccMaterialSet.h"
 #include "ccNormalVectors.h"
 #include "ccPointCloud.h"
@@ -45,6 +46,10 @@
 #include <assert.h>
 #include <cmath> //for std::modf
 #include <string.h>
+
+// Qt
+#include <QOpenGLShader>
+#include <QOpenGLVersionFunctionsFactory>
 
 static CCVector3 s_blankNorm(0, 0, 0);
 
@@ -1671,19 +1676,58 @@ CCCoreLib::VerticesIndexes* ccMesh::getNextTriangleVertIndexes()
 	return nullptr;
 }
 
-// attribute indexes that we bound when creating the program
+// Global OpenGL resources
+static QMap<int, QSharedPointer<QOpenGLShaderProgram>> s_programs;
+static GLuint                                          s_vboVertex  = 0;
+static GLuint                                          s_vboNormals = 0;
+static GLuint                                          s_vboColor   = 0;
+
+// Attribute indexes that we bound when creating the programs
 static const GLuint ATTR_POS = 0;
 static const GLuint ATTR_NOR = 1;
 static const GLuint ATTR_COL = 2;
 
-// create a 2D texture containing all the normals (for OpenGL 2.1)
-static bool CreateNormalLUTTexture(QOpenGLFunctions_2_1* gl, GLuint& outTex, int& width, int& height)
+void ccMesh::ReleaseOpenGLRessources()
 {
-	width = 0;
-	height = 0;
+	if (!QOpenGLContext::currentContext())
+	{
+		ccLog::Warning("[ccMesh::ReleaseOpenGLRessources] No valid OpenGL context");
+		return;
+	}
+
+	// get the set of OpenGL functions (version 2.1)
+	QOpenGLFunctions_2_1* glFunc = QOpenGLVersionFunctionsFactory::get<QOpenGLFunctions_2_1>(QOpenGLContext::currentContext());
+	if (glFunc)
+	{
+		s_programs.clear();
+
+		if (s_vboVertex != 0)
+		{
+			glFunc->glDeleteBuffers(1, &s_vboVertex);
+			s_vboVertex = 0;
+		}
+
+		if (s_vboNormals != 0)
+		{
+			glFunc->glDeleteBuffers(1, &s_vboNormals);
+			s_vboNormals = 0;
+		}
+
+		if (s_vboColor != 0)
+		{
+			glFunc->glDeleteBuffers(1, &s_vboColor);
+			s_vboColor = 0;
+		}
+	}
+}
+
+// create a 2D texture containing all the normals (for OpenGL 2.1)
+static QSharedPointer<QOpenGLTexture> CreateNormalLUTTexture(QOpenGLFunctions_2_1* gl)
+{
 	if (!gl)
 	{
-		return false;
+		assert(false);
+		return nullptr;
 	}
 
 	const unsigned totalNormals = ccNormalCompressor::MAX_VALID_NORM_CODE + 1; // number of valid codes
@@ -1692,12 +1736,12 @@ static bool CreateNormalLUTTexture(QOpenGLFunctions_2_1* gl, GLuint& outTex, int
 	gl->glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTexSize);
 	if (maxTexSize <= 0)
 	{
-		return false;
+		return nullptr;
 	}
 
 	// choose width as large as possible (but <= maxTexSize) to minimize height
-	width  = std::min(static_cast<int>(totalNormals), maxTexSize);
-	height = static_cast<int>(std::ceil(static_cast<float>(totalNormals) / float(width)));
+	int width  = std::min(static_cast<int>(totalNormals), maxTexSize);
+	int height = static_cast<int>(std::ceil(static_cast<float>(totalNormals) / float(width)));
 
 	const size_t texels = static_cast<size_t>(width) * static_cast<size_t>(height);
 
@@ -1710,7 +1754,7 @@ static bool CreateNormalLUTTexture(QOpenGLFunctions_2_1* gl, GLuint& outTex, int
 	catch (const std::bad_alloc&)
 	{
 		ccLog::Warning("[ccMesh::CreateNormalLUTTexture] Not enough memory");
-		return false;
+		return nullptr;
 	}
 
 	// fill: for each index, call ccNormalCompressor::Decompress
@@ -1720,83 +1764,54 @@ static bool CreateNormalLUTTexture(QOpenGLFunctions_2_1* gl, GLuint& outTex, int
 
 		// map [-1,1] -> [0,255]
 		// handle NULL_NORM_CODE: Decompress sets to 0, so it becomes 127 -> you can change if needed
-		unsigned char r = static_cast<unsigned char>(std::round(std::clamp((n.x * 0.5 + 0.5), 0.0, 1.0) * 255.0));
-		unsigned char g = static_cast<unsigned char>(std::round(std::clamp((n.y * 0.5 + 0.5), 0.0, 1.0) * 255.0));
-		unsigned char b = static_cast<unsigned char>(std::round(std::clamp((n.z * 0.5 + 0.5), 0.0, 1.0) * 255.0));
-
-		size_t idx          = static_cast<size_t>(i);
-		pixels[idx * 3 + 0] = r;
-		pixels[idx * 3 + 1] = g;
-		pixels[idx * 3 + 2] = b;
+		pixels[i * 3 + 0] = static_cast<unsigned char>(std::round(std::clamp((n.x * 0.5 + 0.5), 0.0, 1.0) * 255.0));
+		pixels[i * 3 + 1] = static_cast<unsigned char>(std::round(std::clamp((n.y * 0.5 + 0.5), 0.0, 1.0) * 255.0));
+		pixels[i * 3 + 2] = static_cast<unsigned char>(std::round(std::clamp((n.z * 0.5 + 0.5), 0.0, 1.0) * 255.0));
 	}
 
-	// generate or update GL texture
-	if (outTex == 0)
-	{
-		gl->glGenTextures(1, &outTex);
-	}
+	// generate GL texture
+	QSharedPointer<QOpenGLTexture> tex(new QOpenGLTexture(QOpenGLTexture::Target2D));
 
-	gl->glBindTexture(GL_TEXTURE_2D, outTex);
-	gl->glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-	gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	gl->glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	// configure texture
+	tex->setFormat(QOpenGLTexture::RGB8_UNorm);
+	tex->setSize(width, height);
+	tex->allocateStorage();
+	tex->setWrapMode(QOpenGLTexture::ClampToEdge);
+	tex->setMinificationFilter(QOpenGLTexture::Nearest);
+	tex->setMagnificationFilter(QOpenGLTexture::Nearest);
 
-	// upload as GL_RGB/GL_UNSIGNED_BYTE
-	gl->glTexImage2D(GL_TEXTURE_2D,
-	                 0,
-	                 GL_RGB,
-	                 width,
-	                 height,
-	                 0,
-	                 GL_RGB,
-	                 GL_UNSIGNED_BYTE,
-	                 pixels.data());
+	// upload data
+	tex->setData(QOpenGLTexture::RGB, QOpenGLTexture::UInt8, pixels.data());
 
-	gl->glBindTexture(GL_TEXTURE_2D, 0);
-	return true;
+	return tex;
 }
 
 // Simple program builder (GLSL 1.20) for mesh rendering (position, normal, color)
-static GLuint BuildSimpleMeshProgram(QOpenGLFunctions_2_1* glFunc)
+static QSharedPointer<QOpenGLShaderProgram> BuildSimpleMeshProgram(QOpenGLFunctions_2_1* glFunc, int attributes)
 {
 	if (!glFunc)
-		return 0;
+	{
+		assert(false);
+		return nullptr;
+	}
 
-	static GLuint s_program = 0;
-	if (s_program != 0)
-		return s_program;
+	if (s_programs.contains(attributes))
+	{
+		return s_programs[attributes];
+	}
 
-	const char* vertSrc =
+	QString vertexProgSrc;
+	QString fragmentProgSrc;
+
+	static const char* ColorOnlyFragmentProgSrc =
 	    "#version 120\n"
-	    "attribute vec3 aPosition;\n"
-	    "attribute float aNormalIndex;\n"
-	    "attribute vec4 aColor;\n"
 	    "varying vec4 vColor;\n"
-	    "varying vec3 vNormal;\n"
-		"uniform sampler2D uNormalLUT;\n"
-		"uniform int uLUTWidth;\n"
-		"uniform int uLUTHeight;\n"
-		"vec3 fetchNormalFromLUT(float fi)\n"
-		"{\n"
-		"	float w  = float(uLUTWidth);\n"
-		"	float h  = float(uLUTHeight);\n"
-		"	float tx = mod(fi, w);\n"
-		"	float ty = floor(fi / w);\n"
-		"	vec2 uv = vec2((tx + 0.5) / w, (ty + 0.5) / h);\n"
-		"	vec3 enc = texture2D(uNormalLUT, uv).rgb;\n"
-		"	vec3 n = enc * 2.0 - 1.0;\n"
-		"	return normalize(n);\n"
-		"}\n"
 	    "void main()\n"
 	    "{\n"
-	    "    vColor = aColor;\n"
-	    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n"
-	    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
+	    "    gl_FragColor = vColor;\n"
 	    "}\n";
 
-	const char* fragSrc =
+	static const char* ColorAndNormalFragmentProgSrc =
 	    "#version 120\n"
 	    "varying vec4 vColor;\n"
 	    "varying vec3 vNormal;\n"
@@ -1809,64 +1824,153 @@ static GLuint BuildSimpleMeshProgram(QOpenGLFunctions_2_1* glFunc)
 	    "    gl_FragColor = vec4(base.rgb * diff, base.a);\n"
 	    "}\n";
 
-	GLuint vert = glFunc->glCreateShader(GL_VERTEX_SHADER);
-	GLuint frag = glFunc->glCreateShader(GL_FRAGMENT_SHADER);
-
-	glFunc->glShaderSource(vert, 1, &vertSrc, nullptr);
-	glFunc->glCompileShader(vert);
-	GLint compiled = 0;
-	glFunc->glGetShaderiv(vert, GL_COMPILE_STATUS, &compiled);
-	if (!compiled)
+	switch (attributes)
 	{
-		// optionally retrieve log with glGetShaderInfoLog
-		GLchar buffer[1024];
-		glFunc->glGetShaderInfoLog(vert, 1024, nullptr, buffer);
-		ccLog::Warning(QString("[BuildSimpleMeshProgram] Vertex shader compilation failed:\n%1").arg(QString(buffer)));
-		glFunc->glDeleteShader(vert);
-		return 0;
+	case ATTR_POS:
+		vertexProgSrc =
+		    "#version 120\n"
+		    "attribute vec3 aPosition;\n"
+		    "varying vec4 vColor;\n"
+		    "void main()\n"
+		    "{\n"
+		    "    vColor = gl_Color;\n"
+		    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
+		    "}\n";
+
+		fragmentProgSrc = ColorOnlyFragmentProgSrc;
+
+		break;
+
+	case ATTR_COL:
+		vertexProgSrc =
+		    "#version 120\n"
+		    "attribute vec3 aPosition;\n"
+		    "attribute vec4 aColor;\n"
+		    "varying vec4 vColor;\n"
+		    "void main()\n"
+		    "{\n"
+		    "    vColor = aColor;\n"
+		    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
+		    "}\n";
+
+		fragmentProgSrc = ColorOnlyFragmentProgSrc;
+		break;
+
+	case ATTR_NOR:
+		vertexProgSrc =
+		    "#version 120\n"
+		    "attribute vec3 aPosition;\n"
+		    "attribute float aNormalIndex;\n"
+		    "varying vec4 vColor;\n"
+		    "varying vec3 vNormal;\n"
+		    "uniform sampler2D uNormalLUT;\n"
+		    "uniform int uLUTWidth;\n"
+		    "uniform int uLUTHeight;\n"
+		    "vec3 fetchNormalFromLUT(float fi)\n"
+		    "{\n"
+		    "	float w  = float(uLUTWidth);\n"
+		    "	float h  = float(uLUTHeight);\n"
+		    "	float tx = mod(fi, w);\n"
+		    "	float ty = floor(fi / w);\n"
+		    "	vec2 uv = vec2((tx + 0.5) / w, (ty + 0.5) / h);\n"
+		    "	vec3 enc = texture2D(uNormalLUT, uv).rgb;\n"
+		    "	vec3 n = enc * 2.0 - 1.0;\n"
+		    "	return normalize(n);\n"
+		    "}\n"
+		    "void main()\n"
+		    "{\n"
+		    "    vColor = gl_Color;\n"
+		    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n"
+		    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
+		    "}\n";
+
+		fragmentProgSrc = ColorAndNormalFragmentProgSrc;
+		break;
+
+	case (ATTR_COL | ATTR_NOR):
+		vertexProgSrc =
+		    "#version 120\n"
+		    "attribute vec3 aPosition;\n"
+		    "attribute float aNormalIndex;\n"
+		    "attribute vec4 aColor;\n"
+		    "varying vec4 vColor;\n"
+		    "varying vec3 vNormal;\n"
+		    "uniform sampler2D uNormalLUT;\n"
+		    "uniform int uLUTWidth;\n"
+		    "uniform int uLUTHeight;\n"
+		    "vec3 fetchNormalFromLUT(float fi)\n"
+		    "{\n"
+		    "	float w  = float(uLUTWidth);\n"
+		    "	float h  = float(uLUTHeight);\n"
+		    "	float tx = mod(fi, w);\n"
+		    "	float ty = floor(fi / w);\n"
+		    "	vec2 uv = vec2((tx + 0.5) / w, (ty + 0.5) / h);\n"
+		    "	vec3 enc = texture2D(uNormalLUT, uv).rgb;\n"
+		    "	vec3 n = enc * 2.0 - 1.0;\n"
+		    "	return normalize(n);\n"
+		    "}\n"
+		    "void main()\n"
+		    "{\n"
+		    "    vColor = aColor;\n"
+		    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n"
+		    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
+		    "}\n";
+
+		fragmentProgSrc = ColorAndNormalFragmentProgSrc;
+		break;
+
+	default:
+		assert(false);
+		ccLog::Warning("[BuildSimpleMeshProgram] Unsupported feature combination!");
+		return nullptr;
 	}
 
-	glFunc->glShaderSource(frag, 1, &fragSrc, nullptr);
-	glFunc->glCompileShader(frag);
-	glFunc->glGetShaderiv(frag, GL_COMPILE_STATUS, &compiled);
-	if (!compiled)
+	QOpenGLShader vertexShader(QOpenGLShader::Vertex);
+	if (false == vertexShader.compileSourceCode(vertexProgSrc))
 	{
-		glFunc->glDeleteShader(vert);
-		glFunc->glDeleteShader(frag);
-		return 0;
+		ccLog::Warning(QString("[BuildSimpleMeshProgram] Vertex shader compilation failed: ") + vertexShader.log());
+		return nullptr;
+	}
+	QOpenGLShader fragmentShader(QOpenGLShader::Fragment);
+	if (false == fragmentShader.compileSourceCode(fragmentProgSrc))
+	{
+		ccLog::Warning(QString("[BuildSimpleMeshProgram] Fragment shader compilation failed: ") + fragmentShader.log());
+		return nullptr;
+	}
+	QSharedPointer<QOpenGLShaderProgram> program(new QOpenGLShaderProgram);
+	program->addShader(&vertexShader);
+	program->addShader(&fragmentShader);
+
+	// bind attribute locations before linking for stable locations
+	program->bindAttributeLocation("aPosition", ATTR_POS);
+	if (attributes & ATTR_COL)
+	{
+		program->bindAttributeLocation("aColor", ATTR_COL);
+	}
+	if (attributes & ATTR_NOR)
+	{
+		program->bindAttributeLocation("aNormalIndex", ATTR_NOR);
 	}
 
-	s_program = glFunc->glCreateProgram();
-	glFunc->glAttachShader(s_program, vert);
-	glFunc->glAttachShader(s_program, frag);
-
-	// Bind attribute locations before linking for stable locations
-	glFunc->glBindAttribLocation(s_program, ATTR_POS, "aPosition");
-	glFunc->glBindAttribLocation(s_program, ATTR_NOR, "aNormalIndex");
-	glFunc->glBindAttribLocation(s_program, ATTR_COL, "aColor");
-
-	glFunc->glLinkProgram(s_program);
-	GLint linked = 0;
-	glFunc->glGetProgramiv(s_program, GL_LINK_STATUS, &linked);
-	if (!linked)
+	if (false == program->link())
 	{
-		// cleanup on failure
-		glFunc->glDeleteProgram(s_program);
-		s_program = 0;
-		glFunc->glDeleteShader(vert);
-		glFunc->glDeleteShader(frag);
-		return 0;
+		ccLog::Warning(QString("[BuildSimpleMeshProgram] Shader program linking failed: ") + program->log());
+		return nullptr;
 	}
 
-	// shaders can be deleted after linking
-	glFunc->glDeleteShader(vert);
-	glFunc->glDeleteShader(frag);
+	s_programs[attributes] = program;
 
-	return s_program;
+	return program;
 }
 
 void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 {
+	// 3D pass only
+	if (!MACRO_Draw3D(context))
+	{
+		return;
+	}
+
 	if (!m_associatedCloud || !m_associatedCloud->isA(CC_TYPES::POINT_CLOUD))
 	{
 		return;
@@ -1878,194 +1982,203 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 	// get the set of OpenGL functions (version 2.1)
 	QOpenGLFunctions_2_1* glFunc = context.glFunctions<QOpenGLFunctions_2_1>();
-	assert(glFunc != nullptr);
-
 	if (glFunc == nullptr)
+	{
+		assert(false);
+		return;
+	}
+
+	// any triangle?
+	size_t triNum = m_triVertIndexes->size();
+	if (triNum == 0)
 	{
 		return;
 	}
 
-	// 3D pass
-	if (MACRO_Draw3D(context))
+	// L.O.D.
+	bool     lodEnabled = (triNum > context.minLODTriangleCount && context.decimateMeshOnMove && MACRO_LODActivated(context));
+	unsigned decimStep  = (lodEnabled ? static_cast<unsigned>(ceil(static_cast<double>(triNum * 3) / context.minLODTriangleCount)) : 1);
+
+	// display parameters
+	glDrawParams glParams;
+	getDrawingParameters(glParams);
+
+	// vertices visibility
+	const ccGenericPointCloud::VisibilityTableType& verticesVisibility = cloud->getTheVisibilityArray();
+	bool                                            visFiltering       = (verticesVisibility.size() >= cloud->size());
+
+	// wireframe ? (not compatible with LOD)
+	bool showWired = isShownAsWire() && !lodEnabled;
+
+	// per-triangle normals?
+	bool showTriNormals = (hasTriNormals() && triNormsShown());
+	// fix 'showNorms'
+	glParams.showNorms = showTriNormals || (cloud->hasNormals() && m_normalsDisplayed);
+	// no normals shading without light!
+	bool entityPickingMode = MACRO_EntityPicking(context);
+	bool lightIsEnabled    = ((m_forceSunLightOn && !entityPickingMode) || MACRO_LightIsEnabled(context));
+	if (!lightIsEnabled)
 	{
-		// any triangle?
-		size_t triNum = m_triVertIndexes->size();
-		if (triNum == 0)
+		glParams.showNorms = false;
+	}
+
+	// materials & textures
+	bool applyMaterials = (hasMaterials() && materialsShown());
+	bool showTextures   = (hasTextures() && materialsShown() && !lodEnabled);
+
+	// color-based entity picking
+	ccColor::Rgb pickingColor;
+	if (entityPickingMode)
+	{
+		// not fast at all!
+		if (MACRO_FastEntityPicking(context))
 		{
 			return;
 		}
 
-		// L.O.D.
-		bool     lodEnabled = (triNum > context.minLODTriangleCount && context.decimateMeshOnMove && MACRO_LODActivated(context));
-		unsigned decimStep  = (lodEnabled ? static_cast<unsigned>(ceil(static_cast<double>(triNum * 3) / context.minLODTriangleCount)) : 1);
+		pickingColor = context.entityPicking.registerEntity(this);
 
-		// display parameters
-		glDrawParams glParams;
-		getDrawingParameters(glParams);
+		// minimal display for picking mode!
+		glParams.showNorms  = false;
+		glParams.showColors = false;
+		// glParams.showSF --> we keep it only if SF 'NaN' values are hidden
+		showTriNormals = false;
+		applyMaterials = false;
+		showTextures   = false;
+	}
 
-		// vertices visibility
-		const ccGenericPointCloud::VisibilityTableType& verticesVisibility = cloud->getTheVisibilityArray();
-		bool                                            visFiltering       = (verticesVisibility.size() >= cloud->size());
+	// in the case we need to display scalar field colors
+	ccScalarField* currentDisplayedScalarField = nullptr;
+	bool           sfMayHaveHiddenValues       = false;
+	// unsigned colorRampSteps = 0;
+	ccColorScale::Shared colorScale(nullptr);
 
-		// wireframe ? (not compatible with LOD)
-		bool showWired = isShownAsWire() && !lodEnabled;
+	if (glParams.showSF)
+	{
+		currentDisplayedScalarField = cloud->getCurrentDisplayedScalarField();
+		sfMayHaveHiddenValues       = currentDisplayedScalarField ? currentDisplayedScalarField->mayHaveHiddenValues() : false;
 
-		// per-triangle normals?
-		bool showTriNormals = (hasTriNormals() && triNormsShown());
-		// fix 'showNorms'
-		glParams.showNorms = showTriNormals || (cloud->hasNormals() && m_normalsDisplayed);
-		// no normals shading without light!
-		bool entityPickingMode = MACRO_EntityPicking(context);
-		bool lightIsEnabled    = ((m_forceSunLightOn && !entityPickingMode) || MACRO_LightIsEnabled(context));
-		if (!lightIsEnabled)
+		if (!currentDisplayedScalarField
+		    || (entityPickingMode && !sfMayHaveHiddenValues)) // in picking mode, no need to take SF into account if we don't hide any points!
 		{
-			glParams.showNorms = false;
-		}
-
-		// materials & textures
-		bool applyMaterials = (hasMaterials() && materialsShown());
-		bool showTextures   = (hasTextures() && materialsShown() && !lodEnabled);
-
-		// color-based entity picking
-		ccColor::Rgb pickingColor;
-		if (entityPickingMode)
-		{
-			// not fast at all!
-			if (MACRO_FastEntityPicking(context))
-			{
-				return;
-			}
-
-			pickingColor = context.entityPicking.registerEntity(this);
-
-			// minimal display for picking mode!
-			glParams.showNorms  = false;
-			glParams.showColors = false;
-			// glParams.showSF --> we keep it only if SF 'NaN' values are hidden
-			showTriNormals = false;
-			applyMaterials = false;
-			showTextures   = false;
-		}
-
-		// in the case we need to display scalar field colors
-		ccScalarField* currentDisplayedScalarField = nullptr;
-		bool           sfMayHaveHiddenValues       = false;
-		// unsigned colorRampSteps = 0;
-		ccColorScale::Shared colorScale(nullptr);
-
-		if (glParams.showSF)
-		{
-			currentDisplayedScalarField = cloud->getCurrentDisplayedScalarField();
-			sfMayHaveHiddenValues       = currentDisplayedScalarField ? currentDisplayedScalarField->mayHaveHiddenValues() : false;
-
-			if (!currentDisplayedScalarField
-			    || (entityPickingMode && !sfMayHaveHiddenValues)) // in picking mode, no need to take SF into account if we don't hide any points!
-			{
-				currentDisplayedScalarField = nullptr;
-				glParams.showSF             = false;
-			}
-			else
-			{
-				colorScale = currentDisplayedScalarField->getColorScale();
-				// colorRampSteps = currentDisplayedScalarField->getColorRampSteps();
-
-				// get default color ramp if cloud has no scale associated?!
-				if (!colorScale)
-				{
-					assert(false);
-					colorScale = ccColorScalesManager::GetUniqueInstance()->getDefaultScale(ccColorScalesManager::BGYR);
-				}
-			}
-		}
-
-		glFunc->glPushAttrib(GL_LIGHTING_BIT | GL_TRANSFORM_BIT | GL_ENABLE_BIT);
-
-		if (lightIsEnabled)
-		{
-			glFunc->glEnable(GL_LIGHT0);
-		}
-
-		// materials or color?
-		bool colorMaterial = false;
-		if (glParams.showSF || glParams.showColors)
-		{
-			applyMaterials = false;
-			colorMaterial  = true;
-			glFunc->glColorMaterial(GL_FRONT_AND_BACK, GL_DIFFUSE);
-			glFunc->glEnable(GL_COLOR_MATERIAL);
-		}
-
-		// in the case we need to display vertex colors
-		RGBAColorsTableType* rgbaColorsTable = nullptr;
-		if (glParams.showColors)
-		{
-			if (isColorOverridden())
-			{
-				ccGL::Color(glFunc, m_tempColor);
-				glParams.showColors = false;
-			}
-			else
-			{
-				rgbaColorsTable = cloud->rgbaColors();
-			}
-		}
-		else if (entityPickingMode)
-		{
-			ccGL::Color(glFunc, pickingColor);
+			currentDisplayedScalarField = nullptr;
+			glParams.showSF             = false;
 		}
 		else
 		{
-			ccGL::Color(glFunc, context.defaultMat->getDiffuseFront());
-		}
+			colorScale = currentDisplayedScalarField->getColorScale();
+			// colorRampSteps = currentDisplayedScalarField->getColorRampSteps();
 
+			// get default color ramp if cloud has no scale associated?!
+			if (!colorScale)
+			{
+				assert(false);
+				colorScale = ccColorScalesManager::GetUniqueInstance()->getDefaultScale(ccColorScalesManager::BGYR);
+			}
+		}
+	}
+
+	glFunc->glPushAttrib(GL_LIGHTING_BIT | GL_TRANSFORM_BIT | GL_ENABLE_BIT);
+
+	if (lightIsEnabled)
+	{
+		glFunc->glEnable(GL_LIGHT0);
+	}
+
+	// materials or color?
+	bool colorMaterial = false;
+	if (glParams.showSF || glParams.showColors)
+	{
+		applyMaterials = false;
+		colorMaterial  = true;
+		glFunc->glColorMaterial(GL_FRONT_AND_BACK, GL_DIFFUSE);
+		glFunc->glEnable(GL_COLOR_MATERIAL);
+	}
+
+	// in the case we need to display vertex colors
+	RGBAColorsTableType* rgbaColorsTable = nullptr;
+	if (glParams.showColors)
+	{
+		if (isColorOverridden())
+		{
+			ccGL::Color(glFunc, m_tempColor);
+			glParams.showColors = false;
+		}
+		else
+		{
+			rgbaColorsTable = cloud->rgbaColors();
+		}
+	}
+	else if (entityPickingMode)
+	{
+		ccGL::Color(glFunc, pickingColor);
+	}
+	else
+	{
+		ccGL::Color(glFunc, context.defaultMat->getDiffuseFront());
+	}
+
+	if (glParams.showNorms)
+	{
+		glFunc->glEnable(GL_RESCALE_NORMAL);
+		glFunc->glEnable(GL_LIGHTING);
+		context.defaultMat->applyGL(context.qGLContext, true, colorMaterial);
+	}
+
+	if (!entityPickingMode)
+	{
+		glFunc->glEnable(GL_BLEND);
+	}
+
+	// in the case we need normals (i.e. lighting)
+	NormsIndexesTableType* normalsIndexesTable = nullptr;
+	ccNormalVectors*       compressedNormals   = nullptr;
+	if (glParams.showNorms)
+	{
+		normalsIndexesTable = cloud->normals();
+		compressedNormals   = ccNormalVectors::GetUniqueInstance();
+	}
+
+	// stipple mask
+	bool stippling = (m_stippling && !entityPickingMode);
+	if (stippling)
+	{
+		EnableGLStippleMask(context.qGLContext, true);
+	}
+
+	if (!visFiltering && !(applyMaterials || showTextures) && (!glParams.showSF || !sfMayHaveHiddenValues))
+	{
+		assert(!entityPickingMode || !glParams.showSF);
+
+		// get GL program
+		int attributes = ATTR_POS;
 		if (glParams.showNorms)
 		{
-			glFunc->glEnable(GL_RESCALE_NORMAL);
-			glFunc->glEnable(GL_LIGHTING);
-			context.defaultMat->applyGL(context.qGLContext, true, colorMaterial);
+			attributes |= ATTR_NOR;
+		}
+		if (glParams.showColors || glParams.showSF)
+		{
+			attributes |= ATTR_COL;
 		}
 
-		if (!entityPickingMode)
+		QSharedPointer<QOpenGLShaderProgram> prog = BuildSimpleMeshProgram(glFunc, attributes);
+		if (prog)
 		{
-			glFunc->glEnable(GL_BLEND);
-		}
-
-		// in the case we need normals (i.e. lighting)
-		NormsIndexesTableType* normalsIndexesTable = nullptr;
-		ccNormalVectors*       compressedNormals   = nullptr;
-		if (glParams.showNorms)
-		{
-			normalsIndexesTable = cloud->normals();
-			compressedNormals   = ccNormalVectors::GetUniqueInstance();
-		}
-
-		// stipple mask
-		bool stippling = (m_stippling && !entityPickingMode);
-		if (stippling)
-		{
-			EnableGLStippleMask(context.qGLContext, true);
-		}
-
-		if (!visFiltering && !(applyMaterials || showTextures) && (!glParams.showSF || !sfMayHaveHiddenValues))
-		{
-			assert(!entityPickingMode || !glParams.showSF);
-
-			// the GL type depends on the PointCoordinateType 'size' (float or double)
-			GLenum GL_COORD_TYPE = sizeof(PointCoordinateType) == 4 ? GL_FLOAT : GL_DOUBLE;
-
-			// get GL program
-			GLuint prog = BuildSimpleMeshProgram(glFunc);
-
 			// static VBO handles reused between calls
-			static GLuint s_vboV = 0;
-			static GLuint s_vboN = 0;
-			static GLuint s_vboC = 0;
-			if (s_vboV == 0)
-				glFunc->glGenBuffers(1, &s_vboV);
-			if (s_vboN == 0)
-				glFunc->glGenBuffers(1, &s_vboN);
-			if (s_vboC == 0)
-				glFunc->glGenBuffers(1, &s_vboC);
+			if (s_vboVertex == 0)
+			{
+				glFunc->glGenBuffers(1, &s_vboVertex);
+			}
+
+			if (glParams.showNorms && s_vboNormals == 0)
+			{
+				glFunc->glGenBuffers(1, &s_vboNormals);
+			}
+
+			if ((glParams.showColors || glParams.showSF) && s_vboColor == 0)
+			{
+				glFunc->glGenBuffers(1, &s_vboColor);
+			}
 
 			auto   vertices  = GetVertexBuffer();
 			float* normals   = reinterpret_cast<float*>(GetNormalsBuffer());
@@ -2078,11 +2191,8 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 				const size_t                      chunkSize               = ccChunk::Size(k, m_triVertIndexes->size());
 				const CCCoreLib::VerticesIndexes* _vertIndexesChunkOrigin = ccChunk::Start(*m_triVertIndexes, k);
 
-				size_t vertexCount       = 0;
-				size_t normalCount       = 0;
-				size_t rgbColorCompCount = 0;
-
 				// vertices
+				size_t vertexCount = 0;
 				{
 					const CCCoreLib::VerticesIndexes* _vertIndexes = _vertIndexesChunkOrigin;
 					CCVector3*                        _vertices    = vertices;
@@ -2099,6 +2209,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 				}
 
 				// scalar field
+				size_t rgbColorCount = 0;
 				if (glParams.showSF)
 				{
 					const CCCoreLib::VerticesIndexes* _vertIndexes = _vertIndexesChunkOrigin;
@@ -2113,11 +2224,10 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 						*_rgbColors++ = *currentDisplayedScalarField->getValueColor(_vertIndexes->i1);
 						*_rgbColors++ = *currentDisplayedScalarField->getValueColor(_vertIndexes->i2);
 						*_rgbColors++ = *currentDisplayedScalarField->getValueColor(_vertIndexes->i3);
-						rgbColorCompCount += 9; // 3 components per vertex
+						rgbColorCount += 3;
 					}
 				}
-				// colors
-				else if (glParams.showColors)
+				else if (glParams.showColors) // colors
 				{
 					const CCCoreLib::VerticesIndexes* _vertIndexes = _vertIndexesChunkOrigin;
 					ccColor::Rgba*                    _rgbaColors  = reinterpret_cast<ccColor::Rgba*>(rgbColors);
@@ -2129,11 +2239,12 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 						*(_rgbaColors)++ = rgbaColorsTable->at(_vertIndexes->i1);
 						*(_rgbaColors)++ = rgbaColorsTable->at(_vertIndexes->i2);
 						*(_rgbaColors)++ = rgbaColorsTable->at(_vertIndexes->i3);
-						rgbColorCompCount += 12; // 4 components per vertex
+						rgbColorCount += 3;
 					}
 				}
 
 				// normals
+				size_t normalCount = 0;
 				if (glParams.showNorms)
 				{
 					float* _normals = normals;
@@ -2172,65 +2283,77 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 				}
 
 				// Upload to VBOs and draw with shader
-				// Bind program if available, else fallback to client arrays (safe fallback)
-				glFunc->glBindTexture(GL_TEXTURE_2D, 0);
-				if (prog != 0)
-				{
-					glFunc->glUseProgram(prog);
-				}
-
-				static GLuint lutTex;
-				static int lutWidth = 0;
-				static int lutHeight = 0;
-				if (lutTex == 0)
-				{
-					CreateNormalLUTTexture(glFunc, lutTex, lutWidth, lutHeight);
-				}
-
-				// bind texture to unit 0
-				glFunc->glActiveTexture(GL_TEXTURE0);
-				glFunc->glBindTexture(GL_TEXTURE_2D, lutTex);
-
-				// set sampler uniform to unit 0
-				GLint locSampler = glFunc->glGetUniformLocation(prog, "uNormalLUT");
-				if (locSampler >= 0)
-					glFunc->glUniform1i(locSampler, 0);
-
-				// set LUT dimensions
-				GLint locW = glFunc->glGetUniformLocation(prog, "uLUTWidth");
-				if (locW >= 0)
-					glFunc->glUniform1i(locW, lutWidth);
-				GLint locH = glFunc->glGetUniformLocation(prog, "uLUTHeight");
-				if (locH >= 0)
-					glFunc->glUniform1i(locH, lutHeight);
-
-				// Vertex buffer
-				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboV);
-				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(vertexCount * 3 * sizeof(PointCoordinateType)), vertices, GL_DYNAMIC_DRAW);
-				glFunc->glEnableVertexAttribArray(ATTR_POS);
-				glFunc->glVertexAttribPointer(ATTR_POS, 3, GL_COORD_TYPE, GL_FALSE, 0, reinterpret_cast<void*>(0));
+				prog->bind();
 
 				// Normals
 				if (glParams.showNorms)
 				{
-					glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboN);
+					// If not done already, create the LUT texture and bind it to unit 0
+					assert(ccMaterial::GetTextureDB());
+					QSharedPointer<QOpenGLTexture> lutTex = ccMaterial::GetTextureDB()->getOpenGLTexture("CompressedNormalsLUT");
+					if (lutTex.isNull())
+					{
+						lutTex = CreateNormalLUTTexture(glFunc);
+						if (lutTex)
+						{
+							ccMaterial::GetTextureDB()->addOpenGLTexture("CompressedNormalsLUT", lutTex);
+						}
+						else
+						{
+							static bool errorAlreadyDisplayed = false;
+							if (!errorAlreadyDisplayed)
+							{
+								ccLog::Error("Failed to create normals LUT texture! Cannot render with normals.");
+								errorAlreadyDisplayed = true;
+							}
+						}
+					}
+
+					// bind texture to unit 0
+					if (!lutTex.isNull())
+					{
+						glFunc->glActiveTexture(GL_TEXTURE0);
+						glFunc->glBindTexture(GL_TEXTURE_2D, lutTex->textureId());
+					}
+
+					// set sampler uniform to unit 0
+					int locSampler = prog->uniformLocation("uNormalLUT");
+					if (locSampler >= 0)
+					{
+						glFunc->glUniform1i(locSampler, 0);
+					}
+					// set LUT dimensions
+					int locW = prog->uniformLocation("uLUTWidth");
+					if (locW >= 0)
+					{
+						glFunc->glUniform1i(locW, lutTex->width());
+					}
+					int locH = prog->uniformLocation("uLUTHeight");
+					if (locH >= 0)
+					{
+						glFunc->glUniform1i(locH, lutTex->height());
+					}
+
+					glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboNormals);
 					glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(normalCount * sizeof(float)), normals, GL_DYNAMIC_DRAW);
 					glFunc->glEnableVertexAttribArray(ATTR_NOR);
 					glFunc->glVertexAttribPointer(ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, reinterpret_cast<void*>(0));
 				}
-				else
+
+				// Vertex buffer
 				{
-					// set default normal to +Z
-					glFunc->glDisableVertexAttribArray(ATTR_NOR);
-					glFunc->glVertexAttrib3f(ATTR_NOR, 0.0f, 0.0f, 1.0f);
+					glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVertex);
+					glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(vertexCount * 3 * sizeof(PointCoordinateType)), vertices, GL_DYNAMIC_DRAW);
+					glFunc->glEnableVertexAttribArray(ATTR_POS);
+					glFunc->glVertexAttribPointer(ATTR_POS, 3, sizeof(PointCoordinateType) == 4 ? GL_FLOAT : GL_DOUBLE, GL_FALSE, 0, reinterpret_cast<void*>(0));
 				}
 
 				// Colors
 				if (glParams.showSF)
 				{
 					// colors are RGB unsigned bytes (3 components)
-					glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboC);
-					glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCompCount * sizeof(unsigned char)), rgbColors, GL_DYNAMIC_DRAW);
+					glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
+					glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCount * 3 * sizeof(unsigned char)), rgbColors, GL_DYNAMIC_DRAW);
 					glFunc->glEnableVertexAttribArray(ATTR_COL);
 					// we upload 3-component unsigned bytes; align to vec4 in shader by setting alpha = 1.0 via glVertexAttrib4f if needed
 					glFunc->glVertexAttribPointer(ATTR_COL, 3, GL_UNSIGNED_BYTE, GL_TRUE, 0, reinterpret_cast<void*>(0));
@@ -2240,17 +2363,10 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 				else if (glParams.showColors)
 				{
 					// colors are RGBA unsigned bytes
-					glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboC);
-					glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCompCount * sizeof(unsigned char)), rgbColors, GL_DYNAMIC_DRAW);
+					glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
+					glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCount * 4 * sizeof(unsigned char)), rgbColors, GL_DYNAMIC_DRAW);
 					glFunc->glEnableVertexAttribArray(ATTR_COL);
 					glFunc->glVertexAttribPointer(ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, reinterpret_cast<void*>(0));
-				}
-				else
-				{
-					// use default material diffuse front (converted to 0..1)
-					glFunc->glDisableVertexAttribArray(ATTR_COL);
-					const ccColor::Rgbaf& def = context.defaultMat->getDiffuseFront();
-					glFunc->glVertexAttrib4fv(ATTR_COL, def.rgba);
 				}
 
 				// draw
@@ -2266,244 +2382,245 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 				// cleanup per-chunk state
 				glFunc->glDisableVertexAttribArray(ATTR_POS);
 				if (glParams.showNorms)
+				{
 					glFunc->glDisableVertexAttribArray(ATTR_NOR);
+					glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+				}
 				if (glParams.showSF || glParams.showColors)
+				{
 					glFunc->glDisableVertexAttribArray(ATTR_COL);
+				}
 
 				// unbind array buffer
 				glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);
-				glFunc->glBindTexture(GL_TEXTURE_2D, 0);
-				if (prog != 0)
-				{
-					glFunc->glUseProgram(0);
-				}
+				prog->release();
 			}
 		}
-		else
+	}
+	else
+	{
+		// current vertex color (RGB)
+		const ccColor::Rgb* rgb1 = nullptr;
+		const ccColor::Rgb* rgb2 = nullptr;
+		const ccColor::Rgb* rgb3 = nullptr;
+		// current vertex color (RGBA)
+		const ccColor::Rgba* rgba1 = nullptr;
+		const ccColor::Rgba* rgba2 = nullptr;
+		const ccColor::Rgba* rgba3 = nullptr;
+		// current vertex normal
+		const PointCoordinateType* N1 = nullptr;
+		const PointCoordinateType* N2 = nullptr;
+		const PointCoordinateType* N3 = nullptr;
+		// current vertex texture coordinates
+		const TexCoords2D* Tx1 = nullptr;
+		const TexCoords2D* Tx2 = nullptr;
+		const TexCoords2D* Tx3 = nullptr;
+
+		int    lasMtlIndex  = -1;
+		GLuint currentTexID = 0;
+
+		GLenum triangleDisplayType = lodEnabled ? GL_POINTS : showWired ? GL_LINE_LOOP
+		                                                                : GL_TRIANGLES;
+		glFunc->glBegin(triangleDisplayType);
+
+		// loop on all triangles
+		for (size_t n = 0; n < triNum; ++n)
 		{
-			// current vertex color (RGB)
-			const ccColor::Rgb* rgb1 = nullptr;
-			const ccColor::Rgb* rgb2 = nullptr;
-			const ccColor::Rgb* rgb3 = nullptr;
-			// current vertex color (RGBA)
-			const ccColor::Rgba* rgba1 = nullptr;
-			const ccColor::Rgba* rgba2 = nullptr;
-			const ccColor::Rgba* rgba3 = nullptr;
-			// current vertex normal
-			const PointCoordinateType* N1 = nullptr;
-			const PointCoordinateType* N2 = nullptr;
-			const PointCoordinateType* N3 = nullptr;
-			// current vertex texture coordinates
-			const TexCoords2D* Tx1 = nullptr;
-			const TexCoords2D* Tx2 = nullptr;
-			const TexCoords2D* Tx3 = nullptr;
-
-			int    lasMtlIndex  = -1;
-			GLuint currentTexID = 0;
-
-			GLenum triangleDisplayType = lodEnabled ? GL_POINTS : showWired ? GL_LINE_LOOP
-			                                                                : GL_TRIANGLES;
-			glFunc->glBegin(triangleDisplayType);
-
-			// loop on all triangles
-			for (size_t n = 0; n < triNum; ++n)
+			// LOD: shall we display this triangle?
+			if (n % decimStep)
 			{
-				// LOD: shall we display this triangle?
-				if (n % decimStep)
-				{
+				continue;
+			}
+
+			// current triangle vertices
+			const CCCoreLib::VerticesIndexes& tsi = m_triVertIndexes->at(n);
+
+			if (visFiltering)
+			{
+				// we skip the triangle if at least one vertex is hidden
+				if ((verticesVisibility[tsi.i1] != CCCoreLib::POINT_VISIBLE) || (verticesVisibility[tsi.i2] != CCCoreLib::POINT_VISIBLE) || (verticesVisibility[tsi.i3] != CCCoreLib::POINT_VISIBLE))
 					continue;
-				}
+			}
 
-				// current triangle vertices
-				const CCCoreLib::VerticesIndexes& tsi = m_triVertIndexes->at(n);
+			if (glParams.showSF)
+			{
+				assert(colorScale);
+				rgb1 = currentDisplayedScalarField->getValueColor(tsi.i1);
+				if (!rgb1)
+					continue;
+				rgb2 = currentDisplayedScalarField->getValueColor(tsi.i2);
+				if (!rgb2)
+					continue;
+				rgb3 = currentDisplayedScalarField->getValueColor(tsi.i3);
+				if (!rgb3)
+					continue;
 
-				if (visFiltering)
+				if (entityPickingMode)
 				{
-					// we skip the triangle if at least one vertex is hidden
-					if ((verticesVisibility[tsi.i1] != CCCoreLib::POINT_VISIBLE) || (verticesVisibility[tsi.i2] != CCCoreLib::POINT_VISIBLE) || (verticesVisibility[tsi.i3] != CCCoreLib::POINT_VISIBLE))
-						continue;
+					// in picking mode, we don't want to apply the colors, just filter the invisible triangles
+					rgb1 = nullptr;
+					rgb2 = nullptr;
+					rgb3 = nullptr;
 				}
+			}
+			else if (glParams.showColors)
+			{
+				rgba1 = &rgbaColorsTable->at(tsi.i1);
+				rgba2 = &rgbaColorsTable->at(tsi.i2);
+				rgba3 = &rgbaColorsTable->at(tsi.i3);
+			}
 
-				if (glParams.showSF)
+			if (glParams.showNorms)
+			{
+				if (showTriNormals)
 				{
-					assert(colorScale);
-					rgb1 = currentDisplayedScalarField->getValueColor(tsi.i1);
-					if (!rgb1)
-						continue;
-					rgb2 = currentDisplayedScalarField->getValueColor(tsi.i2);
-					if (!rgb2)
-						continue;
-					rgb3 = currentDisplayedScalarField->getValueColor(tsi.i3);
-					if (!rgb3)
-						continue;
-
-					if (entityPickingMode)
-					{
-						// in picking mode, we don't want to apply the colors, just filter the invisible triangles
-						rgb1 = nullptr;
-						rgb2 = nullptr;
-						rgb3 = nullptr;
-					}
+					assert(m_triNormalIndexes);
+					const Tuple3i& idx = m_triNormalIndexes->at(n);
+					assert(idx.u[0] < static_cast<int>(m_triNormals->size()));
+					assert(idx.u[1] < static_cast<int>(m_triNormals->size()));
+					assert(idx.u[2] < static_cast<int>(m_triNormals->size()));
+					N1 = (idx.u[0] >= 0 ? ccNormalVectors::GetNormal(m_triNormals->getValue(idx.u[0])).u : nullptr);
+					N2 = (idx.u[0] == idx.u[1] ? N1 : idx.u[1] >= 0 ? ccNormalVectors::GetNormal(m_triNormals->getValue(idx.u[1])).u
+					                                                : nullptr);
+					N3 = (idx.u[0] == idx.u[2] ? N1 : idx.u[2] >= 0 ? ccNormalVectors::GetNormal(m_triNormals->getValue(idx.u[2])).u
+					                                                : nullptr);
 				}
-				else if (glParams.showColors)
+				else
 				{
-					rgba1 = &rgbaColorsTable->at(tsi.i1);
-					rgba2 = &rgbaColorsTable->at(tsi.i2);
-					rgba3 = &rgbaColorsTable->at(tsi.i3);
+					N1 = compressedNormals->getNormal(normalsIndexesTable->getValue(tsi.i1)).u;
+					N2 = compressedNormals->getNormal(normalsIndexesTable->getValue(tsi.i2)).u;
+					N3 = compressedNormals->getNormal(normalsIndexesTable->getValue(tsi.i3)).u;
 				}
+			}
 
-				if (glParams.showNorms)
+			if (applyMaterials || showTextures)
+			{
+				assert(m_materials);
+				int newMatlIndex = m_triMtlIndexes->getValue(n);
+
+				// do we need to change material?
+				if (lasMtlIndex != newMatlIndex)
 				{
-					if (showTriNormals)
-					{
-						assert(m_triNormalIndexes);
-						const Tuple3i& idx = m_triNormalIndexes->at(n);
-						assert(idx.u[0] < static_cast<int>(m_triNormals->size()));
-						assert(idx.u[1] < static_cast<int>(m_triNormals->size()));
-						assert(idx.u[2] < static_cast<int>(m_triNormals->size()));
-						N1 = (idx.u[0] >= 0 ? ccNormalVectors::GetNormal(m_triNormals->getValue(idx.u[0])).u : nullptr);
-						N2 = (idx.u[0] == idx.u[1] ? N1 : idx.u[1] >= 0 ? ccNormalVectors::GetNormal(m_triNormals->getValue(idx.u[1])).u
-						                                                : nullptr);
-						N3 = (idx.u[0] == idx.u[2] ? N1 : idx.u[2] >= 0 ? ccNormalVectors::GetNormal(m_triNormals->getValue(idx.u[2])).u
-						                                                : nullptr);
-					}
-					else
-					{
-						N1 = compressedNormals->getNormal(normalsIndexesTable->getValue(tsi.i1)).u;
-						N2 = compressedNormals->getNormal(normalsIndexesTable->getValue(tsi.i2)).u;
-						N3 = compressedNormals->getNormal(normalsIndexesTable->getValue(tsi.i3)).u;
-					}
-				}
-
-				if (applyMaterials || showTextures)
-				{
-					assert(m_materials);
-					int newMatlIndex = m_triMtlIndexes->getValue(n);
-
-					// do we need to change material?
-					if (lasMtlIndex != newMatlIndex)
-					{
-						assert(newMatlIndex < static_cast<int>(m_materials->size()));
-						glFunc->glEnd();
-						if (showTextures)
-						{
-							if (newMatlIndex >= 0) // valid material index
-							{
-								GLuint newTexID = m_materials->at(newMatlIndex)->getTextureID();
-								if (newTexID != currentTexID)
-								{
-									// the texture ID changes
-									if (0 != newTexID)
-									{
-										// new and valid texture ID --> we bind it
-										currentTexID = newTexID;
-										glFunc->glEnable(GL_TEXTURE_2D); // it seems some driver now won't manage the case where no texture is bound and still try
-										                                 // to display an (invalid) texture. So we have to enable texture mode only when necessary.
-										glFunc->glBindTexture(GL_TEXTURE_2D, currentTexID);
-									}
-									else if (0 != currentTexID)
-									{
-										// the previous texture ID was valid --> we unbind it
-										currentTexID = 0;
-										glFunc->glBindTexture(GL_TEXTURE_2D, 0);
-										glFunc->glDisable(GL_TEXTURE_2D); // it seems some driver now won't manage the case where no texture is bound and still
-										                                  // try to display an (invalid) texture. So we disable the whole texture mode.
-									}
-								}
-							}
-							else if (0 != currentTexID)
-							{
-								currentTexID = 0;
-								glFunc->glBindTexture(GL_TEXTURE_2D, 0);
-								glFunc->glDisable(GL_TEXTURE_2D); // it seems some driver now won't manage the case where no texture is bound and still
-								                                  // try to display an (invalid) texture. So we disable the whole texture mode.
-							}
-						}
-
-						// if we don't have any current material, we apply default one
-						if (newMatlIndex >= 0)
-							(*m_materials)[newMatlIndex]->applyGL(context.qGLContext, glParams.showNorms, false);
-						else
-							context.defaultMat->applyGL(context.qGLContext, glParams.showNorms, false);
-
-						glFunc->glBegin(triangleDisplayType);
-						lasMtlIndex = newMatlIndex;
-					}
-
+					assert(newMatlIndex < static_cast<int>(m_materials->size()));
+					glFunc->glEnd();
 					if (showTextures)
 					{
-						assert(m_texCoords && m_texCoordIndexes);
-						const Tuple3i& txInd = m_texCoordIndexes->getValue(n);
-						assert(txInd.u[0] < static_cast<int>(m_texCoords->size()));
-						assert(txInd.u[1] < static_cast<int>(m_texCoords->size()));
-						assert(txInd.u[2] < static_cast<int>(m_texCoords->size()));
-						Tx1 = (txInd.u[0] >= 0 ? &m_texCoords->getValue(txInd.u[0]) : nullptr);
-						Tx2 = (txInd.u[1] >= 0 ? &m_texCoords->getValue(txInd.u[1]) : nullptr);
-						Tx3 = (txInd.u[2] >= 0 ? &m_texCoords->getValue(txInd.u[2]) : nullptr);
+						if (newMatlIndex >= 0) // valid material index
+						{
+							GLuint newTexID = m_materials->at(newMatlIndex)->getTextureID();
+							if (newTexID != currentTexID)
+							{
+								// the texture ID changes
+								if (0 != newTexID)
+								{
+									// new and valid texture ID --> we bind it
+									currentTexID = newTexID;
+									glFunc->glEnable(GL_TEXTURE_2D); // it seems some driver now won't manage the case where no texture is bound and still try
+									                                 // to display an (invalid) texture. So we have to enable texture mode only when necessary.
+									glFunc->glBindTexture(GL_TEXTURE_2D, currentTexID);
+								}
+								else if (0 != currentTexID)
+								{
+									// the previous texture ID was valid --> we unbind it
+									currentTexID = 0;
+									glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+									glFunc->glDisable(GL_TEXTURE_2D); // it seems some driver now won't manage the case where no texture is bound and still
+									                                  // try to display an (invalid) texture. So we disable the whole texture mode.
+								}
+							}
+						}
+						else if (0 != currentTexID)
+						{
+							currentTexID = 0;
+							glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+							glFunc->glDisable(GL_TEXTURE_2D); // it seems some driver now won't manage the case where no texture is bound and still
+							                                  // try to display an (invalid) texture. So we disable the whole texture mode.
+						}
 					}
-				}
 
-				if (showWired)
-				{
-					glFunc->glEnd();
+					// if we don't have any current material, we apply default one
+					if (newMatlIndex >= 0)
+						(*m_materials)[newMatlIndex]->applyGL(context.qGLContext, glParams.showNorms, false);
+					else
+						context.defaultMat->applyGL(context.qGLContext, glParams.showNorms, false);
+
 					glFunc->glBegin(triangleDisplayType);
+					lasMtlIndex = newMatlIndex;
 				}
 
-				// vertex 1
-				if (N1)
-					ccGL::Normal3v(glFunc, N1);
-				if (rgb1)
-					ccGL::Color(glFunc, *rgb1);
-				else if (rgba1)
-					ccGL::Color(glFunc, *rgba1);
-				if (Tx1)
-					glFunc->glTexCoord2fv(Tx1->t);
-				ccGL::Vertex3v(glFunc, cloud->getPoint(tsi.i1)->u);
-
-				// vertex 2
-				if (N2)
-					ccGL::Normal3v(glFunc, N2);
-				if (rgb2)
-					ccGL::Color(glFunc, *rgb2);
-				else if (rgba2)
-					ccGL::Color(glFunc, *rgba2);
-				if (Tx2)
-					glFunc->glTexCoord2fv(Tx2->t);
-				ccGL::Vertex3v(glFunc, cloud->getPoint(tsi.i2)->u);
-
-				// vertex 3
-				if (N3)
-					ccGL::Normal3v(glFunc, N3);
-				if (rgb3)
-					ccGL::Color(glFunc, *rgb3);
-				else if (rgba3)
-					ccGL::Color(glFunc, *rgba3);
-				if (Tx3)
-					glFunc->glTexCoord2fv(Tx3->t);
-				ccGL::Vertex3v(glFunc, cloud->getPoint(tsi.i3)->u);
-			}
-
-			glFunc->glEnd();
-
-			if (showTextures)
-			{
-				if (0 != currentTexID)
+				if (showTextures)
 				{
-					currentTexID = 0;
-					glFunc->glBindTexture(GL_TEXTURE_2D, 0);
-					glFunc->glDisable(GL_TEXTURE_2D); // it seems some driver now won't manage the case where no texture is bound and still
-					                                  // try to display an (invalid) texture. So we disable the whole texture mode.
+					assert(m_texCoords && m_texCoordIndexes);
+					const Tuple3i& txInd = m_texCoordIndexes->getValue(n);
+					assert(txInd.u[0] < static_cast<int>(m_texCoords->size()));
+					assert(txInd.u[1] < static_cast<int>(m_texCoords->size()));
+					assert(txInd.u[2] < static_cast<int>(m_texCoords->size()));
+					Tx1 = (txInd.u[0] >= 0 ? &m_texCoords->getValue(txInd.u[0]) : nullptr);
+					Tx2 = (txInd.u[1] >= 0 ? &m_texCoords->getValue(txInd.u[1]) : nullptr);
+					Tx3 = (txInd.u[2] >= 0 ? &m_texCoords->getValue(txInd.u[2]) : nullptr);
 				}
 			}
+
+			if (showWired)
+			{
+				glFunc->glEnd();
+				glFunc->glBegin(triangleDisplayType);
+			}
+
+			// vertex 1
+			if (N1)
+				ccGL::Normal3v(glFunc, N1);
+			if (rgb1)
+				ccGL::Color(glFunc, *rgb1);
+			else if (rgba1)
+				ccGL::Color(glFunc, *rgba1);
+			if (Tx1)
+				glFunc->glTexCoord2fv(Tx1->t);
+			ccGL::Vertex3v(glFunc, cloud->getPoint(tsi.i1)->u);
+
+			// vertex 2
+			if (N2)
+				ccGL::Normal3v(glFunc, N2);
+			if (rgb2)
+				ccGL::Color(glFunc, *rgb2);
+			else if (rgba2)
+				ccGL::Color(glFunc, *rgba2);
+			if (Tx2)
+				glFunc->glTexCoord2fv(Tx2->t);
+			ccGL::Vertex3v(glFunc, cloud->getPoint(tsi.i2)->u);
+
+			// vertex 3
+			if (N3)
+				ccGL::Normal3v(glFunc, N3);
+			if (rgb3)
+				ccGL::Color(glFunc, *rgb3);
+			else if (rgba3)
+				ccGL::Color(glFunc, *rgba3);
+			if (Tx3)
+				glFunc->glTexCoord2fv(Tx3->t);
+			ccGL::Vertex3v(glFunc, cloud->getPoint(tsi.i3)->u);
 		}
 
-		if (stippling)
+		glFunc->glEnd();
+
+		if (showTextures)
 		{
-			EnableGLStippleMask(context.qGLContext, false);
+			if (0 != currentTexID)
+			{
+				currentTexID = 0;
+				glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+				glFunc->glDisable(GL_TEXTURE_2D); // it seems some driver now won't manage the case where no texture is bound and still
+				                                  // try to display an (invalid) texture. So we disable the whole texture mode.
+			}
 		}
-
-		glFunc->glPopAttrib(); // GL_LIGHTING_BIT | GL_TRANSFORM_BIT | GL_ENABLE_BIT
 	}
+
+	if (stippling)
+	{
+		EnableGLStippleMask(context.qGLContext, false);
+	}
+
+	glFunc->glPopAttrib(); // GL_LIGHTING_BIT | GL_TRANSFORM_BIT | GL_ENABLE_BIT
 }
 
 ccMesh* ccMesh::createNewMeshFromSelection(bool              removeSelectedTriangles,

--- a/libs/qCC_db/src/ccMesh.cpp
+++ b/libs/qCC_db/src/ccMesh.cpp
@@ -2146,7 +2146,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 		EnableGLStippleMask(context.qGLContext, true);
 	}
 
-	if (!visFiltering && !(applyMaterials || showTextures) && (!glParams.showSF || !sfMayHaveHiddenValues))
+	if (!visFiltering && !(applyMaterials || showTextures) && (!glParams.showSF || !sfMayHaveHiddenValues) && !MACRO_NoShader(context))
 	{
 		assert(!entityPickingMode || !glParams.showSF);
 
@@ -2164,6 +2164,8 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 		QSharedPointer<QOpenGLShaderProgram> prog = BuildSimpleMeshProgram(glFunc, attributes);
 		if (prog)
 		{
+			ccGLDrawContext::CatchGLErrors(glFunc->glGetError(), "ccMesh::shader.program.build");
+
 			// static VBO handles reused between calls
 			if (s_vboVertex == 0)
 			{
@@ -2394,6 +2396,8 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 				// unbind array buffer
 				glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);
 				prog->release();
+
+				ccGLDrawContext::CatchGLErrors(glFunc->glGetError(), "ccMesh::shader.program.end");
 			}
 		}
 	}

--- a/libs/qCC_db/src/ccMesh.cpp
+++ b/libs/qCC_db/src/ccMesh.cpp
@@ -1921,10 +1921,6 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 		{
 			attributes |= ccGLSL::ATTR_COL;
 		}
-		if (!m_clipPlanes.empty())
-		{
-			attributes |= ccGLSL::ATTR_CLIP;
-		}
 
 		prog = ccGLSL::BuildDisplayProgram(glFunc, attributes);
 

--- a/libs/qCC_db/src/ccMesh.cpp
+++ b/libs/qCC_db/src/ccMesh.cpp
@@ -1677,16 +1677,9 @@ CCCoreLib::VerticesIndexes* ccMesh::getNextTriangleVertIndexes()
 }
 
 // Global OpenGL resources
-static QMap<int, QSharedPointer<QOpenGLShaderProgram>> s_programs;
-static GLuint                                          s_vboVertex  = 0;
-static GLuint                                          s_vboNormals = 0;
-static GLuint                                          s_vboColor   = 0;
-
-// Attribute indexes that we bound when creating the programs
-static const GLuint ATTR_POS  = 0;
-static const GLuint ATTR_NOR  = 1;
-static const GLuint ATTR_COL  = 2;
-static const GLuint ATTR_CLIP = 4;
+static GLuint s_vboVertex  = 0;
+static GLuint s_vboNormals = 0;
+static GLuint s_vboColor   = 0;
 
 void ccMesh::ReleaseOpenGLRessources()
 {
@@ -1696,12 +1689,12 @@ void ccMesh::ReleaseOpenGLRessources()
 		return;
 	}
 
+	ccGLSL::ReleaseOpenGLRessources();
+
 	// get the set of OpenGL functions (version 2.1)
 	QOpenGLFunctions_2_1* glFunc = QOpenGLVersionFunctionsFactory::get<QOpenGLFunctions_2_1>(QOpenGLContext::currentContext());
 	if (glFunc)
 	{
-		s_programs.clear();
-
 		if (s_vboVertex != 0)
 		{
 			glFunc->glDeleteBuffers(1, &s_vboVertex);
@@ -1720,176 +1713,6 @@ void ccMesh::ReleaseOpenGLRessources()
 			s_vboColor = 0;
 		}
 	}
-}
-
-// GLSL program builder (GLSL 1.20) for mesh rendering (position, normal, color)
-static QSharedPointer<QOpenGLShaderProgram> BuildMeshDisplayProgram(QOpenGLFunctions_2_1* glFunc, int attributes)
-{
-	if (!glFunc)
-	{
-		assert(false);
-		return nullptr;
-	}
-
-	if (s_programs.contains(attributes))
-	{
-		return s_programs[attributes];
-	}
-
-	// Vertex shaders
-	static const char* VertexProgHeaderSrc =
-	    "#version 120\n"
-	    "attribute vec3 aPosition;\n"
-	    "varying vec4 vColor;\n";
-
-	static const char* VertexProgColorAttributesSrc =
-	    "attribute vec4 aColor;\n";
-
-	static const char* VertexProgNormAttributesSrc =
-	    "attribute float aNormalIndex;\n"
-	    "varying vec3 vNormal;\n"
-	    "uniform sampler2D uNormalLUT;\n"
-	    "uniform int uLUTWidth;\n"
-	    "uniform int uLUTHeight;\n";
-
-	static const char* VertexProgFetchNormFuncSrc =
-	    "vec3 fetchNormalFromLUT(float fi)\n"
-	    "{\n"
-	    "	float w  = float(uLUTWidth);\n"
-	    "	float h  = float(uLUTHeight);\n"
-	    "	float tx = mod(fi, w);\n"
-	    "	float ty = floor(fi / w);\n"
-	    "	vec2 uv = vec2((tx + 0.5) / w, (ty + 0.5) / h);\n"
-	    "	vec3 enc = texture2D(uNormalLUT, uv).rgb;\n"
-	    "	vec3 n = enc * 2.0 - 1.0;\n"
-	    "	return normalize(n);\n"
-	    "}\n";
-
-	static const char* VertexProgMainStartSrc =
-	    "void main()\n"
-	    "{\n";
-
-	static const char* VertexProgMainUseDefaultGLColorSrc =
-	    "    vColor = gl_Color;\n";
-
-	static const char* VertexProgMainUseInputColorSrc =
-	    "    vColor = aColor;\n";
-
-	static const char* VertexProgMainFetchNormalSrc =
-	    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n";
-
-	static const char* VertexProgMainClippingSrc =
-	    "    gl_ClipVertex = gl_ModelViewMatrix * vec4(aPosition, 1.0);\n";
-
-	static const char* VertexProgMainEndSrc =
-	    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
-	    "}\n";
-
-	// Fragment shaders
-	static const char* ColorOnlyFragmentProgSrc =
-	    "#version 120\n"
-	    "varying vec4 vColor;\n"
-	    "void main()\n"
-	    "{\n"
-	    "    gl_FragColor = vColor;\n"
-	    "}\n";
-
-	static const char* ColorAndNormalFragmentProgSrc =
-	    "#version 120\n"
-	    "varying vec4 vColor;\n"
-	    "varying vec3 vNormal;\n"
-	    "void main()\n"
-	    "{\n"
-	    "    vec3 n = normalize(vNormal);\n"
-	    "    vec3 lightDir = normalize(vec3(0.0,0.0,1.0));\n"
-	    "    float diff = max(dot(n, lightDir), 0.0);\n"
-	    "    vec4 base = vColor;\n"
-	    "    gl_FragColor = vec4(base.rgb * diff, base.a);\n"
-	    "}\n";
-
-	QString vertexProgSrc = VertexProgHeaderSrc;
-	{
-		// add attributes
-		if (attributes & ATTR_COL)
-			vertexProgSrc += VertexProgColorAttributesSrc;
-		if (attributes & ATTR_NOR)
-			vertexProgSrc += VertexProgNormAttributesSrc;
-
-		// add special functions
-		if (attributes & ATTR_NOR)
-		{
-			vertexProgSrc += VertexProgFetchNormFuncSrc;
-		}
-
-		// main function
-		{
-			vertexProgSrc += VertexProgMainStartSrc;
-
-			// color transfer
-			if (attributes & ATTR_COL)
-			{
-				vertexProgSrc += VertexProgMainUseInputColorSrc;
-			}
-			else
-			{
-				vertexProgSrc += VertexProgMainUseDefaultGLColorSrc;
-			}
-
-			// normal transfer (if any)
-			if (attributes & ATTR_NOR)
-			{
-				vertexProgSrc += VertexProgMainFetchNormalSrc;
-			}
-
-			if (attributes & ATTR_CLIP)
-			{
-				vertexProgSrc += VertexProgMainClippingSrc;
-			}
-
-			vertexProgSrc += VertexProgMainEndSrc;
-		}
-	}
-
-	QString fragmentProgSrc = (attributes & ATTR_NOR ? ColorAndNormalFragmentProgSrc : ColorOnlyFragmentProgSrc);
-
-	QOpenGLShader vertexShader(QOpenGLShader::Vertex);
-	if (false == vertexShader.compileSourceCode(vertexProgSrc))
-	{
-		ccLog::Warning(QString("[BuildMeshDisplayProgram] Vertex shader compilation failed: ") + vertexShader.log());
-		return nullptr;
-	}
-	QOpenGLShader fragmentShader(QOpenGLShader::Fragment);
-	if (false == fragmentShader.compileSourceCode(fragmentProgSrc))
-	{
-		ccLog::Warning(QString("[BuildMeshDisplayProgram] Fragment shader compilation failed: ") + fragmentShader.log());
-		return nullptr;
-	}
-	QSharedPointer<QOpenGLShaderProgram> program(new QOpenGLShaderProgram);
-	program->addShader(&vertexShader);
-	program->addShader(&fragmentShader);
-
-	// bind attribute locations before linking for stable locations
-	program->bindAttributeLocation("aPosition", ATTR_POS);
-	if (attributes & ATTR_COL)
-	{
-		program->bindAttributeLocation("aColor", ATTR_COL);
-	}
-	if (attributes & ATTR_NOR)
-	{
-		program->bindAttributeLocation("aNormalIndex", ATTR_NOR);
-	}
-
-	if (false == program->link())
-	{
-		ccLog::Warning(QString("[BuildMeshDisplayProgram] Shader program linking failed: ") + program->log());
-		return nullptr;
-	}
-
-	s_programs[attributes] = program;
-
-	ccGLDrawContext::CatchGLErrors(glFunc->glGetError(), "ccMesh::shader.program.build");
-
-	return program;
 }
 
 void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
@@ -2089,21 +1912,21 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 	if (!fallBackDisplay)
 	{
 		// get GL program
-		int attributes = ATTR_POS;
+		int attributes = ccGLSL::ATTR_POS;
 		if (glParams.showNorms)
 		{
-			attributes |= ATTR_NOR;
+			attributes |= ccGLSL::ATTR_NOR;
 		}
 		if (glParams.showColors || glParams.showSF)
 		{
-			attributes |= ATTR_COL;
+			attributes |= ccGLSL::ATTR_COL;
 		}
 		if (!m_clipPlanes.empty())
 		{
-			attributes |= ATTR_CLIP;
+			attributes |= ccGLSL::ATTR_CLIP;
 		}
 
-		prog = BuildMeshDisplayProgram(glFunc, attributes);
+		prog = ccGLSL::BuildDisplayProgram(glFunc, attributes);
 
 		if (prog.isNull())
 		{
@@ -2160,6 +1983,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 			glFunc->glActiveTexture(GL_TEXTURE0);
 			glFunc->glBindTexture(GL_TEXTURE_2D, lutTex->textureId());
 
+			ccGLSL::SetLightUniforms(glFunc, prog.data());
 			ccGLSL::SetLUTTextureUniforms(glFunc, prog.data(), lutTex.data());
 		}
 
@@ -2267,8 +2091,8 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 			{
 				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVertex);
 				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(vertexCount * 3 * sizeof(PointCoordinateType)), vertices, GL_DYNAMIC_DRAW);
-				glFunc->glEnableVertexAttribArray(ATTR_POS);
-				glFunc->glVertexAttribPointer(ATTR_POS, 3, sizeof(PointCoordinateType) == 4 ? GL_FLOAT : GL_DOUBLE, GL_FALSE, 0, nullptr);
+				glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_POS);
+				glFunc->glVertexAttribPointer(ccGLSL::ATTR_POS, 3, sizeof(PointCoordinateType) == 4 ? GL_FLOAT : GL_DOUBLE, GL_FALSE, 0, nullptr);
 			}
 
 			// Normals
@@ -2276,8 +2100,8 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 			{
 				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboNormals);
 				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(normalCount * sizeof(float)), normalIndexes, GL_DYNAMIC_DRAW);
-				glFunc->glEnableVertexAttribArray(ATTR_NOR);
-				glFunc->glVertexAttribPointer(ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+				glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_NOR);
+				glFunc->glVertexAttribPointer(ccGLSL::ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
 			}
 
 			// Colors
@@ -2286,9 +2110,9 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 				// colors are RGB unsigned bytes (3 components)
 				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
 				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCount * 3 * sizeof(unsigned char)), rgbColors, GL_DYNAMIC_DRAW);
-				glFunc->glEnableVertexAttribArray(ATTR_COL);
+				glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_COL);
 				// we upload 3-component unsigned bytes; align to vec4 in shader by setting alpha = 1.0 via glVertexAttrib4f if needed
-				glFunc->glVertexAttribPointer(ATTR_COL, 3, GL_UNSIGNED_BYTE, GL_TRUE, 0, nullptr);
+				glFunc->glVertexAttribPointer(ccGLSL::ATTR_COL, 3, GL_UNSIGNED_BYTE, GL_TRUE, 0, nullptr);
 				// ensure alpha = 1.0 for all vertices
 				// Note: can't set alpha per-vertex when only 3 components provided; shader expects vec4 but attribute with 3 components will get implicit 1.0 as 4th component
 			}
@@ -2297,8 +2121,8 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 				// colors are RGBA unsigned bytes
 				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
 				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCount * 4 * sizeof(unsigned char)), rgbColors, GL_DYNAMIC_DRAW);
-				glFunc->glEnableVertexAttribArray(ATTR_COL);
-				glFunc->glVertexAttribPointer(ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, nullptr);
+				glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_COL);
+				glFunc->glVertexAttribPointer(ccGLSL::ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, nullptr);
 			}
 
 			// draw
@@ -2312,14 +2136,14 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 			}
 
 			// cleanup per-chunk state
-			glFunc->glDisableVertexAttribArray(ATTR_POS);
+			glFunc->glDisableVertexAttribArray(ccGLSL::ATTR_POS);
 			if (glParams.showNorms)
 			{
-				glFunc->glDisableVertexAttribArray(ATTR_NOR);
+				glFunc->glDisableVertexAttribArray(ccGLSL::ATTR_NOR);
 			}
 			if (glParams.showSF || glParams.showColors)
 			{
-				glFunc->glDisableVertexAttribArray(ATTR_COL);
+				glFunc->glDisableVertexAttribArray(ccGLSL::ATTR_COL);
 			}
 
 			// unbind array buffer

--- a/libs/qCC_db/src/ccMesh.cpp
+++ b/libs/qCC_db/src/ccMesh.cpp
@@ -1677,9 +1677,9 @@ CCCoreLib::VerticesIndexes* ccMesh::getNextTriangleVertIndexes()
 }
 
 // Global OpenGL resources
-static GLuint s_vboVertex  = 0;
-static GLuint s_vboNormals = 0;
-static GLuint s_vboColor   = 0;
+static QOpenGLBuffer s_vboVertex;
+static QOpenGLBuffer s_vboNormals;
+static QOpenGLBuffer s_vboColor;
 
 void ccMesh::ReleaseOpenGLRessources()
 {
@@ -1691,28 +1691,17 @@ void ccMesh::ReleaseOpenGLRessources()
 
 	ccGLSL::ReleaseOpenGLRessources();
 
-	// get the set of OpenGL functions (version 2.1)
-	QOpenGLFunctions_2_1* glFunc = QOpenGLVersionFunctionsFactory::get<QOpenGLFunctions_2_1>(QOpenGLContext::currentContext());
-	if (glFunc)
+	auto releaseVBO = [](QOpenGLBuffer& vbo)
 	{
-		if (s_vboVertex != 0)
+		if (vbo.isCreated())
 		{
-			glFunc->glDeleteBuffers(1, &s_vboVertex);
-			s_vboVertex = 0;
+			vbo.destroy();
 		}
+	};
 
-		if (s_vboNormals != 0)
-		{
-			glFunc->glDeleteBuffers(1, &s_vboNormals);
-			s_vboNormals = 0;
-		}
-
-		if (s_vboColor != 0)
-		{
-			glFunc->glDeleteBuffers(1, &s_vboColor);
-			s_vboColor = 0;
-		}
-	}
+	releaseVBO(s_vboVertex);
+	releaseVBO(s_vboNormals);
+	releaseVBO(s_vboColor);
 }
 
 void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
@@ -1902,16 +1891,19 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 	static bool                    s_normalLUTTextureFailed = false;
 	QSharedPointer<QOpenGLTexture> lutTex;
 
+	static bool s_globalVBOCreationFailed = false;
+
 	bool fallBackDisplay = (visFiltering
 	                        || (applyMaterials || showTextures)
 	                        || (glParams.showSF && sfMayHaveHiddenValues)
 	                        || (glParams.showNorms && s_normalLUTTextureFailed))
+	                       || s_globalVBOCreationFailed
 	                       || MACRO_NoShader(context);
 
 	QSharedPointer<QOpenGLShaderProgram> prog;
 	if (!fallBackDisplay)
 	{
-		// get GL program
+		// get the right GLSL program
 		int attributes = ccGLSL::ATTR_POS;
 		if (glParams.showNorms)
 		{
@@ -1924,48 +1916,55 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 		prog = ccGLSL::BuildDisplayProgram(glFunc, attributes);
 
-		if (prog.isNull())
+		if (prog)
 		{
-			fallBackDisplay = true;
-		}
-		else if (glParams.showNorms)
-		{
-			assert(!s_normalLUTTextureFailed);
-
-			// create or retrieve the LUT texture
-			lutTex = ccGLSL::GetNormalLUTTexture(glFunc);
-			if (lutTex.isNull())
+			if (glParams.showNorms)
 			{
-				ccLog::Warning("Failed to create normals LUT texture! Cannot render fast normals.");
-				s_normalLUTTextureFailed = true;
-				fallBackDisplay          = true;
+				// create or retrieve the LUT texture
+				lutTex = ccGLSL::GetNormalLUTTexture(glFunc);
+				if (lutTex.isNull())
+				{
+					ccLog::Warning("Failed to create normals LUT texture! Cannot render fast normals.");
+					s_normalLUTTextureFailed = true;
+					prog.clear();
+				}
+			}
 
-				prog.clear();
-				fallBackDisplay = true;
+			// static VBO handles reused between calls
+			auto createVBOIfNeeded = [&](QOpenGLBuffer& vbo, int sizeBytes)
+			{
+				if (prog && !vbo.isCreated())
+				{
+					if (vbo.create())
+					{
+						vbo.setUsagePattern(QOpenGLBuffer::StreamDraw);
+						vbo.bind();
+						vbo.allocate(sizeBytes);
+						vbo.release();
+					}
+					else
+					{
+						s_globalVBOCreationFailed = true;
+						prog.clear();
+					}
+				}
+			};
+			createVBOIfNeeded(s_vboVertex, static_cast<int>(ccChunk::SIZE * 3 * 3 * sizeof(PointCoordinateType)));
+			if (attributes & ccGLSL::ATTR_NOR)
+			{
+				createVBOIfNeeded(s_vboNormals, static_cast<int>(ccChunk::SIZE * 3 * sizeof(float)));
+			}
+			if (attributes & ccGLSL::ATTR_COL)
+			{
+				createVBOIfNeeded(s_vboColor, static_cast<int>(ccChunk::SIZE * 4 * 3 * sizeof(unsigned char)));
 			}
 		}
 	}
 
-	if (!fallBackDisplay)
+	if (prog)
 	{
 		assert(!entityPickingMode || !glParams.showSF);
 		assert(prog.isNull() == false);
-
-		// static VBO handles reused between calls
-		if (s_vboVertex == 0)
-		{
-			glFunc->glGenBuffers(1, &s_vboVertex);
-		}
-
-		if (glParams.showNorms && s_vboNormals == 0)
-		{
-			glFunc->glGenBuffers(1, &s_vboNormals);
-		}
-
-		if ((glParams.showColors || glParams.showSF) && s_vboColor == 0)
-		{
-			glFunc->glGenBuffers(1, &s_vboColor);
-		}
 
 		auto   vertices      = GetVertexBuffer();
 		float* normalIndexes = reinterpret_cast<float*>(GetNormalsBuffer());
@@ -2085,40 +2084,44 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 			// Vertex buffer
 			{
-				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVertex);
-				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(vertexCount * 3 * sizeof(PointCoordinateType)), vertices, GL_STREAM_DRAW);
+				s_vboVertex.bind();
+				s_vboVertex.write(0, vertices, static_cast<int>(vertexCount * 3 * sizeof(PointCoordinateType)));
 				glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_POS);
 				glFunc->glVertexAttribPointer(ccGLSL::ATTR_POS, 3, sizeof(PointCoordinateType) == 4 ? GL_FLOAT : GL_DOUBLE, GL_FALSE, 0, nullptr);
+				s_vboVertex.release();
 			}
 
 			// Normals
 			if (glParams.showNorms)
 			{
-				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboNormals);
-				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(normalCount * sizeof(float)), normalIndexes, GL_STREAM_DRAW);
+				s_vboNormals.bind();
+				s_vboNormals.write(0, normalIndexes, static_cast<int>(normalCount * sizeof(float)));
 				glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_NOR);
 				glFunc->glVertexAttribPointer(ccGLSL::ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+				s_vboNormals.release();
 			}
 
 			// Colors
 			if (glParams.showSF)
 			{
 				// colors are RGB unsigned bytes (3 components)
-				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
-				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCount * 3 * sizeof(unsigned char)), rgbColors, GL_STREAM_DRAW);
+				s_vboColor.bind();
+				s_vboColor.write(0, rgbColors, static_cast<int>(rgbColorCount * 3 * sizeof(unsigned char)));
 				glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_COL);
 				// we upload 3-component unsigned bytes; align to vec4 in shader by setting alpha = 1.0 via glVertexAttrib4f if needed
 				glFunc->glVertexAttribPointer(ccGLSL::ATTR_COL, 3, GL_UNSIGNED_BYTE, GL_TRUE, 0, nullptr);
 				// ensure alpha = 1.0 for all vertices
 				// Note: can't set alpha per-vertex when only 3 components provided; shader expects vec4 but attribute with 3 components will get implicit 1.0 as 4th component
+				s_vboColor.release();
 			}
 			else if (glParams.showColors)
 			{
 				// colors are RGBA unsigned bytes
-				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
-				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCount * 4 * sizeof(unsigned char)), rgbColors, GL_STREAM_DRAW);
+				s_vboColor.bind();
+				s_vboColor.write(0, rgbColors, static_cast<int>(rgbColorCount * 4 * sizeof(unsigned char)));
 				glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_COL);
 				glFunc->glVertexAttribPointer(ccGLSL::ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, nullptr);
+				s_vboColor.release();
 			}
 
 			// draw

--- a/libs/qCC_db/src/ccMesh.cpp
+++ b/libs/qCC_db/src/ccMesh.cpp
@@ -2086,7 +2086,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 			// Vertex buffer
 			{
 				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVertex);
-				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(vertexCount * 3 * sizeof(PointCoordinateType)), vertices, GL_DYNAMIC_DRAW);
+				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(vertexCount * 3 * sizeof(PointCoordinateType)), vertices, GL_STREAM_DRAW);
 				glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_POS);
 				glFunc->glVertexAttribPointer(ccGLSL::ATTR_POS, 3, sizeof(PointCoordinateType) == 4 ? GL_FLOAT : GL_DOUBLE, GL_FALSE, 0, nullptr);
 			}
@@ -2095,7 +2095,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 			if (glParams.showNorms)
 			{
 				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboNormals);
-				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(normalCount * sizeof(float)), normalIndexes, GL_DYNAMIC_DRAW);
+				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(normalCount * sizeof(float)), normalIndexes, GL_STREAM_DRAW);
 				glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_NOR);
 				glFunc->glVertexAttribPointer(ccGLSL::ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
 			}
@@ -2105,7 +2105,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 			{
 				// colors are RGB unsigned bytes (3 components)
 				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
-				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCount * 3 * sizeof(unsigned char)), rgbColors, GL_DYNAMIC_DRAW);
+				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCount * 3 * sizeof(unsigned char)), rgbColors, GL_STREAM_DRAW);
 				glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_COL);
 				// we upload 3-component unsigned bytes; align to vec4 in shader by setting alpha = 1.0 via glVertexAttrib4f if needed
 				glFunc->glVertexAttribPointer(ccGLSL::ATTR_COL, 3, GL_UNSIGNED_BYTE, GL_TRUE, 0, nullptr);
@@ -2116,7 +2116,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 			{
 				// colors are RGBA unsigned bytes
 				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
-				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCount * 4 * sizeof(unsigned char)), rgbColors, GL_DYNAMIC_DRAW);
+				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCount * 4 * sizeof(unsigned char)), rgbColors, GL_STREAM_DRAW);
 				glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_COL);
 				glFunc->glVertexAttribPointer(ccGLSL::ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, nullptr);
 			}

--- a/libs/qCC_db/src/ccMesh.cpp
+++ b/libs/qCC_db/src/ccMesh.cpp
@@ -1682,9 +1682,10 @@ static GLuint                                          s_vboNormals = 0;
 static GLuint                                          s_vboColor   = 0;
 
 // Attribute indexes that we bound when creating the programs
-static const GLuint ATTR_POS = 0;
-static const GLuint ATTR_NOR = 1;
-static const GLuint ATTR_COL = 2;
+static const GLuint ATTR_POS  = 0;
+static const GLuint ATTR_NOR  = 1;
+static const GLuint ATTR_COL  = 2;
+static const GLuint ATTR_CLIP = 4;
 
 void ccMesh::ReleaseOpenGLRessources()
 {
@@ -1720,8 +1721,8 @@ void ccMesh::ReleaseOpenGLRessources()
 	}
 }
 
-// Simple program builder (GLSL 1.20) for mesh rendering (position, normal, color)
-static QSharedPointer<QOpenGLShaderProgram> BuildSimpleMeshProgram(QOpenGLFunctions_2_1* glFunc, int attributes)
+// GLSL program builder (GLSL 1.20) for mesh rendering (position, normal, color)
+static QSharedPointer<QOpenGLShaderProgram> BuildMeshDisplayProgram(QOpenGLFunctions_2_1* glFunc, int attributes)
 {
 	if (!glFunc)
 	{
@@ -1734,9 +1735,56 @@ static QSharedPointer<QOpenGLShaderProgram> BuildSimpleMeshProgram(QOpenGLFuncti
 		return s_programs[attributes];
 	}
 
-	QString vertexProgSrc;
-	QString fragmentProgSrc;
+	// Vertex shaders
+	static const char* VertexProgHeaderSrc =
+	    "#version 120\n"
+	    "attribute vec3 aPosition;\n"
+	    "varying vec4 vColor;\n";
 
+	static const char* VertexProgColorAttributesSrc =
+	    "attribute vec4 aColor;\n";
+
+	static const char* VertexProgNormAttributesSrc =
+	    "attribute float aNormalIndex;\n"
+	    "varying vec3 vNormal;\n"
+	    "uniform sampler2D uNormalLUT;\n"
+	    "uniform int uLUTWidth;\n"
+	    "uniform int uLUTHeight;\n";
+
+	static const char* VertexProgFetchNormFuncSrc =
+	    "vec3 fetchNormalFromLUT(float fi)\n"
+	    "{\n"
+	    "	float w  = float(uLUTWidth);\n"
+	    "	float h  = float(uLUTHeight);\n"
+	    "	float tx = mod(fi, w);\n"
+	    "	float ty = floor(fi / w);\n"
+	    "	vec2 uv = vec2((tx + 0.5) / w, (ty + 0.5) / h);\n"
+	    "	vec3 enc = texture2D(uNormalLUT, uv).rgb;\n"
+	    "	vec3 n = enc * 2.0 - 1.0;\n"
+	    "	return normalize(n);\n"
+	    "}\n";
+
+	static const char* VertexProgMainStartSrc =
+	    "void main()\n"
+	    "{\n";
+
+	static const char* VertexProgMainUseDefaultGLColorSrc =
+	    "    vColor = gl_Color;\n";
+
+	static const char* VertexProgMainUseInputColorSrc =
+	    "    vColor = aColor;\n";
+
+	static const char* VertexProgMainFetchNormalSrc =
+	    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n";
+
+	static const char* VertexProgMainClippingSrc =
+	    "    gl_ClipVertex = gl_ModelViewMatrix * vec4(aPosition, 1.0);\n";
+
+	static const char* VertexProgMainEndSrc =
+	    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
+	    "}\n";
+
+	// Fragment shaders
 	static const char* ColorOnlyFragmentProgSrc =
 	    "#version 120\n"
 	    "varying vec4 vColor;\n"
@@ -1758,117 +1806,61 @@ static QSharedPointer<QOpenGLShaderProgram> BuildSimpleMeshProgram(QOpenGLFuncti
 	    "    gl_FragColor = vec4(base.rgb * diff, base.a);\n"
 	    "}\n";
 
-	switch (attributes)
+	QString vertexProgSrc = VertexProgHeaderSrc;
 	{
-	case ATTR_POS:
-		vertexProgSrc =
-		    "#version 120\n"
-		    "attribute vec3 aPosition;\n"
-		    "varying vec4 vColor;\n"
-		    "void main()\n"
-		    "{\n"
-		    "    vColor = gl_Color;\n"
-		    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
-		    "}\n";
+		// add attributes
+		if (attributes & ATTR_COL)
+			vertexProgSrc += VertexProgColorAttributesSrc;
+		if (attributes & ATTR_NOR)
+			vertexProgSrc += VertexProgNormAttributesSrc;
 
-		fragmentProgSrc = ColorOnlyFragmentProgSrc;
+		// add special functions
+		if (attributes & ATTR_NOR)
+		{
+			vertexProgSrc += VertexProgFetchNormFuncSrc;
+		}
 
-		break;
+		// main function
+		{
+			vertexProgSrc += VertexProgMainStartSrc;
 
-	case ATTR_COL:
-		vertexProgSrc =
-		    "#version 120\n"
-		    "attribute vec3 aPosition;\n"
-		    "attribute vec4 aColor;\n"
-		    "varying vec4 vColor;\n"
-		    "void main()\n"
-		    "{\n"
-		    "    vColor = aColor;\n"
-		    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
-		    "}\n";
+			// color transfer
+			if (attributes & ATTR_COL)
+			{
+				vertexProgSrc += VertexProgMainUseInputColorSrc;
+			}
+			else
+			{
+				vertexProgSrc += VertexProgMainUseDefaultGLColorSrc;
+			}
 
-		fragmentProgSrc = ColorOnlyFragmentProgSrc;
-		break;
+			// normal transfer (if any)
+			if (attributes & ATTR_NOR)
+			{
+				vertexProgSrc += VertexProgMainFetchNormalSrc;
+			}
 
-	case ATTR_NOR:
-		vertexProgSrc =
-		    "#version 120\n"
-		    "attribute vec3 aPosition;\n"
-		    "attribute float aNormalIndex;\n"
-		    "varying vec4 vColor;\n"
-		    "varying vec3 vNormal;\n"
-		    "uniform sampler2D uNormalLUT;\n"
-		    "uniform int uLUTWidth;\n"
-		    "uniform int uLUTHeight;\n"
-		    "vec3 fetchNormalFromLUT(float fi)\n"
-		    "{\n"
-		    "	float w  = float(uLUTWidth);\n"
-		    "	float h  = float(uLUTHeight);\n"
-		    "	float tx = mod(fi, w);\n"
-		    "	float ty = floor(fi / w);\n"
-		    "	vec2 uv = vec2((tx + 0.5) / w, (ty + 0.5) / h);\n"
-		    "	vec3 enc = texture2D(uNormalLUT, uv).rgb;\n"
-		    "	vec3 n = enc * 2.0 - 1.0;\n"
-		    "	return normalize(n);\n"
-		    "}\n"
-		    "void main()\n"
-		    "{\n"
-		    "    vColor = gl_Color;\n"
-		    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n"
-		    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
-		    "}\n";
+			if (attributes & ATTR_CLIP)
+			{
+				vertexProgSrc += VertexProgMainClippingSrc;
+			}
 
-		fragmentProgSrc = ColorAndNormalFragmentProgSrc;
-		break;
-
-	case (ATTR_COL | ATTR_NOR):
-		vertexProgSrc =
-		    "#version 120\n"
-		    "attribute vec3 aPosition;\n"
-		    "attribute float aNormalIndex;\n"
-		    "attribute vec4 aColor;\n"
-		    "varying vec4 vColor;\n"
-		    "varying vec3 vNormal;\n"
-		    "uniform sampler2D uNormalLUT;\n"
-		    "uniform int uLUTWidth;\n"
-		    "uniform int uLUTHeight;\n"
-		    "vec3 fetchNormalFromLUT(float fi)\n"
-		    "{\n"
-		    "	float w  = float(uLUTWidth);\n"
-		    "	float h  = float(uLUTHeight);\n"
-		    "	float tx = mod(fi, w);\n"
-		    "	float ty = floor(fi / w);\n"
-		    "	vec2 uv = vec2((tx + 0.5) / w, (ty + 0.5) / h);\n"
-		    "	vec3 enc = texture2D(uNormalLUT, uv).rgb;\n"
-		    "	vec3 n = enc * 2.0 - 1.0;\n"
-		    "	return normalize(n);\n"
-		    "}\n"
-		    "void main()\n"
-		    "{\n"
-		    "    vColor = aColor;\n"
-		    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n"
-		    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
-		    "}\n";
-
-		fragmentProgSrc = ColorAndNormalFragmentProgSrc;
-		break;
-
-	default:
-		assert(false);
-		ccLog::Warning("[BuildSimpleMeshProgram] Unsupported feature combination!");
-		return nullptr;
+			vertexProgSrc += VertexProgMainEndSrc;
+		}
 	}
+
+	QString fragmentProgSrc = (attributes & ATTR_NOR ? ColorAndNormalFragmentProgSrc : ColorOnlyFragmentProgSrc);
 
 	QOpenGLShader vertexShader(QOpenGLShader::Vertex);
 	if (false == vertexShader.compileSourceCode(vertexProgSrc))
 	{
-		ccLog::Warning(QString("[BuildSimpleMeshProgram] Vertex shader compilation failed: ") + vertexShader.log());
+		ccLog::Warning(QString("[BuildMeshDisplayProgram] Vertex shader compilation failed: ") + vertexShader.log());
 		return nullptr;
 	}
 	QOpenGLShader fragmentShader(QOpenGLShader::Fragment);
 	if (false == fragmentShader.compileSourceCode(fragmentProgSrc))
 	{
-		ccLog::Warning(QString("[BuildSimpleMeshProgram] Fragment shader compilation failed: ") + fragmentShader.log());
+		ccLog::Warning(QString("[BuildMeshDisplayProgram] Fragment shader compilation failed: ") + fragmentShader.log());
 		return nullptr;
 	}
 	QSharedPointer<QOpenGLShaderProgram> program(new QOpenGLShaderProgram);
@@ -1888,7 +1880,7 @@ static QSharedPointer<QOpenGLShaderProgram> BuildSimpleMeshProgram(QOpenGLFuncti
 
 	if (false == program->link())
 	{
-		ccLog::Warning(QString("[BuildSimpleMeshProgram] Shader program linking failed: ") + program->log());
+		ccLog::Warning(QString("[BuildMeshDisplayProgram] Shader program linking failed: ") + program->log());
 		return nullptr;
 	}
 
@@ -2105,8 +2097,13 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 		{
 			attributes |= ATTR_COL;
 		}
+		if (!m_clipPlanes.empty())
+		{
+			attributes |= ATTR_CLIP;
+		}
 
-		prog = BuildSimpleMeshProgram(glFunc, attributes);
+		prog = BuildMeshDisplayProgram(glFunc, attributes);
+
 		if (prog.isNull())
 		{
 			fallBackDisplay = true;
@@ -2122,6 +2119,9 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 				ccLog::Warning("Failed to create normals LUT texture! Cannot render fast normals.");
 				s_normalLUTTextureFailed = true;
 				fallBackDisplay          = true;
+
+				prog.clear();
+				fallBackDisplay = true;
 			}
 		}
 	}

--- a/libs/qCC_db/src/ccMesh.cpp
+++ b/libs/qCC_db/src/ccMesh.cpp
@@ -2083,7 +2083,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 	}
 
 	// normal acceleration texture (for fast normals display)
-	static bool s_normalLUTTextureFailed = false;
+	static bool                    s_normalLUTTextureFailed = false;
 	QSharedPointer<QOpenGLTexture> lutTex;
 
 	bool fallBackDisplay = (visFiltering
@@ -2129,9 +2129,9 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 	if (!fallBackDisplay)
 	{
 		assert(!entityPickingMode || !glParams.showSF);
-		assert(prog.isNull() == false);	
+		assert(prog.isNull() == false);
 
-			// static VBO handles reused between calls
+		// static VBO handles reused between calls
 		if (s_vboVertex == 0)
 		{
 			glFunc->glGenBuffers(1, &s_vboVertex);
@@ -2147,9 +2147,36 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 			glFunc->glGenBuffers(1, &s_vboColor);
 		}
 
-		auto   vertices  = GetVertexBuffer();
-		float* normals   = reinterpret_cast<float*>(GetNormalsBuffer());
-		auto   rgbColors = GetColorsBuffer();
+		auto   vertices      = GetVertexBuffer();
+		float* normalIndexes = reinterpret_cast<float*>(GetNormalsBuffer());
+		auto   rgbColors     = GetColorsBuffer();
+
+		prog->bind();
+
+		if (glParams.showNorms && lutTex)
+		{
+			// bind texture to unit 0
+			glFunc->glActiveTexture(GL_TEXTURE0);
+			glFunc->glBindTexture(GL_TEXTURE_2D, lutTex->textureId());
+
+			// set sampler uniform to unit 0
+			int locSampler = prog->uniformLocation("uNormalLUT");
+			if (locSampler >= 0)
+			{
+				glFunc->glUniform1i(locSampler, 0);
+			}
+			// set LUT dimensions
+			int locW = prog->uniformLocation("uLUTWidth");
+			if (locW >= 0)
+			{
+				glFunc->glUniform1i(locW, lutTex->width());
+			}
+			int locH = prog->uniformLocation("uLUTHeight");
+			if (locH >= 0)
+			{
+				glFunc->glUniform1i(locH, lutTex->height());
+			}
+		}
 
 		// we can scan and process each chunk separately in an optimized way
 		size_t chunkCount = ccChunk::Count(m_triVertIndexes->size());
@@ -2210,11 +2237,11 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 				}
 			}
 
-			// normals
+			// normals (indexes)
 			size_t normalCount = 0;
 			if (glParams.showNorms)
 			{
-				float* _normals = normals;
+				float* _normalIndexes = normalIndexes;
 				if (showTriNormals)
 				{
 					assert(m_triNormalIndexes);
@@ -2225,9 +2252,9 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 						assert(_triNormalIndexes->u[1] < static_cast<int>(m_triNormals->size()));
 						assert(_triNormalIndexes->u[2] < static_cast<int>(m_triNormals->size()));
 
-						*_normals++ = static_cast<float>(_triNormalIndexes->u[0] >= 0 ? m_triNormals->at(_triNormalIndexes->u[0]) : 0);
-						*_normals++ = static_cast<float>(_triNormalIndexes->u[1] >= 0 ? m_triNormals->at(_triNormalIndexes->u[1]) : 0);
-						*_normals++ = static_cast<float>(_triNormalIndexes->u[2] >= 0 ? m_triNormals->at(_triNormalIndexes->u[2]) : 0);
+						*_normalIndexes++ = static_cast<float>(_triNormalIndexes->u[0] >= 0 ? m_triNormals->at(_triNormalIndexes->u[0]) : 0);
+						*_normalIndexes++ = static_cast<float>(_triNormalIndexes->u[1] >= 0 ? m_triNormals->at(_triNormalIndexes->u[1]) : 0);
+						*_normalIndexes++ = static_cast<float>(_triNormalIndexes->u[2] >= 0 ? m_triNormals->at(_triNormalIndexes->u[2]) : 0);
 
 						normalCount += 3;
 					}
@@ -2240,9 +2267,9 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 						assert(_vertIndexes->i1 < normalsIndexesTable->size());
 						assert(_vertIndexes->i2 < normalsIndexesTable->size());
 						assert(_vertIndexes->i3 < normalsIndexesTable->size());
-						*_normals++ = static_cast<float>(normalsIndexesTable->at(_vertIndexes->i1));
-						*_normals++ = static_cast<float>(normalsIndexesTable->at(_vertIndexes->i2));
-						*_normals++ = static_cast<float>(normalsIndexesTable->at(_vertIndexes->i3));
+						*_normalIndexes++ = static_cast<float>(normalsIndexesTable->at(_vertIndexes->i1));
+						*_normalIndexes++ = static_cast<float>(normalsIndexesTable->at(_vertIndexes->i2));
+						*_normalIndexes++ = static_cast<float>(normalsIndexesTable->at(_vertIndexes->i3));
 
 						normalCount += 3;
 					}
@@ -2250,48 +2277,22 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 			}
 
 			// Upload to VBOs and draw with shader
-			prog->bind();
-
-			// Normals
-			if (glParams.showNorms)
-			{
-				// If not done already, create the LUT texture and bind it to unit 0
-				assert(!lutTex.isNull());
-
-				// bind texture to unit 0
-				glFunc->glActiveTexture(GL_TEXTURE0);
-				glFunc->glBindTexture(GL_TEXTURE_2D, lutTex->textureId());
-
-				// set sampler uniform to unit 0
-				int locSampler = prog->uniformLocation("uNormalLUT");
-				if (locSampler >= 0)
-				{
-					glFunc->glUniform1i(locSampler, 0);
-				}
-				// set LUT dimensions
-				int locW = prog->uniformLocation("uLUTWidth");
-				if (locW >= 0)
-				{
-					glFunc->glUniform1i(locW, lutTex->width());
-				}
-				int locH = prog->uniformLocation("uLUTHeight");
-				if (locH >= 0)
-				{
-					glFunc->glUniform1i(locH, lutTex->height());
-				}
-
-				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboNormals);
-				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(normalCount * sizeof(float)), normals, GL_DYNAMIC_DRAW);
-				glFunc->glEnableVertexAttribArray(ATTR_NOR);
-				glFunc->glVertexAttribPointer(ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, reinterpret_cast<void*>(0));
-			}
 
 			// Vertex buffer
 			{
 				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVertex);
 				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(vertexCount * 3 * sizeof(PointCoordinateType)), vertices, GL_DYNAMIC_DRAW);
 				glFunc->glEnableVertexAttribArray(ATTR_POS);
-				glFunc->glVertexAttribPointer(ATTR_POS, 3, sizeof(PointCoordinateType) == 4 ? GL_FLOAT : GL_DOUBLE, GL_FALSE, 0, reinterpret_cast<void*>(0));
+				glFunc->glVertexAttribPointer(ATTR_POS, 3, sizeof(PointCoordinateType) == 4 ? GL_FLOAT : GL_DOUBLE, GL_FALSE, 0, nullptr);
+			}
+
+			// Normals
+			if (glParams.showNorms)
+			{
+				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboNormals);
+				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(normalCount * sizeof(float)), normalIndexes, GL_DYNAMIC_DRAW);
+				glFunc->glEnableVertexAttribArray(ATTR_NOR);
+				glFunc->glVertexAttribPointer(ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
 			}
 
 			// Colors
@@ -2302,7 +2303,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCount * 3 * sizeof(unsigned char)), rgbColors, GL_DYNAMIC_DRAW);
 				glFunc->glEnableVertexAttribArray(ATTR_COL);
 				// we upload 3-component unsigned bytes; align to vec4 in shader by setting alpha = 1.0 via glVertexAttrib4f if needed
-				glFunc->glVertexAttribPointer(ATTR_COL, 3, GL_UNSIGNED_BYTE, GL_TRUE, 0, reinterpret_cast<void*>(0));
+				glFunc->glVertexAttribPointer(ATTR_COL, 3, GL_UNSIGNED_BYTE, GL_TRUE, 0, nullptr);
 				// ensure alpha = 1.0 for all vertices
 				// Note: can't set alpha per-vertex when only 3 components provided; shader expects vec4 but attribute with 3 components will get implicit 1.0 as 4th component
 			}
@@ -2312,7 +2313,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
 				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(rgbColorCount * 4 * sizeof(unsigned char)), rgbColors, GL_DYNAMIC_DRAW);
 				glFunc->glEnableVertexAttribArray(ATTR_COL);
-				glFunc->glVertexAttribPointer(ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, reinterpret_cast<void*>(0));
+				glFunc->glVertexAttribPointer(ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, nullptr);
 			}
 
 			// draw
@@ -2330,7 +2331,6 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 			if (glParams.showNorms)
 			{
 				glFunc->glDisableVertexAttribArray(ATTR_NOR);
-				glFunc->glBindTexture(GL_TEXTURE_2D, 0);
 			}
 			if (glParams.showSF || glParams.showColors)
 			{
@@ -2339,10 +2339,15 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 			// unbind array buffer
 			glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);
-			prog->release();
 
 			ccGLDrawContext::CatchGLErrors(glFunc->glGetError(), "ccMesh::shader.program.end");
 		}
+
+		if (glParams.showNorms)
+		{
+			glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+		}
+		prog->release();
 	}
 	else
 	{

--- a/libs/qCC_db/src/ccMesh.cpp
+++ b/libs/qCC_db/src/ccMesh.cpp
@@ -23,6 +23,7 @@
 // Local
 #include "ccChunk.h"
 #include "ccColorScalesManager.h"
+#include "ccGLSLHelper.h"
 #include "ccGenericGLDisplay.h"
 #include "ccGenericPointCloud.h"
 #include "ccHObjectCaster.h"
@@ -2113,7 +2114,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 			assert(!s_normalLUTTextureFailed);
 
 			// create or retrieve the LUT texture
-			lutTex = ccNormalVectors::GetNormalLUTTexture(glFunc);
+			lutTex = ccGLSL::GetNormalLUTTexture(glFunc);
 			if (lutTex.isNull())
 			{
 				ccLog::Warning("Failed to create normals LUT texture! Cannot render fast normals.");
@@ -2159,23 +2160,7 @@ void ccMesh::drawMeOnly(CC_DRAW_CONTEXT& context)
 			glFunc->glActiveTexture(GL_TEXTURE0);
 			glFunc->glBindTexture(GL_TEXTURE_2D, lutTex->textureId());
 
-			// set sampler uniform to unit 0
-			int locSampler = prog->uniformLocation("uNormalLUT");
-			if (locSampler >= 0)
-			{
-				glFunc->glUniform1i(locSampler, 0);
-			}
-			// set LUT dimensions
-			int locW = prog->uniformLocation("uLUTWidth");
-			if (locW >= 0)
-			{
-				glFunc->glUniform1i(locW, lutTex->width());
-			}
-			int locH = prog->uniformLocation("uLUTHeight");
-			if (locH >= 0)
-			{
-				glFunc->glUniform1i(locH, lutTex->height());
-			}
+			ccGLSL::SetLUTTextureUniforms(glFunc, prog.data(), lutTex.data());
 		}
 
 		// we can scan and process each chunk separately in an optimized way

--- a/libs/qCC_db/src/ccNormalVectors.cpp
+++ b/libs/qCC_db/src/ccNormalVectors.cpp
@@ -19,6 +19,7 @@
 
 // Local
 #include "ccHObjectCaster.h"
+#include "ccMaterialDB.h"
 #include "ccNormalCompressor.h"
 #include "ccSensor.h"
 #include "ccSingleton.h"
@@ -853,4 +854,93 @@ ccColor::Rgb ccNormalVectors::ConvertNormalToRGB(const CCVector3& N)
 	return ccColor::Rgb(static_cast<ColorCompType>(col.r * ccColor::MAX),
 	                    static_cast<ColorCompType>(col.g * ccColor::MAX),
 	                    static_cast<ColorCompType>(col.b * ccColor::MAX));
+}
+
+QSharedPointer<QOpenGLTexture> ccNormalVectors::CreateNormalLUTTexture(QOpenGLFunctions_2_1* gl)
+{
+	if (!gl)
+	{
+		assert(false);
+		return nullptr;
+	}
+
+	const unsigned totalNormals = ccNormalCompressor::MAX_VALID_NORM_CODE + 1; // number of valid codes
+	// Query max texture size
+	GLint maxTexSize = 0;
+	gl->glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTexSize);
+	if (maxTexSize <= 0)
+	{
+		return nullptr;
+	}
+
+	// choose width as large as possible (but <= maxTexSize) to minimize height
+	int width  = std::min(static_cast<int>(totalNormals), maxTexSize);
+	int height = static_cast<int>(std::ceil(static_cast<float>(totalNormals) / float(width)));
+
+	const size_t texels = static_cast<size_t>(width) * static_cast<size_t>(height);
+
+	// buffer RGB unsigned bytes
+	std::vector<unsigned char> pixels;
+	try
+	{
+		pixels.resize(texels * 3);
+	}
+	catch (const std::bad_alloc&)
+	{
+		ccLog::Warning("[ccMesh::CreateNormalLUTTexture] Not enough memory");
+		return nullptr;
+	}
+
+	// fill: for each index, call ccNormalCompressor::Decompress
+	for (unsigned i = 0; i < totalNormals; ++i)
+	{
+		CCVector3 n = ccNormalVectors::GetNormal(i);
+
+		// map [-1,1] -> [0,255]
+		// handle NULL_NORM_CODE: Decompress sets to 0, so it becomes 127 -> you can change if needed
+		pixels[i * 3 + 0] = static_cast<unsigned char>(std::round(std::clamp((n.x * 0.5 + 0.5), 0.0, 1.0) * 255.0));
+		pixels[i * 3 + 1] = static_cast<unsigned char>(std::round(std::clamp((n.y * 0.5 + 0.5), 0.0, 1.0) * 255.0));
+		pixels[i * 3 + 2] = static_cast<unsigned char>(std::round(std::clamp((n.z * 0.5 + 0.5), 0.0, 1.0) * 255.0));
+	}
+
+	// generate GL texture
+	QSharedPointer<QOpenGLTexture> tex(new QOpenGLTexture(QOpenGLTexture::Target2D));
+
+	// configure texture
+	tex->setFormat(QOpenGLTexture::RGB8_UNorm);
+	tex->setSize(width, height);
+	tex->allocateStorage();
+	tex->setWrapMode(QOpenGLTexture::ClampToEdge);
+	tex->setMinificationFilter(QOpenGLTexture::Nearest);
+	tex->setMagnificationFilter(QOpenGLTexture::Nearest);
+
+	// upload data
+	tex->setData(QOpenGLTexture::RGB, QOpenGLTexture::UInt8, pixels.data());
+
+	return tex;
+}
+
+QSharedPointer<QOpenGLTexture> ccNormalVectors::GetNormalLUTTexture(QOpenGLFunctions_2_1* glFunc)
+{
+	// If not done already, create the LUT texture and bind it to unit 0
+	if (nullptr == ccMaterial::GetTextureDB())
+	{
+		assert(false);
+		return nullptr;
+	}
+
+	QSharedPointer<QOpenGLTexture> lutTex = ccMaterial::GetTextureDB()->getOpenGLTexture("CompressedNormalsLUT");
+	if (!lutTex.isNull())
+	{
+		return lutTex;
+	}
+
+	// try to create it if necessary
+	lutTex = ccNormalVectors::CreateNormalLUTTexture(glFunc);
+	if (!lutTex.isNull())
+	{
+		ccMaterial::GetTextureDB()->addOpenGLTexture("CompressedNormalsLUT", lutTex);
+	}
+
+	return lutTex;
 }

--- a/libs/qCC_db/src/ccNormalVectors.cpp
+++ b/libs/qCC_db/src/ccNormalVectors.cpp
@@ -19,7 +19,6 @@
 
 // Local
 #include "ccHObjectCaster.h"
-#include "ccMaterialDB.h"
 #include "ccNormalCompressor.h"
 #include "ccSensor.h"
 #include "ccSingleton.h"
@@ -854,93 +853,4 @@ ccColor::Rgb ccNormalVectors::ConvertNormalToRGB(const CCVector3& N)
 	return ccColor::Rgb(static_cast<ColorCompType>(col.r * ccColor::MAX),
 	                    static_cast<ColorCompType>(col.g * ccColor::MAX),
 	                    static_cast<ColorCompType>(col.b * ccColor::MAX));
-}
-
-QSharedPointer<QOpenGLTexture> ccNormalVectors::CreateNormalLUTTexture(QOpenGLFunctions_2_1* glFunc)
-{
-	if (!glFunc)
-	{
-		assert(false);
-		return nullptr;
-	}
-
-	const unsigned totalNormals = ccNormalCompressor::MAX_VALID_NORM_CODE + 1; // number of valid codes
-	// Query max texture size
-	GLint maxTexSize = 0;
-	glFunc->glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTexSize);
-	if (maxTexSize <= 0)
-	{
-		return nullptr;
-	}
-
-	// choose width as large as possible (but <= maxTexSize) to minimize height
-	int width  = std::min(static_cast<int>(totalNormals), maxTexSize);
-	int height = static_cast<int>(std::ceil(static_cast<float>(totalNormals) / float(width)));
-
-	const size_t texels = static_cast<size_t>(width) * static_cast<size_t>(height);
-
-	// buffer RGB unsigned bytes
-	std::vector<unsigned char> pixels;
-	try
-	{
-		pixels.resize(texels * 3);
-	}
-	catch (const std::bad_alloc&)
-	{
-		ccLog::Warning("[ccMesh::CreateNormalLUTTexture] Not enough memory");
-		return nullptr;
-	}
-
-	// fill: for each index, call ccNormalCompressor::Decompress
-	for (unsigned i = 0; i < totalNormals; ++i)
-	{
-		CCVector3 n = ccNormalVectors::GetNormal(i);
-
-		// map [-1,1] -> [0,255]
-		// handle NULL_NORM_CODE: Decompress sets to 0, so it becomes 127 -> you can change if needed
-		pixels[i * 3 + 0] = static_cast<unsigned char>(std::round(std::clamp((n.x * 0.5 + 0.5), 0.0, 1.0) * 255.0));
-		pixels[i * 3 + 1] = static_cast<unsigned char>(std::round(std::clamp((n.y * 0.5 + 0.5), 0.0, 1.0) * 255.0));
-		pixels[i * 3 + 2] = static_cast<unsigned char>(std::round(std::clamp((n.z * 0.5 + 0.5), 0.0, 1.0) * 255.0));
-	}
-
-	// generate GL texture
-	QSharedPointer<QOpenGLTexture> tex(new QOpenGLTexture(QOpenGLTexture::Target2D));
-
-	// configure texture
-	tex->setFormat(QOpenGLTexture::RGB8_UNorm);
-	tex->setSize(width, height);
-	tex->allocateStorage();
-	tex->setWrapMode(QOpenGLTexture::ClampToEdge);
-	tex->setMinificationFilter(QOpenGLTexture::Nearest);
-	tex->setMagnificationFilter(QOpenGLTexture::Nearest);
-
-	// upload data
-	tex->setData(QOpenGLTexture::RGB, QOpenGLTexture::UInt8, pixels.data());
-
-	return tex;
-}
-
-QSharedPointer<QOpenGLTexture> ccNormalVectors::GetNormalLUTTexture(QOpenGLFunctions_2_1* glFunc)
-{
-	// If not done already, create the LUT texture and bind it to unit 0
-	if (nullptr == ccMaterial::GetTextureDB())
-	{
-		assert(false);
-		return nullptr;
-	}
-
-	QSharedPointer<QOpenGLTexture> lutTex = ccMaterial::GetTextureDB()->getOpenGLTexture("CompressedNormalsLUT");
-	if (!lutTex.isNull())
-	{
-		return lutTex;
-	}
-
-	// try to create it if necessary
-	lutTex = ccNormalVectors::CreateNormalLUTTexture(glFunc);
-	if (!lutTex.isNull())
-	{
-		ccMaterial::GetTextureDB()->addOpenGLTexture("CompressedNormalsLUT", lutTex);
-	}
-
-	return lutTex;
 }

--- a/libs/qCC_db/src/ccNormalVectors.cpp
+++ b/libs/qCC_db/src/ccNormalVectors.cpp
@@ -856,9 +856,9 @@ ccColor::Rgb ccNormalVectors::ConvertNormalToRGB(const CCVector3& N)
 	                    static_cast<ColorCompType>(col.b * ccColor::MAX));
 }
 
-QSharedPointer<QOpenGLTexture> ccNormalVectors::CreateNormalLUTTexture(QOpenGLFunctions_2_1* gl)
+QSharedPointer<QOpenGLTexture> ccNormalVectors::CreateNormalLUTTexture(QOpenGLFunctions_2_1* glFunc)
 {
-	if (!gl)
+	if (!glFunc)
 	{
 		assert(false);
 		return nullptr;
@@ -867,7 +867,7 @@ QSharedPointer<QOpenGLTexture> ccNormalVectors::CreateNormalLUTTexture(QOpenGLFu
 	const unsigned totalNormals = ccNormalCompressor::MAX_VALID_NORM_CODE + 1; // number of valid codes
 	// Query max texture size
 	GLint maxTexSize = 0;
-	gl->glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTexSize);
+	glFunc->glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTexSize);
 	if (maxTexSize <= 0)
 	{
 		return nullptr;

--- a/libs/qCC_db/src/ccOctree.cpp
+++ b/libs/qCC_db/src/ccOctree.cpp
@@ -209,9 +209,9 @@ void ccOctree::draw(CC_DRAW_CONTEXT& context, ccColor::Rgb* pickingColor /*=null
 
 			if (m_displayMode == MEAN_POINTS)
 			{
-				void* additionalParameters[] = {reinterpret_cast<void*>(&glParams),
-				                                reinterpret_cast<void*>(m_theAssociatedCloudAsGPC),
-				                                reinterpret_cast<void*>(glFunc)};
+				void* additionalParameters[]{reinterpret_cast<void*>(&glParams),
+				                             reinterpret_cast<void*>(m_theAssociatedCloudAsGPC),
+				                             reinterpret_cast<void*>(glFunc)};
 
 				if (glParams.showNorms)
 				{
@@ -254,13 +254,13 @@ void ccOctree::draw(CC_DRAW_CONTEXT& context, ccColor::Rgb* pickingColor /*=null
 
 				// fake context
 				CC_DRAW_CONTEXT fakeContext = context;
-				fakeContext.drawingFlags    = CC_DRAW_3D | CC_DRAW_FOREGROUND | CC_LIGHT_ENABLED;
+				fakeContext.drawingFlags    = CC_DRAW_3D | CC_DRAW_FOREGROUND | CC_LIGHT_ENABLED | CC_NO_SHADER;
 				fakeContext.display         = nullptr;
 
-				void* additionalParameters[] = {reinterpret_cast<void*>(&glParams),
-				                                reinterpret_cast<void*>(m_theAssociatedCloudAsGPC),
-				                                reinterpret_cast<void*>(&box),
-				                                reinterpret_cast<void*>(&fakeContext)};
+				void* additionalParameters[]{reinterpret_cast<void*>(&glParams),
+				                             reinterpret_cast<void*>(m_theAssociatedCloudAsGPC),
+				                             reinterpret_cast<void*>(&box),
+				                             reinterpret_cast<void*>(&fakeContext)};
 
 				executeFunctionForAllCellsAtLevel(m_displayedLevel,
 				                                  &DrawCellAsAPrimitive,

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -5442,42 +5442,6 @@ CCCoreLib::ReferenceCloud* ccPointCloud::crop2D(const ccPolyline* poly, unsigned
 	return ref;
 }
 
-static bool CatchGLErrors(GLenum err, const char* context)
-{
-	// catch GL errors
-	{
-		// see http://www.opengl.org/sdk/docs/man/xhtml/glGetError.xml
-		switch (err)
-		{
-		case GL_NO_ERROR:
-			return false;
-		case GL_INVALID_ENUM:
-			ccLog::Warning("[%s] OpenGL error: invalid enumerator", context);
-			break;
-		case GL_INVALID_VALUE:
-			ccLog::Warning("[%s] OpenGL error: invalid value", context);
-			break;
-		case GL_INVALID_OPERATION:
-			ccLog::Warning("[%s] OpenGL error: invalid operation", context);
-			break;
-		case GL_STACK_OVERFLOW:
-			ccLog::Warning("[%s] OpenGL error: stack overflow", context);
-			break;
-		case GL_STACK_UNDERFLOW:
-			ccLog::Warning("[%s] OpenGL error: stack underflow", context);
-			break;
-		case GL_OUT_OF_MEMORY:
-			ccLog::Warning("[%s] OpenGL error: out of memory", context);
-			break;
-		case GL_INVALID_FRAMEBUFFER_OPERATION:
-			ccLog::Warning("[%s] OpenGL error: invalid framebuffer operation", context);
-			break;
-		}
-	}
-
-	return true;
-}
-
 // DGM: normals are so slow to display that it's a waste of memory and time to load them in VBOs!
 #define DONT_LOAD_NORMALS_IN_VBOS
 
@@ -5606,7 +5570,7 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 			QOpenGLFunctions_2_1* glFunc = context.glFunctions<QOpenGLFunctions_2_1>();
 			if (glFunc)
 			{
-				CatchGLErrors(glFunc->glGetError(), "ccPointCloud::vbo.init");
+				ccGLDrawContext::CatchGLErrors(glFunc->glGetError(), "ccPointCloud::vbo.init");
 			}
 
 			if (vboSizeBytes > 0)
@@ -5696,7 +5660,7 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 				// if an error is detected
 				QOpenGLFunctions_2_1* glFunc = context.glFunctions<QOpenGLFunctions_2_1>();
 				assert(glFunc != nullptr);
-				if (CatchGLErrors(glFunc->glGetError(), "ccPointCloud::updateVBOs"))
+				if (ccGLDrawContext::CatchGLErrors(glFunc->glGetError(), "ccPointCloud::updateVBOs"))
 				{
 					vboSizeBytes = -1;
 				}

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -2762,6 +2762,10 @@ static const GLuint ATTR_POS = 0;
 static const GLuint ATTR_NOR = 1;
 static const GLuint ATTR_COL = 2;
 static const GLuint ATTR_SF  = 4;
+// For internal use only
+static const GLuint ATTR_LOG_SCALE  = 8;
+static const GLuint ATTR_SYM_SCALE  = 16;
+static const GLuint ATTR_HIDDEN_VAL = 32;
 
 // Global OpenGL resources
 static QMap<int, QSharedPointer<QOpenGLShaderProgram>> s_programs;
@@ -3294,6 +3298,29 @@ static QSharedPointer<QOpenGLShaderProgram> BuildCloudDisplayProgram(QOpenGLFunc
 		return nullptr;
 	}
 
+	// add secondary attributes
+	if (attributes & ATTR_SF)
+	{
+		if (!sf)
+		{
+			assert(false);
+			return nullptr;
+		}
+
+		if (sf->logScale())
+		{
+			attributes |= ATTR_LOG_SCALE;
+		}
+		else if (sf->symmetricalScale())
+		{
+			attributes |= ATTR_SYM_SCALE;
+		}
+		if (!sf->areNaNValuesShownInGrey())
+		{
+			attributes |= ATTR_HIDDEN_VAL;
+		}
+	}
+
 	if (s_programs.contains(attributes))
 	{
 		return s_programs[attributes];
@@ -3343,10 +3370,6 @@ static QSharedPointer<QOpenGLShaderProgram> BuildCloudDisplayProgram(QOpenGLFunc
 	static const char* VertexProgFetchSFColorFuncSrc =
 	    "vec4 fetchColorFromTex(float sfVal)\n"
 	    "{\n"
-	    "   if (sfVal < uMinVal)\n"
-	    "       return vec4(uOutOfRangeGreyScale, uOutOfRangeGreyScale, uOutOfRangeGreyScale, 1.0);\n"
-	    "   if (sfVal > uMaxVal)\n"
-	    "       return vec4(uOutOfRangeGreyScale, uOutOfRangeGreyScale, uOutOfRangeGreyScale, 1.0);\n"
 	    "   float v = normalizeSFVal(sfVal);\n"
 	    "   v = v * float(uTexWidth * uTexHeight - 1);\n"
 	    "	float w  = float(uTexWidth);\n"
@@ -3409,7 +3432,25 @@ static QSharedPointer<QOpenGLShaderProgram> BuildCloudDisplayProgram(QOpenGLFunc
 	    "    vColor = aColor;\n";
 
 	static const char* VertexProgMainFetchSFColorSrc =
-	    "    vColor = fetchColorFromTex(aSFValue);\n";
+	    "   if (aSFValue >= uMinVal && aSFValue <= uMaxVal)\n"
+	    "   {\n"
+	    "      vColor = fetchColorFromTex(aSFValue);\n"
+	    "   }\n"
+	    "   else\n"
+	    "   {\n"
+	    "      vColor = vec4(uOutOfRangeGreyScale, uOutOfRangeGreyScale, uOutOfRangeGreyScale, 1.0);\n"
+	    "   }\n";
+
+	static const char* VertexProgMainFetchSFColorHideNaNSrc =
+	    "   if (aSFValue >= uMinVal && aSFValue <= uMaxVal)\n"
+	    "   {\n"
+	    "      vColor = fetchColorFromTex(aSFValue);\n"
+	    "   }\n"
+	    "   else\n"
+	    "   {\n"
+	    "      gl_Position = vec4(0, 0, 0, -1.0);\n" // impossible position, should be discarded by the GPU
+	    "      return;\n"
+	    "   }\n";
 
 	static const char* VertexProgMainFetchNormalSrc =
 	    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n";
@@ -3453,13 +3494,13 @@ static QSharedPointer<QOpenGLShaderProgram> BuildCloudDisplayProgram(QOpenGLFunc
 		// add special functions
 		if (attributes & ATTR_SF)
 		{
-			if (sf->logScale())
+			if (attributes & ATTR_LOG_SCALE)
 			{
 				vertexProgSrc += NormalizeValueLogScaleFuncSrc;
 			}
 			else
 			{
-				vertexProgSrc += (sf->symmetricalScale() ? NormalizeSymmetricalValueFuncSrc : NormalizeNonSymmetricalValueFuncSrc);
+				vertexProgSrc += ((attributes & ATTR_SYM_SCALE) ? NormalizeSymmetricalValueFuncSrc : NormalizeNonSymmetricalValueFuncSrc);
 			}
 			vertexProgSrc += VertexProgFetchSFColorFuncSrc;
 		}
@@ -3475,15 +3516,23 @@ static QSharedPointer<QOpenGLShaderProgram> BuildCloudDisplayProgram(QOpenGLFunc
 
 			// color transfer
 			if (attributes & ATTR_SF)
-				vertexProgSrc += VertexProgMainFetchSFColorSrc;
+			{
+				vertexProgSrc += ((attributes & ATTR_HIDDEN_VAL) ? VertexProgMainFetchSFColorHideNaNSrc : VertexProgMainFetchSFColorSrc);
+			}
 			else if (attributes & ATTR_COL)
+			{
 				vertexProgSrc += VertexProgMainUseInputColorSrc;
+			}
 			else
+			{
 				vertexProgSrc += VertexProgMainUseDefaultGLColorSrc;
+			}
 
 			// normal transfer (if any)
 			if (attributes & ATTR_NOR)
+			{
 				vertexProgSrc += VertexProgMainFetchNormalSrc;
+			}
 
 			vertexProgSrc += VertexProgMainEndSrc;
 		}
@@ -3830,186 +3879,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 			glFunc->glEnd();
 		}
-		else if (glParams.showSF
-		         && m_currentDisplayedScalarField
-		         && m_currentDisplayedScalarField->mayHaveHiddenValues()) // no visibility table enabled but scalar field with hidden points/values
-		{
-			// color ramp shader initialization
-			ccColorRampShader* colorRampShader = context.colorRampShader;
-			{
-				// FIXME: color ramp shader doesn't support log scale yet!
-				if (m_currentDisplayedScalarField->logScale())
-				{
-					colorRampShader = nullptr;
-				}
-				// the shader can't be used during color-based color picking
-				if (entityPickingMode)
-				{
-					colorRampShader = nullptr;
-				}
-			}
-
-			const ccScalarField::Range& sfDisplayRange    = m_currentDisplayedScalarField->displayRange();
-			const ccScalarField::Range& sfSaturationRange = m_currentDisplayedScalarField->saturationRange();
-			const bool                  symmetricalScale  = m_currentDisplayedScalarField->symmetricalScale();
-
-			if (colorRampShader)
-			{
-				// max available space for fragment's shader uniforms
-				GLint maxBytes = 0;
-				glFunc->glGetIntegerv(GL_MAX_FRAGMENT_UNIFORM_COMPONENTS, &maxBytes);
-				GLint    maxComponents = (maxBytes >> 2) - 4; // leave space for the other uniforms!
-				unsigned steps         = m_currentDisplayedScalarField->getColorRampSteps();
-				assert(steps != 0);
-
-				if (steps > ccColorRampShader::MaxColorRampSize() || maxComponents < static_cast<GLint>(steps))
-				{
-					ccLog::WarningDebug("Color ramp steps exceed shader limits!");
-					colorRampShader = nullptr;
-				}
-				else
-				{
-					float sfMinSatRel = 0.0f;
-					float sfMaxSatRel = 1.0f;
-					if (!m_currentDisplayedScalarField->symmetricalScale())
-					{
-						sfMinSatRel = GetNormalizedValue(sfSaturationRange.start(), sfDisplayRange); // doesn't need to be between 0 and 1!
-						sfMaxSatRel = GetNormalizedValue(sfSaturationRange.stop(), sfDisplayRange);  // doesn't need to be between 0 and 1!
-					}
-					else
-					{
-						// we can only handle 'maximum' saturation
-						sfMinSatRel = GetSymmetricalNormalizedValue(-sfSaturationRange.stop(), sfSaturationRange);
-						sfMaxSatRel = GetSymmetricalNormalizedValue(sfSaturationRange.stop(), sfSaturationRange);
-						// we'll have to handle the 'minimum' saturation manually!
-					}
-
-					const ccColorScale::Shared& colorScale = m_currentDisplayedScalarField->getColorScale();
-					assert(colorScale);
-
-					colorRampShader->bind();
-					if (!colorRampShader->setup(glFunc, sfMinSatRel, sfMaxSatRel, steps, colorScale))
-					{
-						// An error occurred during shader initialization?
-						ccLog::WarningDebug("Failed to init ColorRamp shader!");
-						colorRampShader->release();
-						colorRampShader = nullptr;
-					}
-					else if (glParams.showNorms)
-					{
-						// we must get rid of lights material (other than ambient) for the red and green fields
-						glFunc->glPushAttrib(GL_LIGHTING_BIT);
-
-						// we use the ambient light to pass the scalar value (and 'grayed' marker) without any
-						// modification from the GPU pipeline, even if normals are enabled!
-						glFunc->glDisable(GL_COLOR_MATERIAL);
-						glFunc->glColorMaterial(GL_FRONT_AND_BACK, GL_DIFFUSE);
-						glFunc->glColorMaterial(GL_FRONT_AND_BACK, GL_AMBIENT);
-						glFunc->glEnable(GL_COLOR_MATERIAL);
-
-						GLint maxLightCount;
-						glFunc->glGetIntegerv(GL_MAX_LIGHTS, &maxLightCount);
-						for (GLint i = 0; i < maxLightCount; ++i)
-						{
-							if (glFunc->glIsEnabled(GL_LIGHT0 + i))
-							{
-								float diffuse[4];
-								float ambiant[4];
-								float specular[4];
-
-								glFunc->glGetLightfv(GL_LIGHT0 + i, GL_AMBIENT, ambiant);
-								glFunc->glGetLightfv(GL_LIGHT0 + i, GL_DIFFUSE, diffuse);
-								glFunc->glGetLightfv(GL_LIGHT0 + i, GL_SPECULAR, specular);
-
-								ambiant[0] = ambiant[1] = 1.0f;
-								diffuse[0] = diffuse[1] = 0.0f;
-								specular[0] = specular[1] = 0.0f;
-
-								glFunc->glLightfv(GL_LIGHT0 + i, GL_DIFFUSE, diffuse);
-								glFunc->glLightfv(GL_LIGHT0 + i, GL_AMBIENT, ambiant);
-								glFunc->glLightfv(GL_LIGHT0 + i, GL_SPECULAR, specular);
-							}
-						}
-					}
-				}
-			}
-
-			glFunc->glBegin(GL_POINTS);
-
-			if (entityPickingMode)
-			{
-				for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-				{
-					unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-					assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-					const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
-					if (col) // is the point visible?
-					{
-						// for entity picking, don't change the color, we just need to know whether the point is visible
-						ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-					}
-				}
-			}
-			else
-			{
-				// compressed normals set
-				const ccNormalVectors* compressedNormals = ccNormalVectors::GetUniqueInstance();
-				assert(compressedNormals);
-
-				if (colorRampShader)
-				{
-					for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-					{
-						unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-						assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-						const ScalarType sfVal = m_currentDisplayedScalarField->getValue(pointIndex);
-						if (sfDisplayRange.isInRange(sfVal)) // NaN values are rejected
-						{
-							glFunc->glColor3f(symmetricalScale ? GetSymmetricalNormalizedValue(sfVal, sfSaturationRange)
-							                                   : GetNormalizedValue(sfVal, sfDisplayRange),
-							                  1.0f,
-							                  1.0f);
-							if (glParams.showNorms)
-							{
-								ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
-							}
-							ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-						}
-					}
-				}
-				else // no color ramp shader
-				{
-					for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-					{
-						unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-						assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-						const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
-						if (col) // is the point visible?
-						{
-							ccGL::Color(glFunc, *col);
-							if (glParams.showNorms)
-							{
-								ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
-							}
-							ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-						}
-					}
-				}
-			}
-
-			glFunc->glEnd();
-
-			if (colorRampShader)
-			{
-				colorRampShader->release();
-
-				if (glParams.showNorms)
-				{
-					glFunc->glPopAttrib(); // GL_LIGHTING_BIT
-				}
-			}
-		}
-		else // no visibility table enabled, no scalar field or scalar field with no hidden values
+		else // no visibility table enabled
 		{
 			size_t chunkCount = ccChunk::Count(m_points);
 
@@ -4022,8 +3892,9 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 			QSharedPointer<QOpenGLTexture> lutTex;
 
 			QSharedPointer<QOpenGLShaderProgram> prog;
-			if ((glParams.showSF || glParams.showNorms)
-			    && (false == s_normalLUTTextureFailed)
+			if (/*(glParams.showSF || glParams.showNorms)
+			    &&*/
+			    (false == s_normalLUTTextureFailed)
 			    && (false == s_globalVBOCreationFailed))
 			{
 				int attributes = ATTR_POS;
@@ -4120,6 +3991,8 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 				                     /*noNormals=*/!useProgram); // we don't need normal (indexes) VBOs if we don't use the GLSL program
 			}
 
+			bool displayDone = false;
+
 			if (prog)
 			{
 				prog->bind();
@@ -4214,150 +4087,339 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 					}
 				}
 			}
-			else
+			else // no program available
 			{
-				glFunc->glEnableClientState(GL_VERTEX_ARRAY);
-				if (glParams.showNorms)
+				// specific case: long fallback mechanism to display clouds with NaN or outbound SF values without a program... :-(
+				if (glParams.showSF
+				    && m_currentDisplayedScalarField
+				    && m_currentDisplayedScalarField->mayHaveHiddenValues()) // no visibility table enabled but scalar field with hidden points/values
 				{
-					glFunc->glEnableClientState(GL_NORMAL_ARRAY);
-				}
-				if (glParams.showColors)
-				{
-					glFunc->glEnableClientState(GL_COLOR_ARRAY);
-				}
-			}
-
-			if (toDisplay.indexMap) // LoD display
-			{
-				unsigned s = toDisplay.startIndex;
-				while (s < toDisplay.endIndex)
-				{
-					unsigned count = std::min(MAX_POINT_COUNT_PER_LOD_RENDER_PASS, toDisplay.endIndex - s);
-					unsigned e     = s + count;
-
-					const auto& indexMap = (*toDisplay.indexMap);
-
-					// points
-					glLODChunkVertexPointer<QOpenGLFunctions_2_1>(this, glFunc, *toDisplay.indexMap, s, e, useProgram);
-
-					// normals
-					if (glParams.showNorms)
+					// color ramp shader initialization
+					ccColorRampShader* colorRampShader = context.colorRampShader;
 					{
-						glLODChunkNormalPointer<QOpenGLFunctions_2_1>(m_normals, glFunc, *toDisplay.indexMap, s, e, useProgram);
+						// FIXME: color ramp shader doesn't support log scale yet!
+						if (m_currentDisplayedScalarField->logScale())
+						{
+							colorRampShader = nullptr;
+						}
+						// the shader can't be used during color-based color picking
+						if (entityPickingMode)
+						{
+							colorRampShader = nullptr;
+						}
 					}
 
-					// SFs
-					if (glParams.showSF)
+					const ccScalarField::Range& sfDisplayRange    = m_currentDisplayedScalarField->displayRange();
+					const ccScalarField::Range& sfSaturationRange = m_currentDisplayedScalarField->saturationRange();
+					const bool                  symmetricalScale  = m_currentDisplayedScalarField->symmetricalScale();
+
+					if (colorRampShader)
 					{
-						glLODChunkSFPointer<QOpenGLFunctions_2_1>(m_currentDisplayedScalarField, glFunc, *toDisplay.indexMap, s, e, useProgram);
-					}
-					// colors
-					else if (glParams.showColors)
-					{
-						glLODChunkColorPointer<QOpenGLFunctions_2_1>(m_rgbaColors, glFunc, *toDisplay.indexMap, s, e, useProgram);
+						// max available space for fragment's shader uniforms
+						GLint maxBytes = 0;
+						glFunc->glGetIntegerv(GL_MAX_FRAGMENT_UNIFORM_COMPONENTS, &maxBytes);
+						GLint    maxComponents = (maxBytes >> 2) - 4; // leave space for the other uniforms!
+						unsigned steps         = m_currentDisplayedScalarField->getColorRampSteps();
+						assert(steps != 0);
+
+						if (steps > ccColorRampShader::MaxColorRampSize() || maxComponents < static_cast<GLint>(steps))
+						{
+							ccLog::WarningDebug("Color ramp steps exceed shader limits!");
+							colorRampShader = nullptr;
+						}
+						else
+						{
+							float sfMinSatRel = 0.0f;
+							float sfMaxSatRel = 1.0f;
+							if (!m_currentDisplayedScalarField->symmetricalScale())
+							{
+								sfMinSatRel = GetNormalizedValue(sfSaturationRange.start(), sfDisplayRange); // doesn't need to be between 0 and 1!
+								sfMaxSatRel = GetNormalizedValue(sfSaturationRange.stop(), sfDisplayRange);  // doesn't need to be between 0 and 1!
+							}
+							else
+							{
+								// we can only handle 'maximum' saturation
+								sfMinSatRel = GetSymmetricalNormalizedValue(-sfSaturationRange.stop(), sfSaturationRange);
+								sfMaxSatRel = GetSymmetricalNormalizedValue(sfSaturationRange.stop(), sfSaturationRange);
+								// we'll have to handle the 'minimum' saturation manually!
+							}
+
+							const ccColorScale::Shared& colorScale = m_currentDisplayedScalarField->getColorScale();
+							assert(colorScale);
+
+							colorRampShader->bind();
+							if (!colorRampShader->setup(glFunc, sfMinSatRel, sfMaxSatRel, steps, colorScale))
+							{
+								// An error occurred during shader initialization?
+								ccLog::WarningDebug("Failed to init ColorRamp shader!");
+								colorRampShader->release();
+								colorRampShader = nullptr;
+							}
+							else if (glParams.showNorms)
+							{
+								// we must get rid of lights material (other than ambient) for the red and green fields
+								glFunc->glPushAttrib(GL_LIGHTING_BIT);
+
+								// we use the ambient light to pass the scalar value (and 'grayed' marker) without any
+								// modification from the GPU pipeline, even if normals are enabled!
+								glFunc->glDisable(GL_COLOR_MATERIAL);
+								glFunc->glColorMaterial(GL_FRONT_AND_BACK, GL_DIFFUSE);
+								glFunc->glColorMaterial(GL_FRONT_AND_BACK, GL_AMBIENT);
+								glFunc->glEnable(GL_COLOR_MATERIAL);
+
+								GLint maxLightCount;
+								glFunc->glGetIntegerv(GL_MAX_LIGHTS, &maxLightCount);
+								for (GLint i = 0; i < maxLightCount; ++i)
+								{
+									if (glFunc->glIsEnabled(GL_LIGHT0 + i))
+									{
+										float diffuse[4];
+										float ambiant[4];
+										float specular[4];
+
+										glFunc->glGetLightfv(GL_LIGHT0 + i, GL_AMBIENT, ambiant);
+										glFunc->glGetLightfv(GL_LIGHT0 + i, GL_DIFFUSE, diffuse);
+										glFunc->glGetLightfv(GL_LIGHT0 + i, GL_SPECULAR, specular);
+
+										ambiant[0] = ambiant[1] = 1.0f;
+										diffuse[0] = diffuse[1] = 0.0f;
+										specular[0] = specular[1] = 0.0f;
+
+										glFunc->glLightfv(GL_LIGHT0 + i, GL_DIFFUSE, diffuse);
+										glFunc->glLightfv(GL_LIGHT0 + i, GL_AMBIENT, ambiant);
+										glFunc->glLightfv(GL_LIGHT0 + i, GL_SPECULAR, specular);
+									}
+								}
+							}
+						}
 					}
 
-					glFunc->glDrawArrays(GL_POINTS, 0, count);
+					glFunc->glBegin(GL_POINTS);
 
-					if (prog)
+					if (entityPickingMode)
 					{
-						glFunc->glDisableVertexAttribArray(ATTR_POS);
+						for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+						{
+							unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
+							assert(pointIndex < m_currentDisplayedScalarField->currentSize());
+							const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
+							if (col) // is the point visible?
+							{
+								// for entity picking, don't change the color, we just need to know whether the point is visible
+								ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
+							}
+						}
+					}
+					else
+					{
+						// compressed normals set
+						const ccNormalVectors* compressedNormals = ccNormalVectors::GetUniqueInstance();
+						assert(compressedNormals);
+
+						if (colorRampShader)
+						{
+							for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+							{
+								unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
+								assert(pointIndex < m_currentDisplayedScalarField->currentSize());
+								const ScalarType sfVal = m_currentDisplayedScalarField->getValue(pointIndex);
+								if (sfDisplayRange.isInRange(sfVal)) // NaN values are rejected
+								{
+									glFunc->glColor3f(symmetricalScale ? GetSymmetricalNormalizedValue(sfVal, sfSaturationRange)
+									                                   : GetNormalizedValue(sfVal, sfDisplayRange),
+									                  1.0f,
+									                  1.0f);
+									if (glParams.showNorms)
+									{
+										ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
+									}
+									ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
+								}
+							}
+						}
+						else // no color ramp shader
+						{
+							for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+							{
+								unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
+								assert(pointIndex < m_currentDisplayedScalarField->currentSize());
+								const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
+								if (col) // is the point visible?
+								{
+									ccGL::Color(glFunc, *col);
+									if (glParams.showNorms)
+									{
+										ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
+									}
+									ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
+								}
+							}
+						}
+					}
+
+					glFunc->glEnd();
+
+					if (colorRampShader)
+					{
+						colorRampShader->release();
+
 						if (glParams.showNorms)
 						{
-							glFunc->glDisableVertexAttribArray(ATTR_NOR);
+							glFunc->glPopAttrib(); // GL_LIGHTING_BIT
 						}
-						if (glParams.showSF)
-						{
-							glFunc->glDisableVertexAttribArray(ATTR_SF);
-						}
-						else if (glParams.showColors)
-						{
-							glFunc->glDisableVertexAttribArray(ATTR_COL);
-						}
-						// unbind array buffer
-						glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);
 					}
-					s = e;
 				}
-			}
-			else
-			{
-				for (size_t k = 0; k < chunkCount; ++k)
+				else
 				{
-					size_t chunkSize = ccChunk::Size(k, m_points);
-
-					// points
-					glChunkVertexPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
-
-					// normals
+					// simpler fallback mechanism to display a cloud without a program but no missing points
+					glFunc->glEnableClientState(GL_VERTEX_ARRAY);
 					if (glParams.showNorms)
 					{
-						glChunkNormalPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
+						glFunc->glEnableClientState(GL_NORMAL_ARRAY);
 					}
-					// SFs
-					if (glParams.showSF)
+					if (glParams.showSF || glParams.showColors)
 					{
-						glChunkSFPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
+						glFunc->glEnableClientState(GL_COLOR_ARRAY);
 					}
-					// colors
-					else if (glParams.showColors)
-					{
-						glChunkColorPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
-					}
+				}
 
-					if (toDisplay.decimStep > 1)
-					{
-						chunkSize = chunkSize / static_cast<size_t>(toDisplay.decimStep); // equivalent to floor if value >= 0
-					}
+				displayDone = true;
+			}
 
-					glFunc->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(chunkSize));
-
-					if (prog)
+			if (!displayDone)
+			{
+				if (toDisplay.indexMap) // LoD display
+				{
+					unsigned s = toDisplay.startIndex;
+					while (s < toDisplay.endIndex)
 					{
-						glFunc->glDisableVertexAttribArray(ATTR_POS);
+						unsigned count = std::min(MAX_POINT_COUNT_PER_LOD_RENDER_PASS, toDisplay.endIndex - s);
+						unsigned e     = s + count;
+
+						const auto& indexMap = (*toDisplay.indexMap);
+
+						// points
+						glLODChunkVertexPointer<QOpenGLFunctions_2_1>(this, glFunc, *toDisplay.indexMap, s, e, useProgram);
+
+						// normals
 						if (glParams.showNorms)
 						{
-							glFunc->glDisableVertexAttribArray(ATTR_NOR);
+							glLODChunkNormalPointer<QOpenGLFunctions_2_1>(m_normals, glFunc, *toDisplay.indexMap, s, e, useProgram);
 						}
+
+						// SFs
 						if (glParams.showSF)
 						{
-							glFunc->glDisableVertexAttribArray(ATTR_SF);
+							glLODChunkSFPointer<QOpenGLFunctions_2_1>(m_currentDisplayedScalarField, glFunc, *toDisplay.indexMap, s, e, useProgram);
 						}
+						// colors
 						else if (glParams.showColors)
 						{
-							glFunc->glDisableVertexAttribArray(ATTR_COL);
+							glLODChunkColorPointer<QOpenGLFunctions_2_1>(m_rgbaColors, glFunc, *toDisplay.indexMap, s, e, useProgram);
 						}
-						// unbind array buffer
-						glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+						glFunc->glDrawArrays(GL_POINTS, 0, count);
+
+						if (prog)
+						{
+							glFunc->glDisableVertexAttribArray(ATTR_POS);
+							if (glParams.showNorms)
+							{
+								glFunc->glDisableVertexAttribArray(ATTR_NOR);
+							}
+							if (glParams.showSF)
+							{
+								glFunc->glDisableVertexAttribArray(ATTR_SF);
+							}
+							else if (glParams.showColors)
+							{
+								glFunc->glDisableVertexAttribArray(ATTR_COL);
+							}
+							// unbind array buffer
+							glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);
+						}
+						s = e;
 					}
 				}
-			}
+				else
+				{
+					for (size_t k = 0; k < chunkCount; ++k)
+					{
+						size_t chunkSize = ccChunk::Size(k, m_points);
 
-			if (prog)
-			{
-				prog->release();
+						// points
+						glChunkVertexPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
 
-				if (glParams.showNorms)
-				{
-					glFunc->glActiveTexture(GL_TEXTURE0);
-					glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+						// normals
+						if (glParams.showNorms)
+						{
+							glChunkNormalPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
+						}
+						// SFs
+						if (glParams.showSF)
+						{
+							glChunkSFPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
+						}
+						// colors
+						else if (glParams.showColors)
+						{
+							glChunkColorPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
+						}
+
+						if (toDisplay.decimStep > 1)
+						{
+							chunkSize = chunkSize / static_cast<size_t>(toDisplay.decimStep); // equivalent to floor if value >= 0
+						}
+
+						glFunc->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(chunkSize));
+
+						if (prog)
+						{
+							glFunc->glDisableVertexAttribArray(ATTR_POS);
+							if (glParams.showNorms)
+							{
+								glFunc->glDisableVertexAttribArray(ATTR_NOR);
+							}
+							if (glParams.showSF)
+							{
+								glFunc->glDisableVertexAttribArray(ATTR_SF);
+							}
+							else if (glParams.showColors)
+							{
+								glFunc->glDisableVertexAttribArray(ATTR_COL);
+							}
+							// unbind array buffer
+							glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);
+						}
+					}
 				}
-				if (glParams.showSF)
+
+				if (prog)
 				{
-					glFunc->glActiveTexture(GL_TEXTURE1);
-					glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+					prog->release();
+
+					if (glParams.showNorms)
+					{
+						glFunc->glActiveTexture(GL_TEXTURE0);
+						glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+					}
+					if (glParams.showSF)
+					{
+						glFunc->glActiveTexture(GL_TEXTURE1);
+						glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+					}
 				}
-			}
-			else
-			{
-				glFunc->glDisableClientState(GL_VERTEX_ARRAY);
-				if (glParams.showNorms)
+				else
 				{
-					glFunc->glDisableClientState(GL_NORMAL_ARRAY);
-				}
-				if (glParams.showColors)
-				{
-					glFunc->glDisableClientState(GL_COLOR_ARRAY);
+					glFunc->glDisableClientState(GL_VERTEX_ARRAY);
+					if (glParams.showNorms)
+					{
+						glFunc->glDisableClientState(GL_NORMAL_ARRAY);
+					}
+					if (glParams.showSF || glParams.showColors)
+					{
+						glFunc->glDisableClientState(GL_COLOR_ARRAY);
+					}
 				}
 			}
 		}

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -2762,10 +2762,11 @@ static const GLuint ATTR_POS = 0;
 static const GLuint ATTR_NOR = 1;
 static const GLuint ATTR_COL = 2;
 static const GLuint ATTR_SF  = 4;
+static const GLuint ATTR_VIS = 8;
 // For internal use only
-static const GLuint ATTR_LOG_SCALE  = 8;
-static const GLuint ATTR_SYM_SCALE  = 16;
-static const GLuint ATTR_HIDDEN_VAL = 32;
+static const GLuint ATTR_LOG_SCALE  = 16;
+static const GLuint ATTR_SYM_SCALE  = 32;
+static const GLuint ATTR_HIDDEN_VAL = 64;
 
 // Global OpenGL resources
 static QMap<int, QSharedPointer<QOpenGLShaderProgram>> s_programs;
@@ -2773,6 +2774,69 @@ static GLuint                                          s_vboVertex  = 0;
 static GLuint                                          s_vboNormals = 0;
 static GLuint                                          s_vboColor   = 0;
 static GLuint                                          s_vboSF      = 0;
+static GLuint                                          s_vboVisib   = 0;
+
+void ccPointCloud::ReleaseOpenGLRessources()
+{
+	if (!QOpenGLContext::currentContext())
+	{
+		ccLog::Warning("[ccPointCloud::ReleaseOpenGLRessources] No valid OpenGL context");
+		return;
+	}
+
+	ccPointCloud::ReleaseShaders();
+
+	// get the set of OpenGL functions (version 2.1)
+	QOpenGLFunctions_2_1* glFunc = QOpenGLVersionFunctionsFactory::get<QOpenGLFunctions_2_1>(QOpenGLContext::currentContext());
+	if (glFunc)
+	{
+		s_programs.clear();
+
+		if (s_vboVertex != 0)
+		{
+			glFunc->glDeleteBuffers(1, &s_vboVertex);
+			s_vboVertex = 0;
+		}
+
+		if (s_vboNormals != 0)
+		{
+			glFunc->glDeleteBuffers(1, &s_vboNormals);
+			s_vboNormals = 0;
+		}
+
+		if (s_vboColor != 0)
+		{
+			glFunc->glDeleteBuffers(1, &s_vboColor);
+			s_vboColor = 0;
+		}
+
+		if (s_vboSF != 0)
+		{
+			glFunc->glDeleteBuffers(1, &s_vboSF);
+			s_vboSF = 0;
+		}
+
+		if (s_vboVisib != 0)
+		{
+			glFunc->glDeleteBuffers(1, &s_vboVisib);
+			s_vboVisib = 0;
+		}
+	}
+}
+
+/// Maximum number of points (per cloud) displayed in a single LOD iteration
+// warning MUST BE GREATER THAN 'MAX_NUMBER_OF_ELEMENTS_PER_CHUNK'
+#ifdef _DEBUG
+static const unsigned MAX_POINT_COUNT_PER_LOD_RENDER_PASS = (1 << 16); //~ 64K
+#else
+static const unsigned MAX_POINT_COUNT_PER_LOD_RENDER_PASS = (1 << 19); //~ 512K
+#endif
+
+// Vertex indexes for OpenGL "arrays" drawing
+static PointCoordinateType s_pointBuffer[MAX_POINT_COUNT_PER_LOD_RENDER_PASS * 3];
+static PointCoordinateType s_normalBuffer[MAX_POINT_COUNT_PER_LOD_RENDER_PASS * 3];
+static ColorCompType       s_rgbBuffer4ub[MAX_POINT_COUNT_PER_LOD_RENDER_PASS * 4];
+static float               s_visibilityBuffer[MAX_POINT_COUNT_PER_LOD_RENDER_PASS];
 
 void ccPointCloud::glChunkVertexPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs, bool useProg /*=false*/)
 {
@@ -2828,19 +2892,36 @@ void ccPointCloud::glChunkVertexPointer(const CC_DRAW_CONTEXT& context, size_t c
 	}
 }
 
-/// Maximum number of points (per cloud) displayed in a single LOD iteration
-// warning MUST BE GREATER THAN 'MAX_NUMBER_OF_ELEMENTS_PER_CHUNK'
-#ifdef _DEBUG
-static const unsigned MAX_POINT_COUNT_PER_LOD_RENDER_PASS = (1 << 16); //~ 64K
-#else
-static const unsigned MAX_POINT_COUNT_PER_LOD_RENDER_PASS = (1 << 19); //~ 512K
-#endif
+template <class QOpenGLFunctions>
+static void glChunkVisibilityPointer(const ccGenericPointCloud::VisibilityTableType& m_pointsVisibility,
+                                     QOpenGLFunctions*                               glFunc,
+                                     size_t                                          chunkIndex,
+                                     unsigned                                        decimStep)
+{
+	assert(glFunc);
 
-// Vertex indexes for OpenGL "arrays" drawing
-static PointCoordinateType s_pointBuffer[MAX_POINT_COUNT_PER_LOD_RENDER_PASS * 3];
-static PointCoordinateType s_normalBuffer[MAX_POINT_COUNT_PER_LOD_RENDER_PASS * 3];
-static ColorCompType       s_rgbBuffer4ub[MAX_POINT_COUNT_PER_LOD_RENDER_PASS * 4];
-static float               s_rgbBuffer3f[MAX_POINT_COUNT_PER_LOD_RENDER_PASS * 3];
+	if (s_vboVisib == 0)
+	{
+		assert(false);
+		return;
+	}
+
+	// with the program, we don't decode normals in a dedicated static array, we just re-order the indexes
+	float* _visibilityBuffer = reinterpret_cast<float*>(s_visibilityBuffer);
+	size_t s                 = ccChunk::StartPos(chunkIndex);
+	size_t e                 = s + ccChunk::Size(chunkIndex, m_pointsVisibility.size());
+	size_t count             = 0;
+	for (size_t j = s; j < e; j += decimStep)
+	{
+		*_visibilityBuffer++ = static_cast<float>(m_pointsVisibility[j]);
+		++count;
+	}
+
+	glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVisib);
+	glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(count * sizeof(float)), s_visibilityBuffer, GL_DYNAMIC_DRAW);
+	glFunc->glEnableVertexAttribArray(ATTR_VIS);
+	glFunc->glVertexAttribPointer(ATTR_VIS, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+}
 
 void ccPointCloud::glChunkNormalPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs, bool useProg /*=false*/)
 {
@@ -3060,12 +3141,12 @@ void ccPointCloud::glChunkSFPointer(const CC_DRAW_CONTEXT& context, size_t chunk
 }
 
 template <class QOpenGLFunctions>
-void glLODChunkVertexPointer(ccPointCloud*      cloud,
-                             QOpenGLFunctions*  glFunc,
-                             const LODIndexSet& indexMap,
-                             unsigned           startIndex,
-                             unsigned           stopIndex,
-                             bool               useProg = false)
+static void glLODChunkVertexPointer(ccPointCloud*      cloud,
+                                    QOpenGLFunctions*  glFunc,
+                                    const LODIndexSet& indexMap,
+                                    unsigned           startIndex,
+                                    unsigned           stopIndex,
+                                    bool               useProg = false)
 {
 	assert(startIndex < indexMap.size() && stopIndex <= indexMap.size());
 	assert(cloud && glFunc);
@@ -3095,12 +3176,42 @@ void glLODChunkVertexPointer(ccPointCloud*      cloud,
 }
 
 template <class QOpenGLFunctions>
-void glLODChunkNormalPointer(NormsIndexesTableType* normals,
-                             QOpenGLFunctions*      glFunc,
-                             const LODIndexSet&     indexMap,
-                             unsigned               startIndex,
-                             unsigned               stopIndex,
-                             bool                   useProg = false)
+static void glLODChunkVisibilityPointer(const ccGenericPointCloud::VisibilityTableType& m_pointsVisibility,
+                                        QOpenGLFunctions*                               glFunc,
+                                        const LODIndexSet&                              indexMap,
+                                        unsigned                                        startIndex,
+                                        unsigned                                        stopIndex)
+{
+	assert(startIndex < indexMap.size() && stopIndex <= indexMap.size());
+	assert(glFunc);
+
+	if (s_vboVisib == 0)
+	{
+		assert(false);
+		return;
+	}
+
+	// with the program, we don't decode normals in a dedicated static array, we just re-order the indexes
+	float* _visibilityBuffer = reinterpret_cast<float*>(s_visibilityBuffer);
+	for (unsigned j = startIndex; j < stopIndex; j++)
+	{
+		unsigned pointIndex  = indexMap[j];
+		*_visibilityBuffer++ = static_cast<float>(m_pointsVisibility[pointIndex]);
+	}
+
+	glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVisib);
+	glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * sizeof(float)), s_visibilityBuffer, GL_DYNAMIC_DRAW);
+	glFunc->glEnableVertexAttribArray(ATTR_VIS);
+	glFunc->glVertexAttribPointer(ATTR_VIS, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+}
+
+template <class QOpenGLFunctions>
+static void glLODChunkNormalPointer(NormsIndexesTableType* normals,
+                                    QOpenGLFunctions*      glFunc,
+                                    const LODIndexSet&     indexMap,
+                                    unsigned               startIndex,
+                                    unsigned               stopIndex,
+                                    bool                   useProg = false)
 {
 	assert(startIndex < indexMap.size() && stopIndex <= indexMap.size());
 	assert(normals && glFunc);
@@ -3149,12 +3260,12 @@ void glLODChunkNormalPointer(NormsIndexesTableType* normals,
 }
 
 template <class QOpenGLFunctions>
-void glLODChunkColorPointer(RGBAColorsTableType* colors,
-                            QOpenGLFunctions*    glFunc,
-                            const LODIndexSet&   indexMap,
-                            unsigned             startIndex,
-                            unsigned             stopIndex,
-                            bool                 useProg = false)
+static void glLODChunkColorPointer(RGBAColorsTableType* colors,
+                                   QOpenGLFunctions*    glFunc,
+                                   const LODIndexSet&   indexMap,
+                                   unsigned             startIndex,
+                                   unsigned             stopIndex,
+                                   bool                 useProg = false)
 {
 	assert(startIndex < indexMap.size() && stopIndex <= indexMap.size());
 	assert(colors && glFunc);
@@ -3195,12 +3306,12 @@ void glLODChunkColorPointer(RGBAColorsTableType* colors,
 }
 
 template <class QOpenGLFunctions>
-void glLODChunkSFPointer(ccScalarField*     sf,
-                         QOpenGLFunctions*  glFunc,
-                         const LODIndexSet& indexMap,
-                         unsigned           startIndex,
-                         unsigned           stopIndex,
-                         bool               useProg = false)
+static void glLODChunkSFPointer(ccScalarField*     sf,
+                                QOpenGLFunctions*  glFunc,
+                                const LODIndexSet& indexMap,
+                                unsigned           startIndex,
+                                unsigned           stopIndex,
+                                bool               useProg = false)
 {
 	assert(startIndex < indexMap.size() && stopIndex <= indexMap.size());
 	assert(sf && glFunc);
@@ -3332,6 +3443,9 @@ static QSharedPointer<QOpenGLShaderProgram> BuildCloudDisplayProgram(QOpenGLFunc
 	    "attribute vec3 aPosition;\n"
 	    "varying vec4 vColor;\n";
 
+	static const char* VertexProgVisibilityAttributesSrc =
+	    "attribute float aVisib;\n";
+
 	static const char* VertexProgColorAttributesSrc =
 	    "attribute vec4 aColor;\n";
 
@@ -3452,6 +3566,13 @@ static QSharedPointer<QOpenGLShaderProgram> BuildCloudDisplayProgram(QOpenGLFunc
 	    "      return;\n"
 	    "   }\n";
 
+	static const char* VertexProgMainTestVisibilitySrc =
+	    "   if (aVisib > 0.0)\n" // CCCoreLib::POINT_VISIBLE = 0
+	    "   {\n"
+	    "      gl_Position = vec4(0, 0, 0, -1.0);\n" // impossible position, should be discarded by the GPU
+	    "      return;\n"
+	    "   }\n";
+
 	static const char* VertexProgMainFetchNormalSrc =
 	    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n";
 
@@ -3490,6 +3611,8 @@ static QSharedPointer<QOpenGLShaderProgram> BuildCloudDisplayProgram(QOpenGLFunc
 			vertexProgSrc += VertexProgColorAttributesSrc;
 		if (attributes & ATTR_NOR)
 			vertexProgSrc += VertexProgNormAttributesSrc;
+		if (attributes & ATTR_VIS)
+			vertexProgSrc += VertexProgVisibilityAttributesSrc;
 
 		// add special functions
 		if (attributes & ATTR_SF)
@@ -3513,6 +3636,11 @@ static QSharedPointer<QOpenGLShaderProgram> BuildCloudDisplayProgram(QOpenGLFunc
 		// main function
 		{
 			vertexProgSrc += VertexProgMainStartSrc;
+
+			if (attributes & ATTR_VIS)
+			{
+				vertexProgSrc += VertexProgMainTestVisibilitySrc;
+			}
 
 			// color transfer
 			if (attributes & ATTR_SF)
@@ -3558,6 +3686,10 @@ static QSharedPointer<QOpenGLShaderProgram> BuildCloudDisplayProgram(QOpenGLFunc
 
 	// bind attribute locations before linking for stable locations
 	program->bindAttributeLocation("aPosition", ATTR_POS);
+	if (attributes & ATTR_VIS)
+	{
+		program->bindAttributeLocation("aVisib", ATTR_VIS);
+	}
 	if (attributes & ATTR_SF)
 	{
 		assert((attributes & ATTR_COL) == 0);
@@ -3824,124 +3956,71 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 	// main display procedure
 	{
-		// if some points are hidden (= visibility table instantiated), we can't use display arrays :(
-		if (isVisibilityTableInstantiated())
+		size_t chunkCount = ccChunk::Count(m_points);
+
+		bool visTableEnabled = isVisibilityTableInstantiated();
+
+		// sf display acceleration texture (for fast scalar field display)
+		QSharedPointer<QOpenGLTexture> sfTex;
+
+		// normal display acceleration texture (for fast normals display)
+		static bool                    s_globalVBOCreationFailed = false;
+		static bool                    s_normalLUTTextureFailed  = false;
+		QSharedPointer<QOpenGLTexture> lutTex;
+
+		// by default, we'll try to use a composite GLSL program (if possible)
+		QSharedPointer<QOpenGLShaderProgram> prog;
+		if ((false == s_normalLUTTextureFailed)
+		    && (false == s_globalVBOCreationFailed))
 		{
-			assert(m_pointsVisibility.size() == m_points.size());
-
-			glFunc->glBegin(GL_POINTS);
-
-			if (!entityPickingMode)
+			int attributes = ATTR_POS;
+			if (glParams.showNorms)
 			{
-				// compressed normals set
-				const ccNormalVectors* compressedNormals = ccNormalVectors::GetUniqueInstance();
-				assert(compressedNormals);
-
-				for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-				{
-					// we must test each point visibility
-					unsigned pointIndex = toDisplay.indexMap ? toDisplay.indexMap->at(j) : j;
-					if (m_pointsVisibility.empty() || m_pointsVisibility[pointIndex] == CCCoreLib::POINT_VISIBLE)
-					{
-						if (glParams.showSF)
-						{
-							assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-							const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
-							// we force display of points hidden because of their scalar field value
-							// to be sure that the user doesn't miss them (during manual segmentation for instance)
-							ccGL::Color(glFunc, col ? *col : ccColor::lightGreyRGB); // Make sure all points are visible. No alpha used on purpose
-						}
-						else if (glParams.showColors)
-						{
-							ccGL::Color(glFunc, m_rgbaColors->getValue(pointIndex));
-						}
-						if (glParams.showNorms)
-						{
-							ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
-						}
-						ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-					}
-				}
+				attributes |= ATTR_NOR;
 			}
-			else // picking mode
+			if (glParams.showSF)
 			{
-				for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+				attributes |= ATTR_SF;
+			}
+			else if (glParams.showColors)
+			{
+				attributes |= ATTR_COL;
+			}
+			if (visTableEnabled)
+			{
+				attributes |= ATTR_VIS;
+			}
+
+			prog = BuildCloudDisplayProgram(glFunc, attributes, glParams.showSF ? m_currentDisplayedScalarField : nullptr);
+
+			if (glParams.showSF && prog)
+			{
+				assert(m_currentDisplayedScalarField);
+				auto colorScale = m_currentDisplayedScalarField->getColorScale();
+				assert(!colorScale.isNull());
+
+				sfTex = colorScale->getTexture(glFunc);
+				if (sfTex.isNull())
 				{
-					// we must test each point visibility
-					unsigned pointIndex = toDisplay.indexMap ? toDisplay.indexMap->at(j) : j;
-					if (m_pointsVisibility.empty() || m_pointsVisibility[pointIndex] == CCCoreLib::POINT_VISIBLE)
-					{
-						// in color-based picking mode, we only display the points
-						ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-					}
+					ccLog::Warning("Failed to create scalar field texture! Cannot render fast scalar field.");
+					prog.clear();
 				}
 			}
 
-			glFunc->glEnd();
-		}
-		else // no visibility table enabled
-		{
-			size_t chunkCount = ccChunk::Count(m_points);
-
-			// sf display acceleration texture (for fast scalar field display)
-			QSharedPointer<QOpenGLTexture> sfTex;
-
-			// normal display acceleration texture (for fast normals display)
-			static bool                    s_globalVBOCreationFailed = false;
-			static bool                    s_normalLUTTextureFailed  = false;
-			QSharedPointer<QOpenGLTexture> lutTex;
-
-			QSharedPointer<QOpenGLShaderProgram> prog;
-			if (/*(glParams.showSF || glParams.showNorms)
-			    &&*/
-			    (false == s_normalLUTTextureFailed)
-			    && (false == s_globalVBOCreationFailed))
+			if (glParams.showNorms && prog)
 			{
-				int attributes = ATTR_POS;
-				if (glParams.showNorms)
+				// create or retrieve the LUT texture
+				lutTex = ccNormalVectors::GetNormalLUTTexture(glFunc);
+				if (lutTex.isNull())
 				{
-					attributes |= ATTR_NOR;
-				}
-				if (glParams.showSF)
-				{
-					attributes |= ATTR_SF;
-				}
-				else if (glParams.showColors)
-				{
-					attributes |= ATTR_COL;
-				}
-
-				prog = BuildCloudDisplayProgram(glFunc, attributes, glParams.showSF ? m_currentDisplayedScalarField : nullptr);
-
-				if (glParams.showSF && prog)
-				{
-					assert(m_currentDisplayedScalarField);
-					auto colorScale = m_currentDisplayedScalarField->getColorScale();
-					assert(!colorScale.isNull());
-
-					sfTex = colorScale->getTexture(glFunc);
-					if (sfTex.isNull())
-					{
-						ccLog::Warning("Failed to create scalar field texture! Cannot render fast scalar field.");
-						prog.clear();
-					}
-				}
-
-				if (glParams.showNorms && prog)
-				{
-					// create or retrieve the LUT texture
-					lutTex = ccNormalVectors::GetNormalLUTTexture(glFunc);
-					if (lutTex.isNull())
-					{
-						ccLog::Warning("Failed to create normals LUT texture! Cannot render fast normals.");
-						s_normalLUTTextureFailed = true;
-						prog.clear();
-					}
+					ccLog::Warning("Failed to create normals LUT texture! Cannot render fast normals.");
+					s_normalLUTTextureFailed = true;
+					prog.clear();
 				}
 			}
 
 			// static VBO handles reused between calls
-			if (prog && s_vboVertex == 0)
+			if (prog && (attributes & ATTR_POS) && s_vboVertex == 0)
 			{
 				glFunc->glGenBuffers(1, &s_vboVertex);
 				if (0 == s_vboVertex)
@@ -3951,7 +4030,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 				}
 			}
 
-			if (prog && s_vboNormals == 0)
+			if (prog && (attributes & ATTR_NOR) && s_vboNormals == 0)
 			{
 				glFunc->glGenBuffers(1, &s_vboNormals);
 				if (0 == s_vboNormals)
@@ -3961,7 +4040,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 				}
 			}
 
-			if (prog && s_vboSF == 0)
+			if (prog && (attributes & ATTR_SF) && s_vboSF == 0)
 			{
 				glFunc->glGenBuffers(1, &s_vboSF);
 				if (0 == s_vboSF)
@@ -3971,7 +4050,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 				}
 			}
 
-			if (prog && s_vboColor == 0)
+			if (prog && (attributes & ATTR_COL) && s_vboColor == 0)
 			{
 				glFunc->glGenBuffers(1, &s_vboColor);
 				if (0 == s_vboColor)
@@ -3981,8 +4060,265 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 				}
 			}
 
+			if (prog && (attributes & ATTR_VIS) && s_vboVisib == 0)
+			{
+				glFunc->glGenBuffers(1, &s_vboVisib);
+				if (0 == s_vboVisib)
+				{
+					s_globalVBOCreationFailed = true;
+					prog.clear();
+				}
+			}
+		}
+
+		bool displayDone = false;
+
+		if (!prog) // no program available
+		{
+			// specific case: fallback mechanism to display clouds with a visibility array but without a program... :-(
+			if (visTableEnabled)
+			{
+				assert(m_pointsVisibility.size() == m_points.size());
+
+				glFunc->glBegin(GL_POINTS);
+
+				if (!entityPickingMode)
+				{
+					// compressed normals set
+					const ccNormalVectors* compressedNormals = ccNormalVectors::GetUniqueInstance();
+					assert(compressedNormals);
+
+					for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+					{
+						// we must test each point visibility
+						unsigned pointIndex = toDisplay.indexMap ? toDisplay.indexMap->at(j) : j;
+						if (m_pointsVisibility.empty() || m_pointsVisibility[pointIndex] == CCCoreLib::POINT_VISIBLE)
+						{
+							if (glParams.showSF)
+							{
+								assert(pointIndex < m_currentDisplayedScalarField->currentSize());
+								const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
+								// we force display of points hidden because of their scalar field value
+								// to be sure that the user doesn't miss them (during manual segmentation for instance)
+								ccGL::Color(glFunc, col ? *col : ccColor::lightGreyRGB); // Make sure all points are visible. No alpha used on purpose
+							}
+							else if (glParams.showColors)
+							{
+								ccGL::Color(glFunc, m_rgbaColors->getValue(pointIndex));
+							}
+							if (glParams.showNorms)
+							{
+								ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
+							}
+							ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
+						}
+					}
+				}
+				else // picking mode
+				{
+					for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+					{
+						// we must test each point visibility
+						unsigned pointIndex = toDisplay.indexMap ? toDisplay.indexMap->at(j) : j;
+						if (m_pointsVisibility.empty() || m_pointsVisibility[pointIndex] == CCCoreLib::POINT_VISIBLE)
+						{
+							// in color-based picking mode, we only display the points
+							ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
+						}
+					}
+				}
+
+				glFunc->glEnd();
+
+				displayDone = true;
+			}
+			// specific case: long fallback mechanism to display clouds with NaN or outbound SF values but without a program... :-(
+			else if (glParams.showSF && m_currentDisplayedScalarField->mayHaveHiddenValues())
+			{
+				// color ramp shader initialization
+				ccColorRampShader* colorRampShader = context.colorRampShader;
+				{
+					// FIXME: color ramp shader doesn't support log scale yet!
+					if (m_currentDisplayedScalarField->logScale())
+					{
+						colorRampShader = nullptr;
+					}
+					// the shader can't be used during color-based color picking
+					if (entityPickingMode)
+					{
+						colorRampShader = nullptr;
+					}
+				}
+
+				const ccScalarField::Range& sfDisplayRange    = m_currentDisplayedScalarField->displayRange();
+				const ccScalarField::Range& sfSaturationRange = m_currentDisplayedScalarField->saturationRange();
+				const bool                  symmetricalScale  = m_currentDisplayedScalarField->symmetricalScale();
+
+				if (colorRampShader)
+				{
+					// max available space for fragment's shader uniforms
+					GLint maxBytes = 0;
+					glFunc->glGetIntegerv(GL_MAX_FRAGMENT_UNIFORM_COMPONENTS, &maxBytes);
+					GLint    maxComponents = (maxBytes >> 2) - 4; // leave space for the other uniforms!
+					unsigned steps         = m_currentDisplayedScalarField->getColorRampSteps();
+					assert(steps != 0);
+
+					if (steps > ccColorRampShader::MaxColorRampSize() || maxComponents < static_cast<GLint>(steps))
+					{
+						ccLog::WarningDebug("Color ramp steps exceed shader limits!");
+						colorRampShader = nullptr;
+					}
+					else
+					{
+						float sfMinSatRel = 0.0f;
+						float sfMaxSatRel = 1.0f;
+						if (!m_currentDisplayedScalarField->symmetricalScale())
+						{
+							sfMinSatRel = GetNormalizedValue(sfSaturationRange.start(), sfDisplayRange); // doesn't need to be between 0 and 1!
+							sfMaxSatRel = GetNormalizedValue(sfSaturationRange.stop(), sfDisplayRange);  // doesn't need to be between 0 and 1!
+						}
+						else
+						{
+							// we can only handle 'maximum' saturation
+							sfMinSatRel = GetSymmetricalNormalizedValue(-sfSaturationRange.stop(), sfSaturationRange);
+							sfMaxSatRel = GetSymmetricalNormalizedValue(sfSaturationRange.stop(), sfSaturationRange);
+							// we'll have to handle the 'minimum' saturation manually!
+						}
+
+						const ccColorScale::Shared& colorScale = m_currentDisplayedScalarField->getColorScale();
+						assert(colorScale);
+
+						colorRampShader->bind();
+						if (!colorRampShader->setup(glFunc, sfMinSatRel, sfMaxSatRel, steps, colorScale))
+						{
+							// An error occurred during shader initialization?
+							ccLog::WarningDebug("Failed to init ColorRamp shader!");
+							colorRampShader->release();
+							colorRampShader = nullptr;
+						}
+						else if (glParams.showNorms)
+						{
+							// we must get rid of lights material (other than ambient) for the red and green fields
+							glFunc->glPushAttrib(GL_LIGHTING_BIT);
+
+							// we use the ambient light to pass the scalar value (and 'grayed' marker) without any
+							// modification from the GPU pipeline, even if normals are enabled!
+							glFunc->glDisable(GL_COLOR_MATERIAL);
+							glFunc->glColorMaterial(GL_FRONT_AND_BACK, GL_DIFFUSE);
+							glFunc->glColorMaterial(GL_FRONT_AND_BACK, GL_AMBIENT);
+							glFunc->glEnable(GL_COLOR_MATERIAL);
+
+							GLint maxLightCount;
+							glFunc->glGetIntegerv(GL_MAX_LIGHTS, &maxLightCount);
+							for (GLint i = 0; i < maxLightCount; ++i)
+							{
+								if (glFunc->glIsEnabled(GL_LIGHT0 + i))
+								{
+									float diffuse[4];
+									float ambiant[4];
+									float specular[4];
+
+									glFunc->glGetLightfv(GL_LIGHT0 + i, GL_AMBIENT, ambiant);
+									glFunc->glGetLightfv(GL_LIGHT0 + i, GL_DIFFUSE, diffuse);
+									glFunc->glGetLightfv(GL_LIGHT0 + i, GL_SPECULAR, specular);
+
+									ambiant[0] = ambiant[1] = 1.0f;
+									diffuse[0] = diffuse[1] = 0.0f;
+									specular[0] = specular[1] = 0.0f;
+
+									glFunc->glLightfv(GL_LIGHT0 + i, GL_DIFFUSE, diffuse);
+									glFunc->glLightfv(GL_LIGHT0 + i, GL_AMBIENT, ambiant);
+									glFunc->glLightfv(GL_LIGHT0 + i, GL_SPECULAR, specular);
+								}
+							}
+						}
+					}
+				}
+
+				glFunc->glBegin(GL_POINTS);
+
+				if (entityPickingMode)
+				{
+					for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+					{
+						unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
+						assert(pointIndex < m_currentDisplayedScalarField->currentSize());
+						const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
+						if (col) // is the point visible?
+						{
+							// for entity picking, don't change the color, we just need to know whether the point is visible
+							ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
+						}
+					}
+				}
+				else
+				{
+					// compressed normals set
+					const ccNormalVectors* compressedNormals = ccNormalVectors::GetUniqueInstance();
+					assert(compressedNormals);
+
+					if (colorRampShader)
+					{
+						for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+						{
+							unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
+							assert(pointIndex < m_currentDisplayedScalarField->currentSize());
+							const ScalarType sfVal = m_currentDisplayedScalarField->getValue(pointIndex);
+							if (sfDisplayRange.isInRange(sfVal)) // NaN values are rejected
+							{
+								glFunc->glColor3f(symmetricalScale ? GetSymmetricalNormalizedValue(sfVal, sfSaturationRange)
+								                                   : GetNormalizedValue(sfVal, sfDisplayRange),
+								                  1.0f,
+								                  1.0f);
+								if (glParams.showNorms)
+								{
+									ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
+								}
+								ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
+							}
+						}
+					}
+					else // no color ramp shader
+					{
+						for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+						{
+							unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
+							assert(pointIndex < m_currentDisplayedScalarField->currentSize());
+							const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
+							if (col) // is the point visible?
+							{
+								ccGL::Color(glFunc, *col);
+								if (glParams.showNorms)
+								{
+									ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
+								}
+								ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
+							}
+						}
+					}
+				}
+
+				glFunc->glEnd();
+
+				if (colorRampShader)
+				{
+					colorRampShader->release();
+
+					if (glParams.showNorms)
+					{
+						glFunc->glPopAttrib(); // GL_LIGHTING_BIT
+					}
+				}
+
+				displayDone = true;
+			}
+		}
+
+		if (!displayDone)
+		{
 			bool useProgram = (nullptr != prog);
-			bool useVBOs    = false;
+
+			bool useVBOs = false;
 			if (context.useVBOs && !toDisplay.indexMap) // VBOs are not compatible with LoD
 			{
 				useVBOs = updateVBOs(context,
@@ -3991,15 +4327,13 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 				                     /*noNormals=*/!useProgram); // we don't need normal (indexes) VBOs if we don't use the GLSL program
 			}
 
-			bool displayDone = false;
-
-			if (prog)
+			if (useProgram)
 			{
 				prog->bind();
 
 				if (lutTex)
 				{
-					// bind texture to unit 0
+					// bind normal acceleration LUT texture to unit 0
 					glFunc->glActiveTexture(GL_TEXTURE0);
 					glFunc->glBindTexture(GL_TEXTURE_2D, lutTex->textureId());
 
@@ -4024,9 +4358,10 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 				if (sfTex && m_currentDisplayedScalarField)
 				{
-					// bind texture to unit 1
+					// bind color ramp texture to unit 1
 					glFunc->glActiveTexture(GL_TEXTURE1);
 					glFunc->glBindTexture(GL_TEXTURE_2D, sfTex->textureId());
+
 					// set sampler uniform to unit 1
 					int locSampler = prog->uniformLocation("uColorScaleTex");
 					if (locSampler >= 0)
@@ -4087,339 +4422,163 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 					}
 				}
 			}
-			else // no program available
+			else
 			{
-				// specific case: long fallback mechanism to display clouds with NaN or outbound SF values without a program... :-(
-				if (glParams.showSF
-				    && m_currentDisplayedScalarField
-				    && m_currentDisplayedScalarField->mayHaveHiddenValues()) // no visibility table enabled but scalar field with hidden points/values
+				// simpler fallback mechanism to display a cloud without a program (but no hidden points)
+				glFunc->glEnableClientState(GL_VERTEX_ARRAY);
+				if (glParams.showNorms)
 				{
-					// color ramp shader initialization
-					ccColorRampShader* colorRampShader = context.colorRampShader;
-					{
-						// FIXME: color ramp shader doesn't support log scale yet!
-						if (m_currentDisplayedScalarField->logScale())
-						{
-							colorRampShader = nullptr;
-						}
-						// the shader can't be used during color-based color picking
-						if (entityPickingMode)
-						{
-							colorRampShader = nullptr;
-						}
-					}
-
-					const ccScalarField::Range& sfDisplayRange    = m_currentDisplayedScalarField->displayRange();
-					const ccScalarField::Range& sfSaturationRange = m_currentDisplayedScalarField->saturationRange();
-					const bool                  symmetricalScale  = m_currentDisplayedScalarField->symmetricalScale();
-
-					if (colorRampShader)
-					{
-						// max available space for fragment's shader uniforms
-						GLint maxBytes = 0;
-						glFunc->glGetIntegerv(GL_MAX_FRAGMENT_UNIFORM_COMPONENTS, &maxBytes);
-						GLint    maxComponents = (maxBytes >> 2) - 4; // leave space for the other uniforms!
-						unsigned steps         = m_currentDisplayedScalarField->getColorRampSteps();
-						assert(steps != 0);
-
-						if (steps > ccColorRampShader::MaxColorRampSize() || maxComponents < static_cast<GLint>(steps))
-						{
-							ccLog::WarningDebug("Color ramp steps exceed shader limits!");
-							colorRampShader = nullptr;
-						}
-						else
-						{
-							float sfMinSatRel = 0.0f;
-							float sfMaxSatRel = 1.0f;
-							if (!m_currentDisplayedScalarField->symmetricalScale())
-							{
-								sfMinSatRel = GetNormalizedValue(sfSaturationRange.start(), sfDisplayRange); // doesn't need to be between 0 and 1!
-								sfMaxSatRel = GetNormalizedValue(sfSaturationRange.stop(), sfDisplayRange);  // doesn't need to be between 0 and 1!
-							}
-							else
-							{
-								// we can only handle 'maximum' saturation
-								sfMinSatRel = GetSymmetricalNormalizedValue(-sfSaturationRange.stop(), sfSaturationRange);
-								sfMaxSatRel = GetSymmetricalNormalizedValue(sfSaturationRange.stop(), sfSaturationRange);
-								// we'll have to handle the 'minimum' saturation manually!
-							}
-
-							const ccColorScale::Shared& colorScale = m_currentDisplayedScalarField->getColorScale();
-							assert(colorScale);
-
-							colorRampShader->bind();
-							if (!colorRampShader->setup(glFunc, sfMinSatRel, sfMaxSatRel, steps, colorScale))
-							{
-								// An error occurred during shader initialization?
-								ccLog::WarningDebug("Failed to init ColorRamp shader!");
-								colorRampShader->release();
-								colorRampShader = nullptr;
-							}
-							else if (glParams.showNorms)
-							{
-								// we must get rid of lights material (other than ambient) for the red and green fields
-								glFunc->glPushAttrib(GL_LIGHTING_BIT);
-
-								// we use the ambient light to pass the scalar value (and 'grayed' marker) without any
-								// modification from the GPU pipeline, even if normals are enabled!
-								glFunc->glDisable(GL_COLOR_MATERIAL);
-								glFunc->glColorMaterial(GL_FRONT_AND_BACK, GL_DIFFUSE);
-								glFunc->glColorMaterial(GL_FRONT_AND_BACK, GL_AMBIENT);
-								glFunc->glEnable(GL_COLOR_MATERIAL);
-
-								GLint maxLightCount;
-								glFunc->glGetIntegerv(GL_MAX_LIGHTS, &maxLightCount);
-								for (GLint i = 0; i < maxLightCount; ++i)
-								{
-									if (glFunc->glIsEnabled(GL_LIGHT0 + i))
-									{
-										float diffuse[4];
-										float ambiant[4];
-										float specular[4];
-
-										glFunc->glGetLightfv(GL_LIGHT0 + i, GL_AMBIENT, ambiant);
-										glFunc->glGetLightfv(GL_LIGHT0 + i, GL_DIFFUSE, diffuse);
-										glFunc->glGetLightfv(GL_LIGHT0 + i, GL_SPECULAR, specular);
-
-										ambiant[0] = ambiant[1] = 1.0f;
-										diffuse[0] = diffuse[1] = 0.0f;
-										specular[0] = specular[1] = 0.0f;
-
-										glFunc->glLightfv(GL_LIGHT0 + i, GL_DIFFUSE, diffuse);
-										glFunc->glLightfv(GL_LIGHT0 + i, GL_AMBIENT, ambiant);
-										glFunc->glLightfv(GL_LIGHT0 + i, GL_SPECULAR, specular);
-									}
-								}
-							}
-						}
-					}
-
-					glFunc->glBegin(GL_POINTS);
-
-					if (entityPickingMode)
-					{
-						for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-						{
-							unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-							assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-							const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
-							if (col) // is the point visible?
-							{
-								// for entity picking, don't change the color, we just need to know whether the point is visible
-								ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-							}
-						}
-					}
-					else
-					{
-						// compressed normals set
-						const ccNormalVectors* compressedNormals = ccNormalVectors::GetUniqueInstance();
-						assert(compressedNormals);
-
-						if (colorRampShader)
-						{
-							for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-							{
-								unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-								assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-								const ScalarType sfVal = m_currentDisplayedScalarField->getValue(pointIndex);
-								if (sfDisplayRange.isInRange(sfVal)) // NaN values are rejected
-								{
-									glFunc->glColor3f(symmetricalScale ? GetSymmetricalNormalizedValue(sfVal, sfSaturationRange)
-									                                   : GetNormalizedValue(sfVal, sfDisplayRange),
-									                  1.0f,
-									                  1.0f);
-									if (glParams.showNorms)
-									{
-										ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
-									}
-									ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-								}
-							}
-						}
-						else // no color ramp shader
-						{
-							for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-							{
-								unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-								assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-								const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
-								if (col) // is the point visible?
-								{
-									ccGL::Color(glFunc, *col);
-									if (glParams.showNorms)
-									{
-										ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
-									}
-									ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-								}
-							}
-						}
-					}
-
-					glFunc->glEnd();
-
-					if (colorRampShader)
-					{
-						colorRampShader->release();
-
-						if (glParams.showNorms)
-						{
-							glFunc->glPopAttrib(); // GL_LIGHTING_BIT
-						}
-					}
+					glFunc->glEnableClientState(GL_NORMAL_ARRAY);
 				}
-				else
+				if (glParams.showSF || glParams.showColors)
 				{
-					// simpler fallback mechanism to display a cloud without a program but no missing points
-					glFunc->glEnableClientState(GL_VERTEX_ARRAY);
-					if (glParams.showNorms)
-					{
-						glFunc->glEnableClientState(GL_NORMAL_ARRAY);
-					}
-					if (glParams.showSF || glParams.showColors)
-					{
-						glFunc->glEnableClientState(GL_COLOR_ARRAY);
-					}
+					glFunc->glEnableClientState(GL_COLOR_ARRAY);
 				}
-
-				displayDone = true;
 			}
 
-			if (!displayDone)
+			if (toDisplay.indexMap) // LoD display
 			{
-				if (toDisplay.indexMap) // LoD display
+				unsigned s = toDisplay.startIndex;
+				while (s < toDisplay.endIndex)
 				{
-					unsigned s = toDisplay.startIndex;
-					while (s < toDisplay.endIndex)
-					{
-						unsigned count = std::min(MAX_POINT_COUNT_PER_LOD_RENDER_PASS, toDisplay.endIndex - s);
-						unsigned e     = s + count;
+					unsigned count = std::min(MAX_POINT_COUNT_PER_LOD_RENDER_PASS, toDisplay.endIndex - s);
+					unsigned e     = s + count;
 
-						const auto& indexMap = (*toDisplay.indexMap);
+					const auto& indexMap = (*toDisplay.indexMap);
 
-						// points
-						glLODChunkVertexPointer<QOpenGLFunctions_2_1>(this, glFunc, *toDisplay.indexMap, s, e, useProgram);
+					// points
+					glLODChunkVertexPointer<QOpenGLFunctions_2_1>(this, glFunc, *toDisplay.indexMap, s, e, useProgram);
 
-						// normals
-						if (glParams.showNorms)
-						{
-							glLODChunkNormalPointer<QOpenGLFunctions_2_1>(m_normals, glFunc, *toDisplay.indexMap, s, e, useProgram);
-						}
-
-						// SFs
-						if (glParams.showSF)
-						{
-							glLODChunkSFPointer<QOpenGLFunctions_2_1>(m_currentDisplayedScalarField, glFunc, *toDisplay.indexMap, s, e, useProgram);
-						}
-						// colors
-						else if (glParams.showColors)
-						{
-							glLODChunkColorPointer<QOpenGLFunctions_2_1>(m_rgbaColors, glFunc, *toDisplay.indexMap, s, e, useProgram);
-						}
-
-						glFunc->glDrawArrays(GL_POINTS, 0, count);
-
-						if (prog)
-						{
-							glFunc->glDisableVertexAttribArray(ATTR_POS);
-							if (glParams.showNorms)
-							{
-								glFunc->glDisableVertexAttribArray(ATTR_NOR);
-							}
-							if (glParams.showSF)
-							{
-								glFunc->glDisableVertexAttribArray(ATTR_SF);
-							}
-							else if (glParams.showColors)
-							{
-								glFunc->glDisableVertexAttribArray(ATTR_COL);
-							}
-							// unbind array buffer
-							glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);
-						}
-						s = e;
-					}
-				}
-				else
-				{
-					for (size_t k = 0; k < chunkCount; ++k)
-					{
-						size_t chunkSize = ccChunk::Size(k, m_points);
-
-						// points
-						glChunkVertexPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
-
-						// normals
-						if (glParams.showNorms)
-						{
-							glChunkNormalPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
-						}
-						// SFs
-						if (glParams.showSF)
-						{
-							glChunkSFPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
-						}
-						// colors
-						else if (glParams.showColors)
-						{
-							glChunkColorPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
-						}
-
-						if (toDisplay.decimStep > 1)
-						{
-							chunkSize = chunkSize / static_cast<size_t>(toDisplay.decimStep); // equivalent to floor if value >= 0
-						}
-
-						glFunc->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(chunkSize));
-
-						if (prog)
-						{
-							glFunc->glDisableVertexAttribArray(ATTR_POS);
-							if (glParams.showNorms)
-							{
-								glFunc->glDisableVertexAttribArray(ATTR_NOR);
-							}
-							if (glParams.showSF)
-							{
-								glFunc->glDisableVertexAttribArray(ATTR_SF);
-							}
-							else if (glParams.showColors)
-							{
-								glFunc->glDisableVertexAttribArray(ATTR_COL);
-							}
-							// unbind array buffer
-							glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);
-						}
-					}
-				}
-
-				if (prog)
-				{
-					prog->release();
-
+					// normals
 					if (glParams.showNorms)
 					{
-						glFunc->glActiveTexture(GL_TEXTURE0);
-						glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+						glLODChunkNormalPointer<QOpenGLFunctions_2_1>(m_normals, glFunc, *toDisplay.indexMap, s, e, useProgram);
 					}
+
+					// visibility table
+					if (visTableEnabled && useProgram)
+					{
+						glLODChunkVisibilityPointer<QOpenGLFunctions_2_1>(m_pointsVisibility, glFunc, *toDisplay.indexMap, s, e);
+					}
+
+					// SFs
 					if (glParams.showSF)
 					{
-						glFunc->glActiveTexture(GL_TEXTURE1);
-						glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+						glLODChunkSFPointer<QOpenGLFunctions_2_1>(m_currentDisplayedScalarField, glFunc, *toDisplay.indexMap, s, e, useProgram);
 					}
+					// colors
+					else if (glParams.showColors)
+					{
+						glLODChunkColorPointer<QOpenGLFunctions_2_1>(m_rgbaColors, glFunc, *toDisplay.indexMap, s, e, useProgram);
+					}
+
+					glFunc->glDrawArrays(GL_POINTS, 0, count);
+
+					if (prog)
+					{
+						glFunc->glDisableVertexAttribArray(ATTR_POS);
+						if (glParams.showNorms)
+						{
+							glFunc->glDisableVertexAttribArray(ATTR_NOR);
+						}
+						if (glParams.showSF)
+						{
+							glFunc->glDisableVertexAttribArray(ATTR_SF);
+						}
+						else if (glParams.showColors)
+						{
+							glFunc->glDisableVertexAttribArray(ATTR_COL);
+						}
+						// unbind array buffer
+						glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);
+					}
+					s = e;
 				}
-				else
+			}
+			else // standard display (all the points, or one every N points if toDisplay.decimStep > 0)
+			{
+				for (size_t k = 0; k < chunkCount; ++k)
 				{
-					glFunc->glDisableClientState(GL_VERTEX_ARRAY);
+					size_t chunkSize = ccChunk::Size(k, m_points);
+
+					// points
+					glChunkVertexPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
+
+					// visibility table
+					if (visTableEnabled && useProgram)
+					{
+						glChunkVisibilityPointer<QOpenGLFunctions_2_1>(m_pointsVisibility, glFunc, k, toDisplay.decimStep);
+					}
+
+					// normals
 					if (glParams.showNorms)
 					{
-						glFunc->glDisableClientState(GL_NORMAL_ARRAY);
+						glChunkNormalPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
 					}
-					if (glParams.showSF || glParams.showColors)
+					// SFs
+					if (glParams.showSF)
 					{
-						glFunc->glDisableClientState(GL_COLOR_ARRAY);
+						glChunkSFPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
 					}
+					// colors
+					else if (glParams.showColors)
+					{
+						glChunkColorPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
+					}
+
+					if (toDisplay.decimStep > 1)
+					{
+						chunkSize = chunkSize / static_cast<size_t>(toDisplay.decimStep); // equivalent to floor if value >= 0
+					}
+
+					glFunc->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(chunkSize));
+
+					if (useProgram)
+					{
+						glFunc->glDisableVertexAttribArray(ATTR_POS);
+						if (glParams.showNorms)
+						{
+							glFunc->glDisableVertexAttribArray(ATTR_NOR);
+						}
+						if (glParams.showSF)
+						{
+							glFunc->glDisableVertexAttribArray(ATTR_SF);
+						}
+						else if (glParams.showColors)
+						{
+							glFunc->glDisableVertexAttribArray(ATTR_COL);
+						}
+						// unbind array buffer
+						glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);
+					}
+				}
+			}
+
+			if (useProgram)
+			{
+				prog->release();
+
+				if (glParams.showNorms)
+				{
+					glFunc->glActiveTexture(GL_TEXTURE0);
+					glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+				}
+				if (glParams.showSF)
+				{
+					glFunc->glActiveTexture(GL_TEXTURE1);
+					glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+				}
+			}
+			else
+			{
+				glFunc->glDisableClientState(GL_VERTEX_ARRAY);
+				if (glParams.showNorms)
+				{
+					glFunc->glDisableClientState(GL_NORMAL_ARRAY);
+				}
+				if (glParams.showSF || glParams.showColors)
+				{
+					glFunc->glDisableClientState(GL_COLOR_ARRAY);
 				}
 			}
 		}

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -31,6 +31,7 @@
 #include "ccFastMarchingForNormsDirection.h"
 #include "ccFrustum.h"
 #include "ccGBLSensor.h"
+#include "ccGLSLHelper.h"
 #include "ccGenericGLDisplay.h"
 #include "ccGenericMesh.h"
 #include "ccHObjectCaster.h"
@@ -2757,25 +2758,12 @@ inline float GetSymmetricalNormalizedValue(ScalarType sfVal, const ccScalarField
 // the GL type depends on the PointCoordinateType 'size' (float or double)
 static GLenum GL_COORD_TYPE = sizeof(PointCoordinateType) == 4 ? GL_FLOAT : GL_DOUBLE;
 
-// Attribute indexes that we bound when creating the programs
-static const GLuint ATTR_POS  = 0;
-static const GLuint ATTR_NOR  = 1;
-static const GLuint ATTR_COL  = 2;
-static const GLuint ATTR_SF   = 4;
-static const GLuint ATTR_VIS  = 8;
-static const GLuint ATTR_CLIP = 16;
-// For internal use only
-static const GLuint ATTR_LOG_SCALE  = 32;
-static const GLuint ATTR_SYM_SCALE  = 64;
-static const GLuint ATTR_HIDDEN_VAL = 128;
-
 // Global OpenGL resources
-static QMap<int, QSharedPointer<QOpenGLShaderProgram>> s_programs;
-static GLuint                                          s_vboVertex  = 0;
-static GLuint                                          s_vboNormals = 0;
-static GLuint                                          s_vboColor   = 0;
-static GLuint                                          s_vboSF      = 0;
-static GLuint                                          s_vboVisib   = 0;
+static GLuint s_vboVertex  = 0;
+static GLuint s_vboNormals = 0;
+static GLuint s_vboColor   = 0;
+static GLuint s_vboSF      = 0;
+static GLuint s_vboVisib   = 0;
 
 void ccPointCloud::ReleaseOpenGLRessources()
 {
@@ -2786,13 +2774,12 @@ void ccPointCloud::ReleaseOpenGLRessources()
 	}
 
 	ccPointCloud::ReleaseShaders();
+	ccGLSL::ReleaseOpenGLRessources();
 
 	// get the set of OpenGL functions (version 2.1)
 	QOpenGLFunctions_2_1* glFunc = QOpenGLVersionFunctionsFactory::get<QOpenGLFunctions_2_1>(QOpenGLContext::currentContext());
 	if (glFunc)
 	{
-		s_programs.clear();
-
 		if (s_vboVertex != 0)
 		{
 			glFunc->glDeleteBuffers(1, &s_vboVertex);
@@ -2855,8 +2842,8 @@ void ccPointCloud::glChunkVertexPointer(const CC_DRAW_CONTEXT& context, size_t c
 		{
 			if (useProg)
 			{
-				glFunc->glEnableVertexAttribArray(ATTR_POS);
-				glFunc->glVertexAttribPointer(ATTR_POS, 3, GL_COORD_TYPE, GL_FALSE, decimStep * 3 * sizeof(PointCoordinateType), nullptr);
+				glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_POS);
+				glFunc->glVertexAttribPointer(ccGLSL::ATTR_POS, 3, GL_COORD_TYPE, GL_FALSE, decimStep * 3 * sizeof(PointCoordinateType), nullptr);
 			}
 			else
 			{
@@ -2878,8 +2865,8 @@ void ccPointCloud::glChunkVertexPointer(const CC_DRAW_CONTEXT& context, size_t c
 		{
 			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVertex);
 			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(ccChunk::Size(chunkIndex, m_points) * 3 * sizeof(PointCoordinateType)), ccChunk::Start(m_points, chunkIndex), GL_DYNAMIC_DRAW);
-			glFunc->glEnableVertexAttribArray(ATTR_POS);
-			glFunc->glVertexAttribPointer(ATTR_POS, 3, GL_COORD_TYPE, GL_FALSE, decimStep * 3 * sizeof(PointCoordinateType), nullptr);
+			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_POS);
+			glFunc->glVertexAttribPointer(ccGLSL::ATTR_POS, 3, GL_COORD_TYPE, GL_FALSE, decimStep * 3 * sizeof(PointCoordinateType), nullptr);
 		}
 		else
 		{
@@ -2920,8 +2907,8 @@ static void glChunkVisibilityPointer(const ccGenericPointCloud::VisibilityTableT
 
 	glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVisib);
 	glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(count * sizeof(float)), s_visibilityBuffer, GL_DYNAMIC_DRAW);
-	glFunc->glEnableVertexAttribArray(ATTR_VIS);
-	glFunc->glVertexAttribPointer(ATTR_VIS, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+	glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_VIS);
+	glFunc->glVertexAttribPointer(ccGLSL::ATTR_VIS, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
 }
 
 void ccPointCloud::glChunkNormalPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs, bool useProg /*=false*/)
@@ -2947,8 +2934,8 @@ void ccPointCloud::glChunkNormalPointer(const CC_DRAW_CONTEXT& context, size_t c
 			// we can use the pre-loaded VBOs
 			if (m_vboManager.vbos[chunkIndex]->normalIndexBuffer.bind())
 			{
-				glFunc->glEnableVertexAttribArray(ATTR_NOR);
-				glFunc->glVertexAttribPointer(ATTR_NOR, 1, GL_FLOAT, GL_FALSE, decimStep * sizeof(float), nullptr);
+				glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_NOR);
+				glFunc->glVertexAttribPointer(ccGLSL::ATTR_NOR, 1, GL_FLOAT, GL_FALSE, decimStep * sizeof(float), nullptr);
 				m_vboManager.vbos[chunkIndex]->normalIndexBuffer.release();
 			}
 			else
@@ -2976,8 +2963,8 @@ void ccPointCloud::glChunkNormalPointer(const CC_DRAW_CONTEXT& context, size_t c
 
 				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboNormals);
 				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(count * sizeof(float)), s_normalBuffer, GL_DYNAMIC_DRAW);
-				glFunc->glEnableVertexAttribArray(ATTR_NOR);
-				glFunc->glVertexAttribPointer(ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+				glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_NOR);
+				glFunc->glVertexAttribPointer(ccGLSL::ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
 			}
 			else
 			{
@@ -3031,8 +3018,8 @@ void ccPointCloud::glChunkColorPointer(const CC_DRAW_CONTEXT& context, size_t ch
 		{
 			if (useProg)
 			{
-				glFunc->glEnableVertexAttribArray(ATTR_COL);
-				glFunc->glVertexAttribPointer(ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, decimStep * 4 * sizeof(ColorCompType), nullptr);
+				glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_COL);
+				glFunc->glVertexAttribPointer(ccGLSL::ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, decimStep * 4 * sizeof(ColorCompType), nullptr);
 			}
 			else
 			{
@@ -3054,8 +3041,8 @@ void ccPointCloud::glChunkColorPointer(const CC_DRAW_CONTEXT& context, size_t ch
 		{
 			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
 			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(ccChunk::Size(chunkIndex, m_rgbaColors->size()) * 4 * sizeof(unsigned char)), ccChunk::Start(*m_rgbaColors, chunkIndex), GL_DYNAMIC_DRAW);
-			glFunc->glEnableVertexAttribArray(ATTR_COL);
-			glFunc->glVertexAttribPointer(ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, decimStep * 4 * sizeof(ColorCompType), nullptr);
+			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_COL);
+			glFunc->glVertexAttribPointer(ccGLSL::ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, decimStep * 4 * sizeof(ColorCompType), nullptr);
 		}
 		else
 		{
@@ -3111,8 +3098,8 @@ void ccPointCloud::glChunkSFPointer(const CC_DRAW_CONTEXT& context, size_t chunk
 		{
 			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboSF);
 			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(ccChunk::Size(chunkIndex, m_currentDisplayedScalarField->size()) * sizeof(float)), ccChunk::Start(m_currentDisplayedScalarField->data(), chunkIndex), GL_DYNAMIC_DRAW);
-			glFunc->glEnableVertexAttribArray(ATTR_SF);
-			glFunc->glVertexAttribPointer(ATTR_SF, 1, GL_FLOAT, GL_FALSE, decimStep * sizeof(float), nullptr);
+			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_SF);
+			glFunc->glVertexAttribPointer(ccGLSL::ATTR_SF, 1, GL_FLOAT, GL_FALSE, decimStep * sizeof(float), nullptr);
 		}
 		else
 		{
@@ -3168,8 +3155,8 @@ static void glLODChunkVertexPointer(ccPointCloud*      cloud,
 		{
 			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVertex);
 			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * 3 * sizeof(PointCoordinateType)), s_pointBuffer, GL_DYNAMIC_DRAW);
-			glFunc->glEnableVertexAttribArray(ATTR_POS);
-			glFunc->glVertexAttribPointer(ATTR_POS, 3, GL_COORD_TYPE, GL_FALSE, 0, nullptr);
+			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_POS);
+			glFunc->glVertexAttribPointer(ccGLSL::ATTR_POS, 3, GL_COORD_TYPE, GL_FALSE, 0, nullptr);
 		}
 		else
 		{
@@ -3209,8 +3196,8 @@ static void glLODChunkVisibilityPointer(const ccGenericPointCloud::VisibilityTab
 
 	glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVisib);
 	glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * sizeof(float)), s_visibilityBuffer, GL_DYNAMIC_DRAW);
-	glFunc->glEnableVertexAttribArray(ATTR_VIS);
-	glFunc->glVertexAttribPointer(ATTR_VIS, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+	glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_VIS);
+	glFunc->glVertexAttribPointer(ccGLSL::ATTR_VIS, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
 }
 
 template <class QOpenGLFunctions>
@@ -3238,8 +3225,8 @@ static void glLODChunkNormalPointer(NormsIndexesTableType* normals,
 
 			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboNormals);
 			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * sizeof(float)), s_normalBuffer, GL_DYNAMIC_DRAW);
-			glFunc->glEnableVertexAttribArray(ATTR_NOR);
-			glFunc->glVertexAttribPointer(ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_NOR);
+			glFunc->glVertexAttribPointer(ccGLSL::ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
 		}
 		else
 		{
@@ -3298,8 +3285,8 @@ static void glLODChunkColorPointer(RGBAColorsTableType* colors,
 			// we must re-order colors in a dedicated static array
 			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
 			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * 4 * sizeof(unsigned char)), s_rgbBuffer4ub, GL_DYNAMIC_DRAW);
-			glFunc->glEnableVertexAttribArray(ATTR_COL);
-			glFunc->glVertexAttribPointer(ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, nullptr);
+			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_COL);
+			glFunc->glVertexAttribPointer(ccGLSL::ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, nullptr);
 		}
 		else
 		{
@@ -3338,8 +3325,8 @@ static void glLODChunkSFPointer(ccScalarField*     sf,
 
 			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboSF);
 			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * sizeof(float)), s_rgbBuffer4ub, GL_DYNAMIC_DRAW);
-			glFunc->glEnableVertexAttribArray(ATTR_SF);
-			glFunc->glVertexAttribPointer(ATTR_SF, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_SF);
+			glFunc->glVertexAttribPointer(ccGLSL::ATTR_SF, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
 		}
 		else
 		{
@@ -3407,332 +3394,6 @@ struct DisplayDesc : LODLevelDesc
 	//! Map of indexes (to invert the natural order)
 	LODIndexSet* indexMap;
 };
-
-// GLSL program builder (GLSL 1.20) for cloud rendering (position, normal, color, scalar values)
-static QSharedPointer<QOpenGLShaderProgram> BuildCloudDisplayProgram(QOpenGLFunctions_2_1* glFunc, int attributes, ccScalarField* sf /*=nullptr*/)
-{
-	if (!glFunc)
-	{
-		assert(false);
-		return nullptr;
-	}
-
-	// add secondary attributes
-	if (attributes & ATTR_SF)
-	{
-		if (!sf)
-		{
-			assert(false);
-			return nullptr;
-		}
-
-		if (sf->logScale())
-		{
-			attributes |= ATTR_LOG_SCALE;
-		}
-		else if (sf->symmetricalScale())
-		{
-			attributes |= ATTR_SYM_SCALE;
-		}
-		if (!sf->areNaNValuesShownInGrey())
-		{
-			attributes |= ATTR_HIDDEN_VAL;
-		}
-	}
-
-	if (s_programs.contains(attributes))
-	{
-		return s_programs[attributes];
-	}
-
-	// Vertex programs
-	static const char* VertexProgHeaderSrc =
-	    "#version 120\n"
-	    "attribute vec3 aPosition;\n"
-	    "varying vec4 vColor;\n";
-
-	static const char* VertexProgVisibilityAttributesSrc =
-	    "attribute float aVisib;\n";
-
-	static const char* VertexProgColorAttributesSrc =
-	    "attribute vec4 aColor;\n";
-
-	static const char* VertexProgSFAttributesSrc =
-	    "attribute float aSFValue;\n"
-	    "uniform sampler2D uColorScaleTex;\n"
-	    "uniform int uTexWidth;\n"
-	    "uniform int uTexHeight;\n"
-	    "uniform float uMinVal;\n"
-	    "uniform float uMaxVal;\n"
-	    "uniform float uMinSat;\n"
-	    "uniform float uMaxSat;\n"
-	    "uniform float uSatRange;\n"
-	    "uniform float uOutOfRangeGreyScale;\n";
-
-	static const char* VertexProgNormAttributesSrc =
-	    "attribute float aNormalIndex;\n"
-	    "varying vec3 vNormal;\n"
-	    "uniform sampler2D uNormalLUT;\n"
-	    "uniform int uLUTWidth;\n"
-	    "uniform int uLUTHeight;\n";
-
-	static const char* VertexProgFetchNormFuncSrc =
-	    "vec3 fetchNormalFromLUT(float fi)\n"
-	    "{\n"
-	    "	float w  = float(uLUTWidth);\n"
-	    "	float h  = float(uLUTHeight);\n"
-	    "	float tx = mod(fi, w);\n"
-	    "	float ty = floor(fi / w);\n"
-	    "	vec2 uv = vec2((tx + 0.5) / w, (ty + 0.5) / h);\n"
-	    "	vec3 enc = texture2D(uNormalLUT, uv).rgb;\n"
-	    "	vec3 n = enc * 2.0 - 1.0;\n"
-	    "	return normalize(n);\n"
-	    "}\n";
-
-	static const char* VertexProgFetchSFColorFuncSrc =
-	    "vec4 fetchColorFromTex(float sfVal)\n"
-	    "{\n"
-	    "   float v = normalizeSFVal(sfVal);\n"
-	    "   v = v * float(uTexWidth * uTexHeight - 1);\n"
-	    "	float w  = float(uTexWidth);\n"
-	    "	float h  = float(uTexHeight);\n"
-	    "	float tx = mod(v, w);\n"
-	    "	float ty = floor(v/ w);\n"
-	    "	vec2 uv = vec2(tx / w, ty / h);\n"
-	    "	vec4 color = texture2D(uColorScaleTex, uv);\n"
-	    "	return color;\n"
-	    "}\n";
-
-	static const char* NormalizeNonSymmetricalValueFuncSrc =
-	    "float normalizeSFVal(float sfVal)\n"
-	    "{\n"
-	    "   if (sfVal <= uMinSat)\n"
-	    "      return 0.0;\n"
-	    "   if (sfVal >= uMaxSat)\n"
-	    "      return 1.0;\n"
-	    "   return (sfVal - uMinSat) / uSatRange;\n"
-	    "}\n";
-
-	static const char* NormalizeSymmetricalValueFuncSrc =
-	    "float normalizeSFVal(float sfVal)\n"
-	    "{\n"
-	    "   if (abs(sfVal) <= uMinSat)\n"
-	    "      return 0.5;\n"
-	    "   if (sfVal >= 0)\n"
-	    "   {\n"
-	    "      if (sfVal > uMaxSat)\n"
-	    "         return 1.0;\n"
-	    "      return (1.0 + (sfVal - uMinSat) / uSatRange) / 2.0;\n"
-	    "   }\n"
-	    "   else\n"
-	    "   {\n"
-	    "      if (sfVal < -uMaxSat)\n"
-	    "         return 0.0;\n"
-	    "      return (1.0 + (sfVal + uMinSat) / uSatRange) / 2.0;\n"
-	    "   }\n"
-	    "}\n";
-
-	static const char* NormalizeValueLogScaleFuncSrc =
-	    "float normalizeSFVal(float sfVal)\n"
-	    "{\n"
-	    " 	float dLog = log(max(abs(d), 0.00001)) / log(10.0);\n"
-	    "   if (dLog <= uMinSat)\n"
-	    "      return 0.0;\n"
-	    "   if (dLog >= uMaxSat)\n"
-	    "      return 1.0;\n"
-	    "   return (dLog - uMinSat) / uSatRange;\n"
-	    "}\n";
-
-	static const char* VertexProgMainStartSrc =
-	    "void main()\n"
-	    "{\n";
-
-	static const char* VertexProgMainUseDefaultGLColorSrc =
-	    "    vColor = gl_Color;\n";
-
-	static const char* VertexProgMainUseInputColorSrc =
-	    "    vColor = aColor;\n";
-
-	static const char* VertexProgMainFetchSFColorSrc =
-	    "   if (aSFValue >= uMinVal && aSFValue <= uMaxVal)\n"
-	    "   {\n"
-	    "      vColor = fetchColorFromTex(aSFValue);\n"
-	    "   }\n"
-	    "   else\n"
-	    "   {\n"
-	    "      vColor = vec4(uOutOfRangeGreyScale, uOutOfRangeGreyScale, uOutOfRangeGreyScale, 1.0);\n"
-	    "   }\n";
-
-	static const char* VertexProgMainFetchSFColorHideNaNSrc =
-	    "   if (aSFValue >= uMinVal && aSFValue <= uMaxVal)\n"
-	    "   {\n"
-	    "      vColor = fetchColorFromTex(aSFValue);\n"
-	    "   }\n"
-	    "   else\n"
-	    "   {\n"
-	    "      gl_Position = vec4(0, 0, 0, -1.0);\n" // impossible position, should be discarded by the GPU
-	    "      return;\n"
-	    "   }\n";
-
-	static const char* VertexProgMainTestVisibilitySrc =
-	    "   if (aVisib > 0.0)\n" // CCCoreLib::POINT_VISIBLE = 0
-	    "   {\n"
-	    "      gl_Position = vec4(0, 0, 0, -1.0);\n" // impossible position, should be discarded by the GPU
-	    "      return;\n"
-	    "   }\n";
-
-	static const char* VertexProgMainFetchNormalSrc =
-	    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n";
-
-	static const char* VertexProgMainClippingSrc =
-	    "    gl_ClipVertex = gl_ModelViewMatrix * vec4(aPosition, 1.0);\n";
-
-	static const char* VertexProgMainEndSrc =
-	    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
-	    "}\n";
-
-	// Fragment programs
-	static const char* ColorOnlyFragmentProgSrc =
-	    "#version 120\n"
-	    "varying vec4 vColor;\n"
-	    "void main()\n"
-	    "{\n"
-	    "    gl_FragColor = vColor;\n"
-	    "}\n";
-
-	static const char* ColorAndNormalFragmentProgSrc =
-	    "#version 120\n"
-	    "varying vec4 vColor;\n"
-	    "varying vec3 vNormal;\n"
-	    "void main()\n"
-	    "{\n"
-	    "    vec3 n = normalize(vNormal);\n"
-	    "    vec3 lightDir = normalize(vec3(0.0,0.0,1.0));\n"
-	    "    float diff = max(dot(n, lightDir), 0.0);\n"
-	    "    vec4 base = vColor;\n"
-	    "    gl_FragColor = vec4(base.rgb * diff, base.a);\n"
-	    "}\n";
-
-	QString vertexProgSrc = VertexProgHeaderSrc;
-	{
-		// add attributes
-		if (attributes & ATTR_SF)
-			vertexProgSrc += VertexProgSFAttributesSrc;
-		else if (attributes & ATTR_COL)
-			vertexProgSrc += VertexProgColorAttributesSrc;
-		if (attributes & ATTR_NOR)
-			vertexProgSrc += VertexProgNormAttributesSrc;
-		if (attributes & ATTR_VIS)
-			vertexProgSrc += VertexProgVisibilityAttributesSrc;
-
-		// add special functions
-		if (attributes & ATTR_SF)
-		{
-			if (attributes & ATTR_LOG_SCALE)
-			{
-				vertexProgSrc += NormalizeValueLogScaleFuncSrc;
-			}
-			else
-			{
-				vertexProgSrc += ((attributes & ATTR_SYM_SCALE) ? NormalizeSymmetricalValueFuncSrc : NormalizeNonSymmetricalValueFuncSrc);
-			}
-			vertexProgSrc += VertexProgFetchSFColorFuncSrc;
-		}
-
-		if (attributes & ATTR_NOR)
-		{
-			vertexProgSrc += VertexProgFetchNormFuncSrc;
-		}
-
-		// main function
-		{
-			vertexProgSrc += VertexProgMainStartSrc;
-
-			if (attributes & ATTR_VIS)
-			{
-				vertexProgSrc += VertexProgMainTestVisibilitySrc;
-			}
-
-			// color transfer
-			if (attributes & ATTR_SF)
-			{
-				vertexProgSrc += ((attributes & ATTR_HIDDEN_VAL) ? VertexProgMainFetchSFColorHideNaNSrc : VertexProgMainFetchSFColorSrc);
-			}
-			else if (attributes & ATTR_COL)
-			{
-				vertexProgSrc += VertexProgMainUseInputColorSrc;
-			}
-			else
-			{
-				vertexProgSrc += VertexProgMainUseDefaultGLColorSrc;
-			}
-
-			// normal transfer (if any)
-			if (attributes & ATTR_NOR)
-			{
-				vertexProgSrc += VertexProgMainFetchNormalSrc;
-			}
-
-			if (attributes & ATTR_CLIP)
-			{
-				vertexProgSrc += VertexProgMainClippingSrc;
-			}
-
-			vertexProgSrc += VertexProgMainEndSrc;
-		}
-	}
-
-	QString fragmentProgSrc = (attributes & ATTR_NOR ? ColorAndNormalFragmentProgSrc : ColorOnlyFragmentProgSrc);
-
-	QOpenGLShader vertexShader(QOpenGLShader::Vertex);
-	if (false == vertexShader.compileSourceCode(vertexProgSrc))
-	{
-		ccLog::Warning(QString("[BuildCloudDisplayProgram] Vertex shader compilation failed: ") + vertexShader.log());
-		return nullptr;
-	}
-	QOpenGLShader fragmentShader(QOpenGLShader::Fragment);
-	if (false == fragmentShader.compileSourceCode(fragmentProgSrc))
-	{
-		ccLog::Warning(QString("[BuildCloudDisplayProgram] Fragment shader compilation failed: ") + fragmentShader.log());
-		return nullptr;
-	}
-	QSharedPointer<QOpenGLShaderProgram> program(new QOpenGLShaderProgram);
-	program->addShader(&vertexShader);
-	program->addShader(&fragmentShader);
-
-	// bind attribute locations before linking for stable locations
-	program->bindAttributeLocation("aPosition", ATTR_POS);
-	if (attributes & ATTR_VIS)
-	{
-		program->bindAttributeLocation("aVisib", ATTR_VIS);
-	}
-	if (attributes & ATTR_SF)
-	{
-		assert((attributes & ATTR_COL) == 0);
-		program->bindAttributeLocation("aSFValue", ATTR_SF);
-	}
-	else if (attributes & ATTR_COL)
-	{
-		assert((attributes & ATTR_SF) == 0);
-		program->bindAttributeLocation("aColor", ATTR_COL);
-	}
-	if (attributes & ATTR_NOR)
-	{
-		program->bindAttributeLocation("aNormalIndex", ATTR_NOR);
-	}
-
-	if (false == program->link())
-	{
-		ccLog::Warning(QString("[BuildCloudDisplayProgram] Shader program linking failed: ") + program->log());
-		return nullptr;
-	}
-
-	s_programs[attributes] = program;
-
-	ccGLDrawContext::CatchGLErrors(glFunc->glGetError(), "ccPointCloud::shader.program.build");
-
-	return program;
-}
 
 void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 {
@@ -3989,29 +3650,29 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 		if ((false == s_normalLUTTextureFailed)
 		    && (false == s_globalVBOCreationFailed))
 		{
-			int attributes = ATTR_POS; // ATTR_POS == 0
+			int attributes = ccGLSL::ATTR_POS; // ccGLSL::ATTR_POS == 0
 			if (glParams.showNorms)
 			{
-				attributes |= ATTR_NOR;
+				attributes |= ccGLSL::ATTR_NOR;
 			}
 			if (glParams.showSF)
 			{
-				attributes |= ATTR_SF;
+				attributes |= ccGLSL::ATTR_SF;
 			}
 			else if (glParams.showColors)
 			{
-				attributes |= ATTR_COL;
+				attributes |= ccGLSL::ATTR_COL;
 			}
 			if (visTableEnabled)
 			{
-				attributes |= ATTR_VIS;
+				attributes |= ccGLSL::ATTR_VIS;
 			}
 			if (!m_clipPlanes.empty())
 			{
-				attributes |= ATTR_CLIP;
+				attributes |= ccGLSL::ATTR_CLIP;
 			}
 
-			prog = BuildCloudDisplayProgram(glFunc, attributes, glParams.showSF ? m_currentDisplayedScalarField : nullptr);
+			prog = ccGLSL::BuildDisplayProgram(glFunc, attributes, glParams.showSF ? m_currentDisplayedScalarField : nullptr);
 
 			if (glParams.showSF && prog)
 			{
@@ -4050,7 +3711,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 				}
 			}
 
-			if (prog && (attributes & ATTR_NOR) && s_vboNormals == 0)
+			if (prog && (attributes & ccGLSL::ATTR_NOR) && s_vboNormals == 0)
 			{
 				glFunc->glGenBuffers(1, &s_vboNormals);
 				if (0 == s_vboNormals)
@@ -4060,7 +3721,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 				}
 			}
 
-			if (prog && (attributes & ATTR_SF) && s_vboSF == 0)
+			if (prog && (attributes & ccGLSL::ATTR_SF) && s_vboSF == 0)
 			{
 				glFunc->glGenBuffers(1, &s_vboSF);
 				if (0 == s_vboSF)
@@ -4070,7 +3731,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 				}
 			}
 
-			if (prog && (attributes & ATTR_COL) && s_vboColor == 0)
+			if (prog && (attributes & ccGLSL::ATTR_COL) && s_vboColor == 0)
 			{
 				glFunc->glGenBuffers(1, &s_vboColor);
 				if (0 == s_vboColor)
@@ -4080,7 +3741,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 				}
 			}
 
-			if (prog && (attributes & ATTR_VIS) && s_vboVisib == 0)
+			if (prog && (attributes & ccGLSL::ATTR_VIS) && s_vboVisib == 0)
 			{
 				glFunc->glGenBuffers(1, &s_vboVisib);
 				if (0 == s_vboVisib)
@@ -4351,6 +4012,12 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 			{
 				prog->bind();
 
+				if (glParams.showNorms)
+				{
+					glFunc->glUniform1i(prog->uniformLocation("uLight0Enabled"), glFunc->glIsEnabled(GL_LIGHT0) ? 1 : 0);
+					glFunc->glUniform1i(prog->uniformLocation("uLight1Enabled"), glFunc->glIsEnabled(GL_LIGHT1) ? 1 : 0);
+				}
+
 				if (lutTex)
 				{
 					// bind normal acceleration LUT texture to unit 0
@@ -4358,22 +4025,10 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 					glFunc->glBindTexture(GL_TEXTURE_2D, lutTex->textureId());
 
 					// set sampler uniform to unit 0
-					int locSampler = prog->uniformLocation("uNormalLUT");
-					if (locSampler >= 0)
-					{
-						glFunc->glUniform1i(locSampler, 0);
-					}
+					glFunc->glUniform1i(prog->uniformLocation("uNormalLUT"), 0);
 					// set LUT dimensions
-					int locW = prog->uniformLocation("uLUTWidth");
-					if (locW >= 0)
-					{
-						glFunc->glUniform1i(locW, lutTex->width());
-					}
-					int locH = prog->uniformLocation("uLUTHeight");
-					if (locH >= 0)
-					{
-						glFunc->glUniform1i(locH, lutTex->height());
-					}
+					glFunc->glUniform1i(prog->uniformLocation("uLUTWidth"), lutTex->width());
+					glFunc->glUniform1i(prog->uniformLocation("uLUTHeight"), lutTex->height());
 				}
 
 				if (sfTex && m_currentDisplayedScalarField)
@@ -4383,22 +4038,10 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 					glFunc->glBindTexture(GL_TEXTURE_2D, sfTex->textureId());
 
 					// set sampler uniform to unit 1
-					int locSampler = prog->uniformLocation("uColorScaleTex");
-					if (locSampler >= 0)
-					{
-						glFunc->glUniform1i(locSampler, 1);
-					}
+					glFunc->glUniform1i(prog->uniformLocation("uColorScaleTex"), 1);
 					// set texture dimensions
-					int locW = prog->uniformLocation("uTexWidth");
-					if (locW >= 0)
-					{
-						glFunc->glUniform1i(locW, sfTex->width());
-					}
-					int locH = prog->uniformLocation("uTexHeight");
-					if (locH >= 0)
-					{
-						glFunc->glUniform1i(locH, sfTex->height());
-					}
+					glFunc->glUniform1i(prog->uniformLocation("uTexWidth"), sfTex->width());
+					glFunc->glUniform1i(prog->uniformLocation("uTexHeight"), sfTex->height());
 
 					auto   colorScale = m_currentDisplayedScalarField->getColorScale();
 					double offset     = m_currentDisplayedScalarField->getOffset();
@@ -4496,18 +4139,18 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 					if (prog)
 					{
-						glFunc->glDisableVertexAttribArray(ATTR_POS);
+						glFunc->glDisableVertexAttribArray(ccGLSL::ATTR_POS);
 						if (glParams.showNorms)
 						{
-							glFunc->glDisableVertexAttribArray(ATTR_NOR);
+							glFunc->glDisableVertexAttribArray(ccGLSL::ATTR_NOR);
 						}
 						if (glParams.showSF)
 						{
-							glFunc->glDisableVertexAttribArray(ATTR_SF);
+							glFunc->glDisableVertexAttribArray(ccGLSL::ATTR_SF);
 						}
 						else if (glParams.showColors)
 						{
-							glFunc->glDisableVertexAttribArray(ATTR_COL);
+							glFunc->glDisableVertexAttribArray(ccGLSL::ATTR_COL);
 						}
 						// unbind array buffer
 						glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -4555,18 +4198,18 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 					if (useProgram)
 					{
-						glFunc->glDisableVertexAttribArray(ATTR_POS);
+						glFunc->glDisableVertexAttribArray(ccGLSL::ATTR_POS);
 						if (glParams.showNorms)
 						{
-							glFunc->glDisableVertexAttribArray(ATTR_NOR);
+							glFunc->glDisableVertexAttribArray(ccGLSL::ATTR_NOR);
 						}
 						if (glParams.showSF)
 						{
-							glFunc->glDisableVertexAttribArray(ATTR_SF);
+							glFunc->glDisableVertexAttribArray(ccGLSL::ATTR_SF);
 						}
 						else if (glParams.showColors)
 						{
-							glFunc->glDisableVertexAttribArray(ATTR_COL);
+							glFunc->glDisableVertexAttribArray(ccGLSL::ATTR_COL);
 						}
 						// unbind array buffer
 						glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -3164,10 +3164,17 @@ static void glLODChunkVertexPointer(ccPointCloud*      cloud,
 
 	if (useProg)
 	{
-		glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVertex);
-		glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * 3 * sizeof(PointCoordinateType)), s_pointBuffer, GL_DYNAMIC_DRAW);
-		glFunc->glEnableVertexAttribArray(ATTR_POS);
-		glFunc->glVertexAttribPointer(ATTR_POS, 3, GL_COORD_TYPE, GL_FALSE, 0, nullptr);
+		if (0 != s_vboVertex)
+		{
+			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVertex);
+			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * 3 * sizeof(PointCoordinateType)), s_pointBuffer, GL_DYNAMIC_DRAW);
+			glFunc->glEnableVertexAttribArray(ATTR_POS);
+			glFunc->glVertexAttribPointer(ATTR_POS, 3, GL_COORD_TYPE, GL_FALSE, 0, nullptr);
+		}
+		else
+		{
+			assert(false);
+		}
 	}
 	else
 	{
@@ -3982,7 +3989,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 		if ((false == s_normalLUTTextureFailed)
 		    && (false == s_globalVBOCreationFailed))
 		{
-			int attributes = ATTR_POS;
+			int attributes = ATTR_POS; // ATTR_POS == 0
 			if (glParams.showNorms)
 			{
 				attributes |= ATTR_NOR;
@@ -4033,7 +4040,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 			}
 
 			// static VBO handles reused between calls
-			if (prog && (attributes & ATTR_POS) && s_vboVertex == 0)
+			if (prog && s_vboVertex == 0)
 			{
 				glFunc->glGenBuffers(1, &s_vboVertex);
 				if (0 == s_vboVertex)

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -3570,7 +3570,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 	// ccLog::Print(QString("Rendering %1 points starting from index %2 (LoD = %3 / PN = %4)").arg(toDisplay.count).arg(toDisplay.startIndex).arg(toDisplay.indexMap ? "yes" : "no").arg(pushName ? "yes" : "no"));
 
-	glFunc->glPushAttrib(GL_LIGHTING_BIT | GL_COLOR_BUFFER_BIT | GL_TRANSFORM_BIT | GL_POINT_BIT | GL_TEXTURE_BIT | GL_POINT_BIT);
+	glFunc->glPushAttrib(GL_LIGHTING_BIT | GL_COLOR_BUFFER_BIT | GL_TRANSFORM_BIT | GL_POINT_BIT | GL_TEXTURE_BIT);
 
 	if (glParams.showSF || glParams.showColors)
 	{
@@ -6838,7 +6838,7 @@ void ccPointCloud::decompressNormals()
 		{
 			m_decompressedNormals.resize(size());
 		}
-		catch (const std::bad_alloc)
+		catch (const std::bad_alloc&)
 		{
 			ccLog::Warning("Not enough memory to decompress normals");
 			m_normalsDrawnAsLines = false;

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -2759,11 +2759,11 @@ inline float GetSymmetricalNormalizedValue(ScalarType sfVal, const ccScalarField
 static GLenum GL_COORD_TYPE = sizeof(PointCoordinateType) == 4 ? GL_FLOAT : GL_DOUBLE;
 
 // Global OpenGL resources
-static GLuint s_vboVertex  = 0;
-static GLuint s_vboNormals = 0;
-static GLuint s_vboColor   = 0;
-static GLuint s_vboSF      = 0;
-static GLuint s_vboVisib   = 0;
+static QOpenGLBuffer s_vboVertex;
+static QOpenGLBuffer s_vboNormals;
+static QOpenGLBuffer s_vboColor;
+static QOpenGLBuffer s_vboSF;
+static QOpenGLBuffer s_vboVisib;
 
 void ccPointCloud::ReleaseOpenGLRessources()
 {
@@ -2776,40 +2776,19 @@ void ccPointCloud::ReleaseOpenGLRessources()
 	ccPointCloud::ReleaseShaders();
 	ccGLSL::ReleaseOpenGLRessources();
 
-	// get the set of OpenGL functions (version 2.1)
-	QOpenGLFunctions_2_1* glFunc = QOpenGLVersionFunctionsFactory::get<QOpenGLFunctions_2_1>(QOpenGLContext::currentContext());
-	if (glFunc)
+	auto releaseVBO = [](QOpenGLBuffer& vbo)
 	{
-		if (s_vboVertex != 0)
+		if (vbo.isCreated())
 		{
-			glFunc->glDeleteBuffers(1, &s_vboVertex);
-			s_vboVertex = 0;
+			vbo.destroy();
 		}
+	};
 
-		if (s_vboNormals != 0)
-		{
-			glFunc->glDeleteBuffers(1, &s_vboNormals);
-			s_vboNormals = 0;
-		}
-
-		if (s_vboColor != 0)
-		{
-			glFunc->glDeleteBuffers(1, &s_vboColor);
-			s_vboColor = 0;
-		}
-
-		if (s_vboSF != 0)
-		{
-			glFunc->glDeleteBuffers(1, &s_vboSF);
-			s_vboSF = 0;
-		}
-
-		if (s_vboVisib != 0)
-		{
-			glFunc->glDeleteBuffers(1, &s_vboVisib);
-			s_vboVisib = 0;
-		}
-	}
+	releaseVBO(s_vboVertex);
+	releaseVBO(s_vboNormals);
+	releaseVBO(s_vboColor);
+	releaseVBO(s_vboSF);
+	releaseVBO(s_vboVisib);
 }
 
 /// Maximum number of points (per cloud) displayed in a single LOD iteration
@@ -2861,12 +2840,13 @@ void ccPointCloud::glChunkVertexPointer(const CC_DRAW_CONTEXT& context, size_t c
 	}
 	else if (useProg) // use a program but no pre-saved VBOs (only the global one)
 	{
-		if (s_vboVertex != 0)
+		if (s_vboVertex.isCreated())
 		{
-			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVertex);
-			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(ccChunk::Size(chunkIndex, m_points) * 3 * sizeof(PointCoordinateType)), ccChunk::Start(m_points, chunkIndex), GL_STREAM_DRAW);
+			s_vboVertex.bind();
+			s_vboVertex.write(0, ccChunk::Start(m_points, chunkIndex), static_cast<int>(ccChunk::Size(chunkIndex, m_points) * 3 * sizeof(PointCoordinateType)));
 			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_POS);
 			glFunc->glVertexAttribPointer(ccGLSL::ATTR_POS, 3, GL_COORD_TYPE, GL_FALSE, decimStep * 3 * sizeof(PointCoordinateType), nullptr);
+			s_vboVertex.release();
 		}
 		else
 		{
@@ -2888,7 +2868,7 @@ static void glChunkVisibilityPointer(const ccGenericPointCloud::VisibilityTableT
 {
 	assert(glFunc);
 
-	if (s_vboVisib == 0)
+	if (!s_vboVisib.isCreated())
 	{
 		assert(false);
 		return;
@@ -2905,10 +2885,11 @@ static void glChunkVisibilityPointer(const ccGenericPointCloud::VisibilityTableT
 		++count;
 	}
 
-	glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVisib);
-	glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(count * sizeof(float)), s_visibilityBuffer, GL_STREAM_DRAW);
+	s_vboVisib.bind();
+	s_vboVisib.write(0, s_visibilityBuffer, static_cast<int>(count * sizeof(float)));
 	glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_VIS);
 	glFunc->glVertexAttribPointer(ccGLSL::ATTR_VIS, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+	s_vboVisib.release();
 }
 
 void ccPointCloud::glChunkNormalPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs, bool useProg /*=false*/)
@@ -2948,7 +2929,7 @@ void ccPointCloud::glChunkNormalPointer(const CC_DRAW_CONTEXT& context, size_t c
 		}
 		else // use a program but no pre-saved VBOs (only the global one)
 		{
-			if (s_vboNormals != 0)
+			if (s_vboNormals.isCreated())
 			{
 				// TODO FIXME: use a more recent GLSL version to pass unsigned int directly!
 				float* _normalIndexes = reinterpret_cast<float*>(s_normalBuffer);
@@ -2961,10 +2942,11 @@ void ccPointCloud::glChunkNormalPointer(const CC_DRAW_CONTEXT& context, size_t c
 					++count;
 				}
 
-				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboNormals);
-				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(count * sizeof(float)), s_normalBuffer, GL_STREAM_DRAW);
+				s_vboNormals.bind();
+				s_vboNormals.write(0, s_normalBuffer, static_cast<int>(count * sizeof(float)));
 				glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_NOR);
 				glFunc->glVertexAttribPointer(ccGLSL::ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+				s_vboNormals.release();
 			}
 			else
 			{
@@ -3037,12 +3019,13 @@ void ccPointCloud::glChunkColorPointer(const CC_DRAW_CONTEXT& context, size_t ch
 	}
 	else if (useProg) // use a program but no pre-loaded VBOs (only the global one)
 	{
-		if (s_vboColor != 0)
+		if (s_vboColor.isCreated())
 		{
-			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
-			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(ccChunk::Size(chunkIndex, m_rgbaColors->size()) * 4 * sizeof(unsigned char)), ccChunk::Start(*m_rgbaColors, chunkIndex), GL_STREAM_DRAW);
+			s_vboColor.bind();
+			s_vboColor.write(0, ccChunk::Start(*m_rgbaColors, chunkIndex), static_cast<int>(ccChunk::Size(chunkIndex, m_rgbaColors->size()) * 4 * sizeof(unsigned char)));
 			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_COL);
 			glFunc->glVertexAttribPointer(ccGLSL::ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, decimStep * 4 * sizeof(ColorCompType), nullptr);
+			s_vboColor.release();
 		}
 		else
 		{
@@ -3094,12 +3077,13 @@ void ccPointCloud::glChunkSFPointer(const CC_DRAW_CONTEXT& context, size_t chunk
 	}
 	else if (useProg) // use a program but no pre-loaded VBOs (only the global one)
 	{
-		if (0 != s_vboSF)
+		if (s_vboSF.isCreated())
 		{
-			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboSF);
-			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(ccChunk::Size(chunkIndex, m_currentDisplayedScalarField->size()) * sizeof(float)), ccChunk::Start(m_currentDisplayedScalarField->data(), chunkIndex), GL_STREAM_DRAW);
+			s_vboSF.bind();
+			s_vboSF.write(0, ccChunk::Start(m_currentDisplayedScalarField->data(), chunkIndex), static_cast<int>(ccChunk::Size(chunkIndex, m_currentDisplayedScalarField->size()) * sizeof(float)));
 			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_SF);
 			glFunc->glVertexAttribPointer(ccGLSL::ATTR_SF, 1, GL_FLOAT, GL_FALSE, decimStep * sizeof(float), nullptr);
+			s_vboSF.release();
 		}
 		else
 		{
@@ -3151,12 +3135,13 @@ static void glLODChunkVertexPointer(ccPointCloud*      cloud,
 
 	if (useProg)
 	{
-		if (0 != s_vboVertex)
+		if (s_vboVertex.isCreated())
 		{
-			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVertex);
-			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * 3 * sizeof(PointCoordinateType)), s_pointBuffer, GL_STREAM_DRAW);
+			s_vboVertex.bind();
+			s_vboVertex.write(0, s_pointBuffer, static_cast<int>((stopIndex - startIndex) * 3 * sizeof(PointCoordinateType)));
 			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_POS);
 			glFunc->glVertexAttribPointer(ccGLSL::ATTR_POS, 3, GL_COORD_TYPE, GL_FALSE, 0, nullptr);
+			s_vboVertex.release();
 		}
 		else
 		{
@@ -3180,7 +3165,7 @@ static void glLODChunkVisibilityPointer(const ccGenericPointCloud::VisibilityTab
 	assert(startIndex < indexMap.size() && stopIndex <= indexMap.size());
 	assert(glFunc);
 
-	if (s_vboVisib == 0)
+	if (!s_vboVisib.isCreated())
 	{
 		assert(false);
 		return;
@@ -3194,10 +3179,11 @@ static void glLODChunkVisibilityPointer(const ccGenericPointCloud::VisibilityTab
 		*_visibilityBuffer++ = static_cast<float>(m_pointsVisibility[pointIndex]);
 	}
 
-	glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVisib);
-	glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * sizeof(float)), s_visibilityBuffer, GL_STREAM_DRAW);
+	s_vboVisib.bind();
+	s_vboVisib.write(0, s_visibilityBuffer, static_cast<int>((stopIndex - startIndex) * sizeof(float)));
 	glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_VIS);
 	glFunc->glVertexAttribPointer(ccGLSL::ATTR_VIS, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+	s_vboVisib.release();
 }
 
 template <class QOpenGLFunctions>
@@ -3213,7 +3199,7 @@ static void glLODChunkNormalPointer(NormsIndexesTableType* normals,
 
 	if (useProg)
 	{
-		if (s_vboNormals != 0)
+		if (s_vboNormals.isCreated())
 		{
 			// with the program, we don't decode normals in a dedicated static array, we just re-order the indexes
 			float* _normalIndexes = reinterpret_cast<float*>(s_normalBuffer);
@@ -3223,10 +3209,11 @@ static void glLODChunkNormalPointer(NormsIndexesTableType* normals,
 				*_normalIndexes++   = static_cast<float>(normals->at(pointIndex));
 			}
 
-			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboNormals);
-			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * sizeof(float)), s_normalBuffer, GL_STREAM_DRAW);
+			s_vboNormals.bind();
+			s_vboNormals.write(0, s_normalBuffer, static_cast<int>((stopIndex - startIndex) * sizeof(float)));
 			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_NOR);
 			glFunc->glVertexAttribPointer(ccGLSL::ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+			s_vboNormals.release();
 		}
 		else
 		{
@@ -3280,13 +3267,14 @@ static void glLODChunkColorPointer(RGBAColorsTableType* colors,
 
 	if (useProg)
 	{
-		if (s_vboColor != 0)
+		if (s_vboColor.isCreated())
 		{
 			// we must re-order colors in a dedicated static array
-			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
-			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * 4 * sizeof(unsigned char)), s_rgbBuffer4ub, GL_STREAM_DRAW);
+			s_vboColor.bind();
+			s_vboColor.write(0, s_rgbBuffer4ub, static_cast<int>((stopIndex - startIndex) * 4 * sizeof(unsigned char)));
 			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_COL);
 			glFunc->glVertexAttribPointer(ccGLSL::ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, nullptr);
+			s_vboColor.release();
 		}
 		else
 		{
@@ -3313,7 +3301,7 @@ static void glLODChunkSFPointer(ccScalarField*     sf,
 
 	if (useProg)
 	{
-		if (s_vboSF != 0)
+		if (s_vboSF.isCreated())
 		{
 			// with the program, we don't convert SF values to color, we just re-order them
 			float* _sfValues = reinterpret_cast<float*>(s_rgbBuffer4ub);
@@ -3323,10 +3311,11 @@ static void glLODChunkSFPointer(ccScalarField*     sf,
 				*_sfValues++        = sf->data()[pointIndex];
 			}
 
-			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboSF);
-			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * sizeof(float)), s_rgbBuffer4ub, GL_STREAM_DRAW);
+			s_vboSF.bind();
+			s_vboSF.write(0, s_rgbBuffer4ub, static_cast<int>((stopIndex - startIndex) * sizeof(float)));
 			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_SF);
 			glFunc->glVertexAttribPointer(ccGLSL::ATTR_SF, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+			s_vboSF.release();
 		}
 		else
 		{
@@ -3646,9 +3635,10 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 		QSharedPointer<QOpenGLTexture> sfTex;
 
 		// normal display acceleration texture (for fast normals display)
-		static bool                    s_globalVBOCreationFailed = false;
-		static bool                    s_normalLUTTextureFailed  = false;
+		static bool                    s_normalLUTTextureFailed = false;
 		QSharedPointer<QOpenGLTexture> lutTex;
+
+		static bool s_globalVBOCreationFailed = false;
 
 		// by default, we'll try to use a composite GLSL program (if possible)
 		QSharedPointer<QOpenGLShaderProgram> prog;
@@ -3702,54 +3692,41 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 			}
 
 			// static VBO handles reused between calls
-			if (prog && s_vboVertex == 0)
+			auto createVBOIfNeeded = [&](QOpenGLBuffer& vbo, int sizeBytes)
 			{
-				glFunc->glGenBuffers(1, &s_vboVertex);
-				if (0 == s_vboVertex)
+				if (prog && !vbo.isCreated())
 				{
-					s_globalVBOCreationFailed = true;
-					prog.clear();
+					if (vbo.create())
+					{
+						vbo.setUsagePattern(QOpenGLBuffer::StreamDraw);
+						vbo.bind();
+						vbo.allocate(sizeBytes);
+						vbo.release();
+					}
+					else
+					{
+						s_globalVBOCreationFailed = true;
+						prog.clear();
+					}
 				}
-			}
+			};
 
-			if (prog && (attributes & ccGLSL::ATTR_NOR) && s_vboNormals == 0)
+			createVBOIfNeeded(s_vboVertex, MAX_POINT_COUNT_PER_LOD_RENDER_PASS * 3 * sizeof(PointCoordinateType));
+			if (attributes & ccGLSL::ATTR_NOR)
 			{
-				glFunc->glGenBuffers(1, &s_vboNormals);
-				if (0 == s_vboNormals)
-				{
-					s_globalVBOCreationFailed = true;
-					prog.clear();
-				}
+				createVBOIfNeeded(s_vboNormals, MAX_POINT_COUNT_PER_LOD_RENDER_PASS * sizeof(float));
 			}
-
-			if (prog && (attributes & ccGLSL::ATTR_SF) && s_vboSF == 0)
+			if (attributes & ccGLSL::ATTR_SF)
 			{
-				glFunc->glGenBuffers(1, &s_vboSF);
-				if (0 == s_vboSF)
-				{
-					s_globalVBOCreationFailed = true;
-					prog.clear();
-				}
+				createVBOIfNeeded(s_vboSF, MAX_POINT_COUNT_PER_LOD_RENDER_PASS * sizeof(float));
 			}
-
-			if (prog && (attributes & ccGLSL::ATTR_COL) && s_vboColor == 0)
+			if (attributes & ccGLSL::ATTR_COL)
 			{
-				glFunc->glGenBuffers(1, &s_vboColor);
-				if (0 == s_vboColor)
-				{
-					s_globalVBOCreationFailed = true;
-					prog.clear();
-				}
+				createVBOIfNeeded(s_vboColor, MAX_POINT_COUNT_PER_LOD_RENDER_PASS * 4 * sizeof(unsigned char));
 			}
-
-			if (prog && (attributes & ccGLSL::ATTR_VIS) && s_vboVisib == 0)
+			if (attributes & ccGLSL::ATTR_VIS)
 			{
-				glFunc->glGenBuffers(1, &s_vboVisib);
-				if (0 == s_vboVisib)
-				{
-					s_globalVBOCreationFailed = true;
-					prog.clear();
-				}
+				createVBOIfNeeded(s_vboVisib, MAX_POINT_COUNT_PER_LOD_RENDER_PASS * sizeof(float));
 			}
 		}
 
@@ -4088,12 +4065,16 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 					glFunc->glDrawArrays(GL_POINTS, 0, count);
 
-					if (prog)
+					if (useProgram)
 					{
 						glFunc->glDisableVertexAttribArray(ccGLSL::ATTR_POS);
 						if (glParams.showNorms)
 						{
 							glFunc->glDisableVertexAttribArray(ccGLSL::ATTR_NOR);
+						}
+						if (visTableEnabled)
+						{
+							glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_VIS);
 						}
 						if (glParams.showSF)
 						{
@@ -4153,6 +4134,10 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 						if (glParams.showNorms)
 						{
 							glFunc->glDisableVertexAttribArray(ccGLSL::ATTR_NOR);
+						}
+						if (visTableEnabled)
+						{
+							glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_VIS);
 						}
 						if (glParams.showSF)
 						{

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -4460,29 +4460,29 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 					const auto& indexMap = (*toDisplay.indexMap);
 
 					// points
-					glLODChunkVertexPointer<QOpenGLFunctions_2_1>(this, glFunc, *toDisplay.indexMap, s, e, useProgram);
+					glLODChunkVertexPointer<QOpenGLFunctions_2_1>(this, glFunc, indexMap, s, e, useProgram);
 
 					// normals
 					if (glParams.showNorms)
 					{
-						glLODChunkNormalPointer<QOpenGLFunctions_2_1>(m_normals, glFunc, *toDisplay.indexMap, s, e, useProgram);
+						glLODChunkNormalPointer<QOpenGLFunctions_2_1>(m_normals, glFunc, indexMap, s, e, useProgram);
 					}
 
 					// visibility table
 					if (visTableEnabled && useProgram)
 					{
-						glLODChunkVisibilityPointer<QOpenGLFunctions_2_1>(m_pointsVisibility, glFunc, *toDisplay.indexMap, s, e);
+						glLODChunkVisibilityPointer<QOpenGLFunctions_2_1>(m_pointsVisibility, glFunc, indexMap, s, e);
 					}
 
 					// SFs
 					if (glParams.showSF)
 					{
-						glLODChunkSFPointer<QOpenGLFunctions_2_1>(m_currentDisplayedScalarField, glFunc, *toDisplay.indexMap, s, e, useProgram);
+						glLODChunkSFPointer<QOpenGLFunctions_2_1>(m_currentDisplayedScalarField, glFunc, indexMap, s, e, useProgram);
 					}
 					// colors
 					else if (glParams.showColors)
 					{
-						glLODChunkColorPointer<QOpenGLFunctions_2_1>(m_rgbaColors, glFunc, *toDisplay.indexMap, s, e, useProgram);
+						glLODChunkColorPointer<QOpenGLFunctions_2_1>(m_rgbaColors, glFunc, indexMap, s, e, useProgram);
 					}
 
 					glFunc->glDrawArrays(GL_POINTS, 0, count);

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -2639,12 +2639,14 @@ static GLenum GL_COORD_TYPE = sizeof(PointCoordinateType) == 4 ? GL_FLOAT : GL_D
 static const GLuint ATTR_POS = 0;
 static const GLuint ATTR_NOR = 1;
 static const GLuint ATTR_COL = 2;
+static const GLuint ATTR_SF  = 4;
 
 // Global OpenGL resources
 static QMap<int, QSharedPointer<QOpenGLShaderProgram>> s_programs;
 static GLuint                                          s_vboVertex  = 0;
 static GLuint                                          s_vboNormals = 0;
 static GLuint                                          s_vboColor   = 0;
+static GLuint                                          s_vboSF      = 0;
 
 void ccPointCloud::glChunkVertexPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs, bool useProg /*=false*/)
 {
@@ -2857,15 +2859,20 @@ void ccPointCloud::glChunkColorPointer(const CC_DRAW_CONTEXT& context, size_t ch
 	}
 }
 
-void ccPointCloud::glChunkSFPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs)
+void ccPointCloud::glChunkSFPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs, bool useProg /*=false*/)
 {
-	assert(m_currentDisplayedScalarField);
+	if (!m_currentDisplayedScalarField)
+	{
+		assert(false);
+		return;
+	}
 	assert(sizeof(ColorCompType) == 1);
 
 	QOpenGLFunctions_2_1* glFunc = context.glFunctions<QOpenGLFunctions_2_1>();
 	assert(glFunc != nullptr);
 
 	if (useVBOs
+	    && !useProg
 	    && m_vboManager.state == vboSet::INITIALIZED
 	    && m_vboManager.hasColors
 	    && m_vboManager.vbos.size() > static_cast<size_t>(chunkIndex)
@@ -2887,7 +2894,21 @@ void ccPointCloud::glChunkSFPointer(const CC_DRAW_CONTEXT& context, size_t chunk
 			glChunkSFPointer(context, chunkIndex, decimStep, false);
 		}
 	}
-	else if (m_currentDisplayedScalarField)
+	else if (useProg)
+	{
+		if (0 != s_vboSF)
+		{
+			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboSF);
+			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(ccChunk::Size(chunkIndex, m_currentDisplayedScalarField->size()) * sizeof(float)), ccChunk::Start(m_currentDisplayedScalarField->data(), chunkIndex), GL_DYNAMIC_DRAW);
+			glFunc->glEnableVertexAttribArray(ATTR_SF);
+			glFunc->glVertexAttribPointer(ATTR_SF, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+		}
+		else
+		{
+			assert(false);
+		}
+	}
+	else
 	{
 		// we must convert the scalar values to RGB colors in a dedicated static array
 		size_t         chunkStart = ccChunk::StartPos(chunkIndex);
@@ -3113,7 +3134,7 @@ struct DisplayDesc : LODLevelDesc
 };
 
 // Simple program builder (GLSL 1.20) for cloud rendering (position, normal, color)
-static QSharedPointer<QOpenGLShaderProgram> BuildSimpleCloudProgram(QOpenGLFunctions_2_1* glFunc, int attributes)
+static QSharedPointer<QOpenGLShaderProgram> BuildSimpleCloudProgram(QOpenGLFunctions_2_1* glFunc, int attributes, ccScalarField* sf /*=nullptr*/)
 {
 	if (!glFunc)
 	{
@@ -3126,9 +3147,126 @@ static QSharedPointer<QOpenGLShaderProgram> BuildSimpleCloudProgram(QOpenGLFunct
 		return s_programs[attributes];
 	}
 
-	QString vertexProgSrc;
-	QString fragmentProgSrc;
+	// Vertex programs
+	static const char* VertexProgHeaderSrc =
+	    "#version 120\n"
+	    "attribute vec3 aPosition;\n"
+	    "varying vec4 vColor;\n";
 
+	static const char* VertexProgColorAttributesSrc =
+	    "attribute vec4 aColor;\n";
+
+	static const char* VertexProgSFAttributesSrc =
+	    "attribute float aSFValue;\n"
+	    "uniform sampler2D uColorScaleTex;\n"
+	    "uniform int uTexWidth;\n"
+	    "uniform int uTexHeight;\n"
+	    "uniform float uMinVal;\n"
+	    "uniform float uMaxVal;\n"
+	    "uniform float uMinSat;\n"
+	    "uniform float uMaxSat;\n"
+	    "uniform float uSatRange;\n"
+	    "uniform float uOutOfRangeGreyScale;\n";
+
+	static const char* VertexProgNormAttributesSrc =
+	    "attribute float aNormalIndex;\n"
+	    "varying vec3 vNormal;\n"
+	    "uniform sampler2D uNormalLUT;\n"
+	    "uniform int uLUTWidth;\n"
+	    "uniform int uLUTHeight;\n";
+
+	static const char* VertexProgFetchNormFuncSrc =
+	    "vec3 fetchNormalFromLUT(float fi)\n"
+	    "{\n"
+	    "	float w  = float(uLUTWidth);\n"
+	    "	float h  = float(uLUTHeight);\n"
+	    "	float tx = mod(fi, w);\n"
+	    "	float ty = floor(fi / w);\n"
+	    "	vec2 uv = vec2((tx + 0.5) / w, (ty + 0.5) / h);\n"
+	    "	vec3 enc = texture2D(uNormalLUT, uv).rgb;\n"
+	    "	vec3 n = enc * 2.0 - 1.0;\n"
+	    "	return normalize(n);\n"
+	    "}\n";
+
+	static const char* VertexProgFetchSFColorFuncSrc =
+	    "vec4 fetchColorFromTex(float sfVal)\n"
+	    "{\n"
+	    "   if (sfVal < uMinVal)\n"
+	    "       return vec4(uOutOfRangeGreyScale, uOutOfRangeGreyScale, uOutOfRangeGreyScale, 1.0);\n"
+	    "   if (sfVal > uMaxVal)\n"
+	    "       return vec4(uOutOfRangeGreyScale, uOutOfRangeGreyScale, uOutOfRangeGreyScale, 1.0);\n"
+	    "   float v = normalizeSFVal(sfVal);\n"
+	    "   v = v * float(uTexWidth * uTexHeight - 1);\n"
+	    "	float w  = float(uTexWidth);\n"
+	    "	float h  = float(uTexHeight);\n"
+	    "	float tx = mod(v, w);\n"
+	    "	float ty = floor(v/ w);\n"
+	    "	vec2 uv = vec2(tx / w, ty / h);\n"
+	    "	vec4 color = texture2D(uColorScaleTex, uv);\n"
+	    "	return color;\n"
+	    "}\n";
+
+	static const char* NormalizeNonSymmetricalValueFuncSrc =
+	    "float normalizeSFVal(float sfVal)\n"
+	    "{\n"
+	    "   if (sfVal <= uMinSat)\n"
+	    "      return 0.0;\n"
+	    "   if (sfVal >= uMaxSat)\n"
+	    "      return 1.0;\n"
+	    "   return (sfVal - uMinSat) / uSatRange;\n"
+	    "}\n";
+
+	static const char* NormalizeSymmetricalValueFuncSrc =
+	    "float normalizeSFVal(float sfVal)\n"
+	    "{\n"
+	    "   if (abs(sfVal) <= uMinSat)\n"
+	    "      return 0.5;\n"
+	    "   if (sfVal >= 0)\n"
+	    "   {\n"
+	    "      if (sfVal > uMaxSat)\n"
+	    "         return 1.0;\n"
+	    "      return (1.0 + (sfVal - uMinSat) / uSatRange) / 2.0;\n"
+	    "   }\n"
+	    "   else\n"
+	    "   {\n"
+	    "      if (sfVal < -uMaxSat)\n"
+	    "         return 0.0;\n"
+	    "      return (1.0 + (sfVal + uMinSat) / uSatRange) / 2.0;\n"
+	    "   }\n"
+	    "}\n";
+
+	static const char* NormalizeValueLogScaleFuncSrc =
+	    "float normalizeSFVal(float sfVal)\n"
+	    "{\n"
+	    " 	float dLog = log(max(abs(d), 0.00001)) / log(10.0);\n"
+	    "   if (dLog <= uMinSat)\n"
+	    "      return 0.0;\n"
+	    "   if (dLog >= uMaxSat)\n"
+	    "      return 1.0;\n"
+	    "   return (dLog - uMinSat) / uSatRange;\n"
+	    "}\n";
+
+	static const char* VertexProgMainStartSrc =
+	    "void main()\n"
+	    "{\n";
+
+	static const char* VertexProgMainUseDefaultGLColorSrc =
+	    "    vColor = gl_Color;\n";
+
+	static const char* VertexProgMainUseInputColorSrc =
+	    "    vColor = aColor;\n";
+
+	static const char* VertexProgMainFetchSFColorSrc =
+	    "    vColor = fetchColorFromTex(aSFValue);\n";
+
+	static const char* VertexProgMainFetchNormalSrc =
+	    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n";
+
+	static const char* VertexProgMainEndSrc =
+	    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
+	    "}\n";
+
+	// Fragment programs
 	static const char* ColorOnlyFragmentProgSrc =
 	    "#version 120\n"
 	    "varying vec4 vColor;\n"
@@ -3150,106 +3288,56 @@ static QSharedPointer<QOpenGLShaderProgram> BuildSimpleCloudProgram(QOpenGLFunct
 	    "    gl_FragColor = vec4(base.rgb * diff, base.a);\n"
 	    "}\n";
 
-	switch (attributes)
+	QString vertexProgSrc = VertexProgHeaderSrc;
 	{
-	case ATTR_POS:
-		vertexProgSrc =
-		    "#version 120\n"
-		    "attribute vec3 aPosition;\n"
-		    "varying vec4 vColor;\n"
-		    "void main()\n"
-		    "{\n"
-		    "    vColor = gl_Color;\n"
-		    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
-		    "}\n";
+		// add attributes
+		if (attributes & ATTR_SF)
+			vertexProgSrc += VertexProgSFAttributesSrc;
+		else if (attributes & ATTR_COL)
+			vertexProgSrc += VertexProgColorAttributesSrc;
+		if (attributes & ATTR_NOR)
+			vertexProgSrc += VertexProgNormAttributesSrc;
 
-		fragmentProgSrc = ColorOnlyFragmentProgSrc;
+		// add special functions
+		if (attributes & ATTR_SF)
+		{
+			if (sf->logScale())
+			{
+				vertexProgSrc += NormalizeValueLogScaleFuncSrc;
+			}
+			else
+			{
+				vertexProgSrc += (sf->symmetricalScale() ? NormalizeSymmetricalValueFuncSrc : NormalizeNonSymmetricalValueFuncSrc);
+			}
+			vertexProgSrc += VertexProgFetchSFColorFuncSrc;
+		}
 
-		break;
+		if (attributes & ATTR_NOR)
+		{
+			vertexProgSrc += VertexProgFetchNormFuncSrc;
+		}
 
-	case ATTR_COL:
-		vertexProgSrc =
-		    "#version 120\n"
-		    "attribute vec3 aPosition;\n"
-		    "attribute vec4 aColor;\n"
-		    "varying vec4 vColor;\n"
-		    "void main()\n"
-		    "{\n"
-		    "    vColor = aColor;\n"
-		    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
-		    "}\n";
+		// main function
+		{
+			vertexProgSrc += VertexProgMainStartSrc;
 
-		fragmentProgSrc = ColorOnlyFragmentProgSrc;
-		break;
+			// color transfer
+			if (attributes & ATTR_SF)
+				vertexProgSrc += VertexProgMainFetchSFColorSrc;
+			else if (attributes & ATTR_COL)
+				vertexProgSrc += VertexProgMainUseInputColorSrc;
+			else
+				vertexProgSrc += VertexProgMainUseDefaultGLColorSrc;
 
-	case ATTR_NOR:
-		vertexProgSrc =
-		    "#version 120\n"
-		    "attribute vec3 aPosition;\n"
-		    "attribute float aNormalIndex;\n"
-		    "varying vec4 vColor;\n"
-		    "varying vec3 vNormal;\n"
-		    "uniform sampler2D uNormalLUT;\n"
-		    "uniform int uLUTWidth;\n"
-		    "uniform int uLUTHeight;\n"
-		    "vec3 fetchNormalFromLUT(float fi)\n"
-		    "{\n"
-		    "	float w  = float(uLUTWidth);\n"
-		    "	float h  = float(uLUTHeight);\n"
-		    "	float tx = mod(fi, w);\n"
-		    "	float ty = floor(fi / w);\n"
-		    "	vec2 uv = vec2((tx + 0.5) / w, (ty + 0.5) / h);\n"
-		    "	vec3 enc = texture2D(uNormalLUT, uv).rgb;\n"
-		    "	vec3 n = enc * 2.0 - 1.0;\n"
-		    "	return normalize(n);\n"
-		    "}\n"
-		    "void main()\n"
-		    "{\n"
-		    "    vColor = gl_Color;\n"
-		    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n"
-		    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
-		    "}\n";
+			// normal transfer (if any)
+			if (attributes & ATTR_NOR)
+				vertexProgSrc += VertexProgMainFetchNormalSrc;
 
-		fragmentProgSrc = ColorAndNormalFragmentProgSrc;
-		break;
-
-	case (ATTR_COL | ATTR_NOR):
-		vertexProgSrc =
-		    "#version 120\n"
-		    "attribute vec3 aPosition;\n"
-		    "attribute float aNormalIndex;\n"
-		    "attribute vec4 aColor;\n"
-		    "varying vec4 vColor;\n"
-		    "varying vec3 vNormal;\n"
-		    "uniform sampler2D uNormalLUT;\n"
-		    "uniform int uLUTWidth;\n"
-		    "uniform int uLUTHeight;\n"
-		    "vec3 fetchNormalFromLUT(float fi)\n"
-		    "{\n"
-		    "	float w  = float(uLUTWidth);\n"
-		    "	float h  = float(uLUTHeight);\n"
-		    "	float tx = mod(fi, w);\n"
-		    "	float ty = floor(fi / w);\n"
-		    "	vec2 uv = vec2((tx + 0.5) / w, (ty + 0.5) / h);\n"
-		    "	vec3 enc = texture2D(uNormalLUT, uv).rgb;\n"
-		    "	vec3 n = enc * 2.0 - 1.0;\n"
-		    "	return normalize(n);\n"
-		    "}\n"
-		    "void main()\n"
-		    "{\n"
-		    "    vColor = aColor;\n"
-		    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n"
-		    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
-		    "}\n";
-
-		fragmentProgSrc = ColorAndNormalFragmentProgSrc;
-		break;
-
-	default:
-		assert(false);
-		ccLog::Warning("[	] Unsupported feature combination!");
-		return nullptr;
+			vertexProgSrc += VertexProgMainEndSrc;
+		}
 	}
+
+	QString fragmentProgSrc = (attributes & ATTR_NOR ? ColorAndNormalFragmentProgSrc : ColorOnlyFragmentProgSrc);
 
 	QOpenGLShader vertexShader(QOpenGLShader::Vertex);
 	if (false == vertexShader.compileSourceCode(vertexProgSrc))
@@ -3269,8 +3357,14 @@ static QSharedPointer<QOpenGLShaderProgram> BuildSimpleCloudProgram(QOpenGLFunct
 
 	// bind attribute locations before linking for stable locations
 	program->bindAttributeLocation("aPosition", ATTR_POS);
-	if (attributes & ATTR_COL)
+	if (attributes & ATTR_SF)
 	{
+		assert((attributes & ATTR_COL) == 0);
+		program->bindAttributeLocation("aSFValue", ATTR_SF);
+	}
+	else if (attributes & ATTR_COL)
+	{
+		assert((attributes & ATTR_SF) == 0);
 		program->bindAttributeLocation("aColor", ATTR_COL);
 	}
 	if (attributes & ATTR_NOR)
@@ -3462,7 +3556,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 	// ccLog::Print(QString("Rendering %1 points starting from index %2 (LoD = %3 / PN = %4)").arg(toDisplay.count).arg(toDisplay.startIndex).arg(toDisplay.indexMap ? "yes" : "no").arg(pushName ? "yes" : "no"));
 
-	glFunc->glPushAttrib(GL_LIGHTING_BIT | GL_COLOR_BUFFER_BIT | GL_TRANSFORM_BIT | GL_POINT_BIT);
+	glFunc->glPushAttrib(GL_LIGHTING_BIT | GL_COLOR_BUFFER_BIT | GL_TRANSFORM_BIT | GL_POINT_BIT | GL_TEXTURE_BIT | GL_POINT_BIT);
 
 	if (glParams.showSF || glParams.showColors)
 	{
@@ -3508,7 +3602,6 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 	// rounded points
 	if (context.drawRoundedPoints)
 	{
-		glFunc->glPushAttrib(GL_POINT_BIT);
 		// DGM: alpha/blending doesn't work well because it creates a halo around points with a potentially wrong color (due to the display order)
 		// glFunc->glDisable(GL_BLEND);
 		glFunc->glEnable(GL_POINT_SMOOTH);
@@ -3580,20 +3673,20 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 			glFunc->glEnd();
 		}
-		else if (glParams.showSF) // no visibility table enabled + scalar field
+		else if (glParams.showSF && m_currentDisplayedScalarField->mayHaveHiddenValues()) // no visibility table enabled + scalar field + but hidden values
 		{
 			assert(m_currentDisplayedScalarField);
 
 			// if some points may not be displayed, we'll have to be smarter!
-			bool hiddenPoints = m_currentDisplayedScalarField->mayHaveHiddenValues();
+			// bool hiddenPoints = m_currentDisplayedScalarField->mayHaveHiddenValues();
 
 			// whether VBOs are available (for faster display) or not
 			bool useVBOs = false;
-			if (!hiddenPoints && context.useVBOs && !toDisplay.indexMap) // VBOs are not compatible with LoD
-			{
-				// can't use VBOs if some points are hidden
-				useVBOs = updateVBOs(context, glParams);
-			}
+			// if (!hiddenPoints && context.useVBOs && !toDisplay.indexMap) // VBOs are not compatible with LoD
+			//{
+			//	// can't use VBOs if some points are hidden
+			//	useVBOs = updateVBOs(context, glParams);
+			// }
 
 			// color ramp shader initialization
 			ccColorRampShader* colorRampShader = context.colorRampShader;
@@ -3699,6 +3792,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 				}
 			}
 
+#if 0
 			// if all points should be displayed (fastest case)
 			if (!hiddenPoints)
 			{
@@ -3806,6 +3900,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 				glFunc->glDisableClientState(GL_VERTEX_ARRAY);
 			}
 			else // potentially hidden points
+#endif
 			{
 				// compressed normals set
 				const ccNormalVectors* compressedNormals = ccNormalVectors::GetUniqueInstance();
@@ -3939,19 +4034,22 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 				}
 			}
 		}
-		else // no visibility table enabled, no scalar field
+		else // no visibility table enabled, no scalar field or scalar field with no hidden values
 		{
 			bool useVBOs = context.useVBOs && !toDisplay.indexMap ? updateVBOs(context, glParams) : false; // VBOs are not compatible with LoD
 
 			size_t chunkCount = ccChunk::Count(m_points);
 
-			// normal acceleration texture (for fast normals display)
+			// sf display acceleration texture (for fast scalar field display)
+			QSharedPointer<QOpenGLTexture> sfTex;
+
+			// normal display acceleration texture (for fast normals display)
 			static bool                    s_globalVBOCreationFailed = false;
 			static bool                    s_normalLUTTextureFailed  = false;
 			QSharedPointer<QOpenGLTexture> lutTex;
 
 			QSharedPointer<QOpenGLShaderProgram> prog;
-			if (glParams.showNorms
+			if ((glParams.showSF || glParams.showNorms)
 			    && (false == s_normalLUTTextureFailed)
 			    && (false == s_globalVBOCreationFailed))
 			{
@@ -3960,13 +4058,32 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 				{
 					attributes |= ATTR_NOR;
 				}
-				if (glParams.showColors || glParams.showSF)
+				if (glParams.showSF)
+				{
+					attributes |= ATTR_SF;
+				}
+				else if (glParams.showColors)
 				{
 					attributes |= ATTR_COL;
 				}
 
-				prog = BuildSimpleCloudProgram(glFunc, attributes);
-				if (!prog.isNull())
+				prog = BuildSimpleCloudProgram(glFunc, attributes, glParams.showSF ? m_currentDisplayedScalarField : nullptr);
+
+				if (glParams.showSF && prog)
+				{
+					assert(m_currentDisplayedScalarField);
+					auto colorScale = m_currentDisplayedScalarField->getColorScale();
+					assert(!colorScale.isNull());
+
+					sfTex = colorScale->getTexture(glFunc);
+					if (sfTex.isNull())
+					{
+						ccLog::Warning("Failed to create scalar field texture! Cannot render fast scalar field.");
+						prog.clear();
+					}
+				}
+
+				if (glParams.showNorms && prog)
 				{
 					// create or retrieve the LUT texture
 					lutTex = ccNormalVectors::GetNormalLUTTexture(glFunc);
@@ -3994,6 +4111,16 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 			{
 				glFunc->glGenBuffers(1, &s_vboNormals);
 				if (0 == s_vboNormals)
+				{
+					s_globalVBOCreationFailed = true;
+					prog.clear();
+				}
+			}
+
+			if (prog && s_vboSF == 0)
+			{
+				glFunc->glGenBuffers(1, &s_vboSF);
+				if (0 == s_vboSF)
 				{
 					s_globalVBOCreationFailed = true;
 					prog.clear();
@@ -4036,6 +4163,71 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 					if (locH >= 0)
 					{
 						glFunc->glUniform1i(locH, lutTex->height());
+					}
+				}
+
+				if (sfTex && m_currentDisplayedScalarField)
+				{
+					// bind texture to unit 1
+					glFunc->glActiveTexture(GL_TEXTURE1);
+					glFunc->glBindTexture(GL_TEXTURE_2D, sfTex->textureId());
+					// set sampler uniform to unit 1
+					int locSampler = prog->uniformLocation("uColorScaleTex");
+					if (locSampler >= 0)
+					{
+						glFunc->glUniform1i(locSampler, 1);
+					}
+					// set texture dimensions
+					int locW = prog->uniformLocation("uTexWidth");
+					if (locW >= 0)
+					{
+						glFunc->glUniform1i(locW, sfTex->width());
+					}
+					int locH = prog->uniformLocation("uTexHeight");
+					if (locH >= 0)
+					{
+						glFunc->glUniform1i(locH, sfTex->height());
+					}
+
+					auto   colorScale = m_currentDisplayedScalarField->getColorScale();
+					double offset     = m_currentDisplayedScalarField->getOffset();
+
+					float minVal              = static_cast<float>(m_currentDisplayedScalarField->displayRange().start() - offset);
+					float maxVal              = static_cast<float>(m_currentDisplayedScalarField->displayRange().stop() - offset);
+					float minSat              = static_cast<float>(m_currentDisplayedScalarField->saturationRange().start() - offset);
+					float maxSat              = static_cast<float>(m_currentDisplayedScalarField->saturationRange().stop() - offset);
+					float satRange            = static_cast<float>(m_currentDisplayedScalarField->saturationRange().range());
+					float outOfRangeGreyScale = ccColor::lightGreyRGB.r / 255.0f;
+
+					int locMinVal = prog->uniformLocation("uMinVal");
+					if (locMinVal >= 0)
+					{
+						glFunc->glUniform1f(locMinVal, minVal);
+					}
+					int locMaxVal = prog->uniformLocation("uMaxVal");
+					if (locMaxVal >= 0)
+					{
+						glFunc->glUniform1f(locMaxVal, maxVal);
+					}
+					int locMinSat = prog->uniformLocation("uMinSat");
+					if (locMinSat >= 0)
+					{
+						glFunc->glUniform1f(locMinSat, minSat);
+					}
+					int locMaxSat = prog->uniformLocation("uMaxSat");
+					if (locMaxSat >= 0)
+					{
+						glFunc->glUniform1f(locMaxSat, maxSat);
+					}
+					int locSatRange = prog->uniformLocation("uSatRange");
+					if (locSatRange >= 0)
+					{
+						glFunc->glUniform1f(locSatRange, satRange);
+					}
+					int locOutOfRangeGreyScale = prog->uniformLocation("uOutOfRangeGreyScale");
+					if (locOutOfRangeGreyScale >= 0)
+					{
+						glFunc->glUniform1f(locOutOfRangeGreyScale, outOfRangeGreyScale);
 					}
 				}
 			}
@@ -4086,7 +4278,11 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 						{
 							glFunc->glDisableVertexAttribArray(ATTR_NOR);
 						}
-						if (glParams.showColors)
+						if (glParams.showSF)
+						{
+							glFunc->glDisableVertexAttribArray(ATTR_SF);
+						}
+						else if (glParams.showColors)
 						{
 							glFunc->glDisableVertexAttribArray(ATTR_COL);
 						}
@@ -4110,8 +4306,13 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 					{
 						glChunkNormalPointer(context, k, toDisplay.decimStep, useVBOs, prog != nullptr);
 					}
+					// SFs
+					if (glParams.showSF)
+					{
+						glChunkSFPointer(context, k, toDisplay.decimStep, useVBOs, prog != nullptr);
+					}
 					// colors
-					if (glParams.showColors)
+					else if (glParams.showColors)
 					{
 						glChunkColorPointer(context, k, toDisplay.decimStep, useVBOs, prog != nullptr);
 					}
@@ -4130,11 +4331,14 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 						{
 							glFunc->glDisableVertexAttribArray(ATTR_NOR);
 						}
-						if (glParams.showColors)
+						if (glParams.showSF)
+						{
+							glFunc->glDisableVertexAttribArray(ATTR_SF);
+						}
+						else if (glParams.showColors)
 						{
 							glFunc->glDisableVertexAttribArray(ATTR_COL);
 						}
-
 						// unbind array buffer
 						glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);
 					}
@@ -4147,6 +4351,12 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 				if (glParams.showNorms)
 				{
+					glFunc->glActiveTexture(GL_TEXTURE0);
+					glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+				}
+				if (glParams.showSF)
+				{
+					glFunc->glActiveTexture(GL_TEXTURE1);
 					glFunc->glBindTexture(GL_TEXTURE_2D, 0);
 				}
 			}
@@ -4166,11 +4376,6 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 	}
 
 	/*** END DISPLAY ***/
-
-	if (context.drawRoundedPoints)
-	{
-		glFunc->glPopAttrib(); // GL_POINT_BIT
-	}
 
 	glFunc->glPopAttrib(); // GL_LIGHTING_BIT | GL_COLOR_BUFFER_BIT | GL_TRANSFORM_BIT | GL_POINT_BIT --> will switch the light off
 

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -6478,8 +6478,7 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 				// load colors
 				if (chunkUpdateFlags & vboSet::UPDATE_COLORS)
 				{
-#if 0
-					if (glParams.showSF)
+					if (glParams.showSF && !noSF)
 					{
 						// copy SF colors in static array
 						ColorCompType* _sfColors = s_rgbBuffer4ub;
@@ -6521,9 +6520,7 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 						// upadte 'modification' flag for current displayed SF
 						m_vboManager.sourceSF->setModificationFlag(false);
 					}
-					else
-#endif
-					if (glParams.showColors)
+					else if (glParams.showColors)
 					{
 						currentVBO->colorBuffer.bind();
 						currentVBO->colorBuffer.write(0, ccChunk::Start(*m_rgbaColors, chunkIndex), sizeof(ColorCompType) * chunkSize * 4);
@@ -6532,7 +6529,7 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 				}
 
 				// load normals
-				if (glParams.showNorms && (chunkUpdateFlags & vboSet::UPDATE_NORMALS))
+				if (glParams.showNorms && (chunkUpdateFlags & vboSet::UPDATE_NORMALS) && !noNormals)
 				{
 					// we must decode the normals first!
 					CompressedNormType* inNorms  = ccChunk::Start(*m_normals, chunkIndex);

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -2758,15 +2758,16 @@ inline float GetSymmetricalNormalizedValue(ScalarType sfVal, const ccScalarField
 static GLenum GL_COORD_TYPE = sizeof(PointCoordinateType) == 4 ? GL_FLOAT : GL_DOUBLE;
 
 // Attribute indexes that we bound when creating the programs
-static const GLuint ATTR_POS = 0;
-static const GLuint ATTR_NOR = 1;
-static const GLuint ATTR_COL = 2;
-static const GLuint ATTR_SF  = 4;
-static const GLuint ATTR_VIS = 8;
+static const GLuint ATTR_POS  = 0;
+static const GLuint ATTR_NOR  = 1;
+static const GLuint ATTR_COL  = 2;
+static const GLuint ATTR_SF   = 4;
+static const GLuint ATTR_VIS  = 8;
+static const GLuint ATTR_CLIP = 16;
 // For internal use only
-static const GLuint ATTR_LOG_SCALE  = 16;
-static const GLuint ATTR_SYM_SCALE  = 32;
-static const GLuint ATTR_HIDDEN_VAL = 64;
+static const GLuint ATTR_LOG_SCALE  = 32;
+static const GLuint ATTR_SYM_SCALE  = 64;
+static const GLuint ATTR_HIDDEN_VAL = 128;
 
 // Global OpenGL resources
 static QMap<int, QSharedPointer<QOpenGLShaderProgram>> s_programs;
@@ -3576,6 +3577,9 @@ static QSharedPointer<QOpenGLShaderProgram> BuildCloudDisplayProgram(QOpenGLFunc
 	static const char* VertexProgMainFetchNormalSrc =
 	    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n";
 
+	static const char* VertexProgMainClippingSrc =
+	    "    gl_ClipVertex = gl_ModelViewMatrix * vec4(aPosition, 1.0);\n";
+
 	static const char* VertexProgMainEndSrc =
 	    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
 	    "}\n";
@@ -3660,6 +3664,11 @@ static QSharedPointer<QOpenGLShaderProgram> BuildCloudDisplayProgram(QOpenGLFunc
 			if (attributes & ATTR_NOR)
 			{
 				vertexProgSrc += VertexProgMainFetchNormalSrc;
+			}
+
+			if (attributes & ATTR_CLIP)
+			{
+				vertexProgSrc += VertexProgMainClippingSrc;
 			}
 
 			vertexProgSrc += VertexProgMainEndSrc;
@@ -3989,6 +3998,10 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 			if (visTableEnabled)
 			{
 				attributes |= ATTR_VIS;
+			}
+			if (!m_clipPlanes.empty())
+			{
+				attributes |= ATTR_CLIP;
 			}
 
 			prog = BuildCloudDisplayProgram(glFunc, attributes, glParams.showSF ? m_currentDisplayedScalarField : nullptr);

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -58,6 +58,7 @@ static const char s_deviationSFName[] = "Deviation";
 
 // 'Draw normals' shader program
 static QSharedPointer<QOpenGLShaderProgram> s_programDrawNormals;
+
 // 'Draw normals' shader parameters
 static struct DrawNormalsShaderParameters
 {
@@ -67,8 +68,129 @@ static struct DrawNormalsShaderParameters
 	int matrixLocation       = 0;
 	int colorLocation        = 0;
 } s_drawNormalsShaderParameters;
+
 // Default path to the shader files
 static QString s_shaderPath;
+
+//! Composite VBO structure
+class ccPointCloud::VBO
+{
+  public:
+	QOpenGLBuffer vertexBuffer;      //!< vertex buffer
+	QOpenGLBuffer colorBuffer;       //!< color buffer
+	QOpenGLBuffer normalIndexBuffer; //!< normal indexes buffer
+
+	//! Default constructor
+	VBO()
+	    : vertexBuffer(QOpenGLBuffer::VertexBuffer)
+	    , colorBuffer(QOpenGLBuffer::VertexBuffer)
+	    , normalIndexBuffer(QOpenGLBuffer::VertexBuffer)
+	{
+	}
+
+	//! Inits the VBO
+	/** \return the number of allocated bytes (or -1 if an error occurred)
+	 **/
+	int init(int count, bool withColors, bool withNormals, int* allocationFlags = nullptr)
+	{
+		auto resizeVBO = [allocationFlags](QOpenGLBuffer& buffer, int sizeBytes, int flag) -> bool
+		{
+			if (!buffer.isCreated())
+			{
+				if (!buffer.create())
+				{
+					return false;
+				}
+
+				buffer.setUsagePattern(QOpenGLBuffer::DynamicDraw); //"StaticDraw: The data will be set once and used many times for drawing operations."
+				                                                    //"DynamicDraw: The data will be modified repeatedly and used many times for drawing operations.
+			}
+
+			if (!buffer.bind())
+			{
+				ccLog::Warning("[ccPointCloud::VBO::init] Failed to bind VBO to active context!");
+				buffer.destroy();
+				return false;
+			}
+
+			if (sizeBytes != buffer.size())
+			{
+				buffer.allocate(sizeBytes);
+				if (allocationFlags)
+				{
+					*allocationFlags |= flag;
+				}
+
+				if (buffer.size() != sizeBytes)
+				{
+					ccLog::Warning("[ccPointCloud::VBO::init] Not enough (GPU) memory!");
+					buffer.release();
+					buffer.destroy();
+					return false;
+				}
+			}
+
+			buffer.release();
+			return true;
+		};
+
+		// vertices
+		int vertexSizeBytes = 0;
+		{
+			vertexSizeBytes = sizeof(PointCoordinateType) * count * 3;
+
+			if (!resizeVBO(vertexBuffer, vertexSizeBytes, vboSet::UPDATE_POINTS))
+			{
+				// no message as it will probably happen on a lot on (old) graphic cards
+				return -1;
+			}
+		}
+
+		// colors
+		int colorSizeBytes = 0;
+		if (withColors)
+		{
+			colorSizeBytes = sizeof(ColorCompType) * count * 4;
+
+			if (!resizeVBO(colorBuffer, colorSizeBytes, vboSet::UPDATE_COLORS))
+			{
+				// no message as it will probably happen on a lot on (old) graphic cards
+				return -1;
+			}
+		}
+		else
+		{
+			colorBuffer.destroy();
+		}
+
+		// normal indexes (as floats)
+		int normalSizeBytes = 0;
+		if (withNormals)
+		{
+			normalSizeBytes = sizeof(float) * count;
+
+			if (!resizeVBO(normalIndexBuffer, normalSizeBytes, vboSet::UPDATE_NORMALS))
+			{
+				// no message as it will probably happen on a lot on (old) graphic cards
+				return -1;
+			}
+		}
+		else
+		{
+			normalIndexBuffer.destroy();
+		}
+
+		return vertexSizeBytes + colorSizeBytes + normalSizeBytes;
+	}
+
+	//! Releases the VBO
+	void destroy()
+	{
+		vertexBuffer.destroy();
+		colorBuffer.destroy();
+		normalIndexBuffer.destroy();
+	}
+};
 
 void ccPointCloud::SetShaderPath(const QString& path)
 {
@@ -2677,7 +2799,7 @@ void ccPointCloud::glChunkVertexPointer(const CC_DRAW_CONTEXT& context, size_t c
 		{
 			ccLog::Warning("[VBO] Failed to bind VBO?! We'll deactivate them then...");
 			m_vboManager.state = vboSet::FAILED;
-			// recall the method
+			// call the method again
 			glChunkVertexPointer(context, chunkIndex, decimStep, false, useProg);
 		}
 	}
@@ -2727,54 +2849,57 @@ void ccPointCloud::glChunkNormalPointer(const CC_DRAW_CONTEXT& context, size_t c
 	QOpenGLFunctions_2_1* glFunc = context.glFunctions<QOpenGLFunctions_2_1>();
 	assert(glFunc != nullptr);
 
-	if (useVBOs
-	    && useProg
-	    && m_vboManager.state == vboSet::INITIALIZED
-	    && m_vboManager.hasNormals
-	    && m_vboManager.vbos.size() > static_cast<size_t>(chunkIndex)
-	    && m_vboManager.vbos[chunkIndex]
-	    && m_vboManager.vbos[chunkIndex]->normalIndexBuffer.isCreated())
+	if (useProg)
 	{
-		// we can use VBOs and a program
-		if (m_vboManager.vbos[chunkIndex]->normalIndexBuffer.bind())
+		if (useVBOs
+		    && m_vboManager.state == vboSet::INITIALIZED
+		    && m_vboManager.hasNormals
+		    && m_vboManager.vbos.size() > static_cast<size_t>(chunkIndex)
+		    && m_vboManager.vbos[chunkIndex]
+		    && m_vboManager.vbos[chunkIndex]->normalIndexBuffer.isCreated())
 		{
-			glFunc->glEnableVertexAttribArray(ATTR_NOR);
-			glFunc->glVertexAttribPointer(ATTR_NOR, 1, GL_FLOAT, GL_FALSE, decimStep * sizeof(float), nullptr);
-			m_vboManager.vbos[chunkIndex]->normalIndexBuffer.release();
-		}
-		else
-		{
-			ccLog::Warning("[VBO] Failed to bind VBO?! We'll deactivate them then...");
-			m_vboManager.state = vboSet::FAILED;
-			// recall the method
-			glChunkNormalPointer(context, chunkIndex, decimStep, false, useProg);
-		}
-	}
-	else if (useProg) // use a program but no pre-saved VBOs (only the global one)
-	{
-		if (s_vboNormals != 0)
-		{
-			float* _normalIndexes = reinterpret_cast<float*>(s_normalBuffer);
-			size_t s              = ccChunk::StartPos(chunkIndex);
-			size_t e              = s + ccChunk::Size(chunkIndex, m_normals->size());
-			size_t count          = 0;
-			for (size_t j = s; j < e; j += decimStep)
+			// we can use the pre-loaded VBOs
+			if (m_vboManager.vbos[chunkIndex]->normalIndexBuffer.bind())
 			{
-				*_normalIndexes++ = static_cast<float>(m_normals->at(j));
-				++count;
+				glFunc->glEnableVertexAttribArray(ATTR_NOR);
+				glFunc->glVertexAttribPointer(ATTR_NOR, 1, GL_FLOAT, GL_FALSE, decimStep * sizeof(float), nullptr);
+				m_vboManager.vbos[chunkIndex]->normalIndexBuffer.release();
 			}
-
-			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboNormals);
-			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(count * sizeof(float)), s_normalBuffer, GL_DYNAMIC_DRAW);
-			glFunc->glEnableVertexAttribArray(ATTR_NOR);
-			glFunc->glVertexAttribPointer(ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+			else
+			{
+				ccLog::Warning("[VBO] Failed to bind VBO?! We'll deactivate them then...");
+				m_vboManager.state = vboSet::FAILED;
+				// call the method again
+				glChunkNormalPointer(context, chunkIndex, decimStep, false, useProg);
+			}
 		}
-		else
+		else // use a program but no pre-saved VBOs (only the global one)
 		{
-			assert(false);
+			if (s_vboNormals != 0)
+			{
+				// TODO FIXME: use a more recent GLSL version to pass unsigned int directly!
+				float* _normalIndexes = reinterpret_cast<float*>(s_normalBuffer);
+				size_t s              = ccChunk::StartPos(chunkIndex);
+				size_t e              = s + ccChunk::Size(chunkIndex, m_normals->size());
+				size_t count          = 0;
+				for (size_t j = s; j < e; j += decimStep)
+				{
+					*_normalIndexes++ = static_cast<float>(m_normals->at(j));
+					++count;
+				}
+
+				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboNormals);
+				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(count * sizeof(float)), s_normalBuffer, GL_DYNAMIC_DRAW);
+				glFunc->glEnableVertexAttribArray(ATTR_NOR);
+				glFunc->glVertexAttribPointer(ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+			}
+			else
+			{
+				assert(false);
+			}
 		}
 	}
-	else // no program, no VBOs
+	else // no program (VBOs are useless in this case)
 	{
 		// we must decode normals in a dedicated static array
 		PointCoordinateType*      _normals        = s_normalBuffer;
@@ -2815,7 +2940,7 @@ void ccPointCloud::glChunkColorPointer(const CC_DRAW_CONTEXT& context, size_t ch
 	    && m_vboManager.vbos[chunkIndex]
 	    && m_vboManager.vbos[chunkIndex]->colorBuffer.isCreated())
 	{
-		// we can use VBOs directly
+		// we can use pre-loaded VBOs
 		if (m_vboManager.vbos[chunkIndex]->colorBuffer.bind())
 		{
 			if (useProg)
@@ -2833,11 +2958,11 @@ void ccPointCloud::glChunkColorPointer(const CC_DRAW_CONTEXT& context, size_t ch
 		{
 			ccLog::Warning("[VBO] Failed to bind VBO?! We'll deactivate them then...");
 			m_vboManager.state = vboSet::FAILED;
-			// recall the method
+			// call the method again
 			glChunkColorPointer(context, chunkIndex, decimStep, false, useProg);
 		}
 	}
-	else if (useProg) // use a program but no pre-saved VBOs (only the global one)
+	else if (useProg) // use a program but no pre-loaded VBOs (only the global one)
 	{
 		if (s_vboColor != 0)
 		{
@@ -2880,7 +3005,7 @@ void ccPointCloud::glChunkSFPointer(const CC_DRAW_CONTEXT& context, size_t chunk
 	    && m_vboManager.vbos[chunkIndex]->colorBuffer.isCreated())
 	{
 		assert(m_vboManager.colorIsSF && m_vboManager.sourceSF == m_currentDisplayedScalarField);
-		// we can use VBOs directly
+		// we can use pre-loaded VBOs
 		if (m_vboManager.vbos[chunkIndex]->colorBuffer.bind())
 		{
 			glFunc->glColorPointer(4, GL_UNSIGNED_BYTE, decimStep * 4 * sizeof(ColorCompType), nullptr);
@@ -2894,21 +3019,21 @@ void ccPointCloud::glChunkSFPointer(const CC_DRAW_CONTEXT& context, size_t chunk
 			glChunkSFPointer(context, chunkIndex, decimStep, false);
 		}
 	}
-	else if (useProg)
+	else if (useProg) // use a program but no pre-loaded VBOs (only the global one)
 	{
 		if (0 != s_vboSF)
 		{
 			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboSF);
 			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(ccChunk::Size(chunkIndex, m_currentDisplayedScalarField->size()) * sizeof(float)), ccChunk::Start(m_currentDisplayedScalarField->data(), chunkIndex), GL_DYNAMIC_DRAW);
 			glFunc->glEnableVertexAttribArray(ATTR_SF);
-			glFunc->glVertexAttribPointer(ATTR_SF, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+			glFunc->glVertexAttribPointer(ATTR_SF, 1, GL_FLOAT, GL_FALSE, decimStep * sizeof(float), nullptr);
 		}
 		else
 		{
 			assert(false);
 		}
 	}
-	else
+	else // no program, no VBOs
 	{
 		// we must convert the scalar values to RGB colors in a dedicated static array
 		size_t         chunkStart = ccChunk::StartPos(chunkIndex);
@@ -3070,27 +3195,54 @@ void glLODChunkSFPointer(ccScalarField*     sf,
                          QOpenGLFunctions*  glFunc,
                          const LODIndexSet& indexMap,
                          unsigned           startIndex,
-                         unsigned           stopIndex)
+                         unsigned           stopIndex,
+                         bool               useProg = false)
 {
 	assert(startIndex < indexMap.size() && stopIndex <= indexMap.size());
 	assert(sf && glFunc);
-	assert(sizeof(ColorCompType) == 1);
 
-	// we must re-order and convert SF values to RGB colors in a dedicated static array
-	ColorCompType* _sfColors = s_rgbBuffer4ub;
-	for (unsigned j = startIndex; j < stopIndex; j++)
+	if (useProg)
 	{
-		unsigned pointIndex = indexMap[j];
-		// convert the scalar value to a RGB color
-		const ccColor::Rgb* col = sf->getColor(sf->getValue(pointIndex));
-		assert(col);
-		*_sfColors++ = col->r;
-		*_sfColors++ = col->g;
-		*_sfColors++ = col->b;
-		*_sfColors++ = ccColor::MAX;
+		if (s_vboSF != 0)
+		{
+			// with the program, we don't convert SF values to color, we just re-order them
+			float* _sfValues = reinterpret_cast<float*>(s_rgbBuffer4ub);
+			for (unsigned j = startIndex; j < stopIndex; j++)
+			{
+				unsigned pointIndex = indexMap[j];
+				*_sfValues++        = sf->data()[pointIndex];
+			}
+
+			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboSF);
+			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * sizeof(float)), s_rgbBuffer4ub, GL_DYNAMIC_DRAW);
+			glFunc->glEnableVertexAttribArray(ATTR_SF);
+			glFunc->glVertexAttribPointer(ATTR_SF, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+		}
+		else
+		{
+			assert(false);
+		}
 	}
-	// standard OpenGL copy
-	glFunc->glColorPointer(4, GL_UNSIGNED_BYTE, 0, s_rgbBuffer4ub);
+	else
+	{
+		assert(sizeof(ColorCompType) == 1);
+
+		// we must re-order and convert SF values to RGB colors in a dedicated static array
+		ColorCompType* _sfColors = s_rgbBuffer4ub;
+		for (unsigned j = startIndex; j < stopIndex; j++)
+		{
+			unsigned pointIndex = indexMap[j];
+			// convert the scalar value to a RGB color
+			const ccColor::Rgb* col = sf->getColor(sf->getValue(pointIndex));
+			assert(col);
+			*_sfColors++ = col->r;
+			*_sfColors++ = col->g;
+			*_sfColors++ = col->b;
+			*_sfColors++ = ccColor::MAX;
+		}
+		// standard OpenGL copy
+		glFunc->glColorPointer(4, GL_UNSIGNED_BYTE, 0, s_rgbBuffer4ub);
+	}
 }
 
 // description of the (sub)set of points to display
@@ -3475,10 +3627,14 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 				else
 				{
 					assert(m_lod);
-					// Reset the VBO manager if needed:
-					//  We do not want to use the LoD and
-					//  to have the cloud loaded in the VBOs simultaneously.
-					releaseVBOs();
+
+					if (m_lod->getState() == ccPointCloudLOD::INITIALIZED)
+					{
+						// Reset the VBO manager if needed:
+						//  We do not want to use the LoD and
+						//  to have the cloud loaded in the VBOs simultaneously.
+						releaseVBOs();
+					}
 
 					unsigned char maxLevel          = m_lod->maxLevel();
 					bool          underConstruction = m_lod->isUnderConstruction();
@@ -3623,14 +3779,15 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 		if (isVisibilityTableInstantiated())
 		{
 			assert(m_pointsVisibility.size() == m_points.size());
-			// compressed normals set
-			const ccNormalVectors* compressedNormals = ccNormalVectors::GetUniqueInstance();
-			assert(compressedNormals);
 
 			glFunc->glBegin(GL_POINTS);
 
 			if (!entityPickingMode)
 			{
+				// compressed normals set
+				const ccNormalVectors* compressedNormals = ccNormalVectors::GetUniqueInstance();
+				assert(compressedNormals);
+
 				for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
 				{
 					// we must test each point visibility
@@ -3657,7 +3814,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 					}
 				}
 			}
-			else
+			else // picking mode
 			{
 				for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
 				{
@@ -3673,29 +3830,13 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 			glFunc->glEnd();
 		}
-		else if (glParams.showSF && m_currentDisplayedScalarField->mayHaveHiddenValues()) // no visibility table enabled + scalar field + but hidden values
+		else if (glParams.showSF
+		         && m_currentDisplayedScalarField
+		         && m_currentDisplayedScalarField->mayHaveHiddenValues()) // no visibility table enabled but scalar field with hidden points/values
 		{
-			assert(m_currentDisplayedScalarField);
-
-			// if some points may not be displayed, we'll have to be smarter!
-			// bool hiddenPoints = m_currentDisplayedScalarField->mayHaveHiddenValues();
-
-			// whether VBOs are available (for faster display) or not
-			bool useVBOs = false;
-			// if (!hiddenPoints && context.useVBOs && !toDisplay.indexMap) // VBOs are not compatible with LoD
-			//{
-			//	// can't use VBOs if some points are hidden
-			//	useVBOs = updateVBOs(context, glParams);
-			// }
-
 			// color ramp shader initialization
 			ccColorRampShader* colorRampShader = context.colorRampShader;
 			{
-				// color ramp shader is not compatible with VBOs (and VBOs are faster)
-				if (useVBOs)
-				{
-					colorRampShader = nullptr;
-				}
 				// FIXME: color ramp shader doesn't support log scale yet!
 				if (m_currentDisplayedScalarField->logScale())
 				{
@@ -3710,6 +3851,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 			const ccScalarField::Range& sfDisplayRange    = m_currentDisplayedScalarField->displayRange();
 			const ccScalarField::Range& sfSaturationRange = m_currentDisplayedScalarField->saturationRange();
+			const bool                  symmetricalScale  = m_currentDisplayedScalarField->symmetricalScale();
 
 			if (colorRampShader)
 			{
@@ -3792,237 +3934,70 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 				}
 			}
 
-#if 0
-			// if all points should be displayed (fastest case)
-			if (!hiddenPoints)
+			glFunc->glBegin(GL_POINTS);
+
+			if (entityPickingMode)
 			{
-				glFunc->glEnableClientState(GL_VERTEX_ARRAY);
-				glFunc->glEnableClientState(GL_COLOR_ARRAY);
-				if (glParams.showNorms)
+				for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
 				{
-					glFunc->glEnableClientState(GL_NORMAL_ARRAY);
-				}
-
-				if (toDisplay.indexMap) // LoD display
-				{
-					unsigned s = toDisplay.startIndex;
-					while (s < toDisplay.endIndex)
+					unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
+					assert(pointIndex < m_currentDisplayedScalarField->currentSize());
+					const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
+					if (col) // is the point visible?
 					{
-						unsigned count = std::min(MAX_POINT_COUNT_PER_LOD_RENDER_PASS, toDisplay.endIndex - s);
-						unsigned e     = s + count;
-
-						// points
-						glLODChunkVertexPointer<QOpenGLFunctions_2_1>(this, glFunc, *toDisplay.indexMap, s, e);
-						// normals
-						if (glParams.showNorms)
-						{
-							glLODChunkNormalPointer<QOpenGLFunctions_2_1>(m_normals, glFunc, *toDisplay.indexMap, s, e);
-						}
-						// SF colors
-						if (colorRampShader)
-						{
-							float* _sfColors = s_rgbBuffer3f;
-							bool   symScale  = m_currentDisplayedScalarField->symmetricalScale();
-							for (unsigned j = s; j < e; j++, _sfColors += 3)
-							{
-								unsigned   pointIndex = toDisplay.indexMap->at(j);
-								ScalarType sfVal      = m_currentDisplayedScalarField->getValue(pointIndex);
-								// normalized sf value
-								_sfColors[0] = symScale ? GetSymmetricalNormalizedValue(sfVal, sfSaturationRange) : GetNormalizedValue(sfVal, sfDisplayRange);
-								// flag: whether point is grayed out or not (NaN values are also rejected!)
-								_sfColors[1] = sfDisplayRange.isInRange(sfVal) ? 1.0f : 0.0f;
-								// reference value (to get the true lighting value)
-								_sfColors[2] = 1.0f;
-							}
-							glFunc->glColorPointer(3, GL_FLOAT, 0, s_rgbBuffer3f);
-						}
-						else
-						{
-							glLODChunkSFPointer<QOpenGLFunctions_2_1>(m_currentDisplayedScalarField, glFunc, *toDisplay.indexMap, s, e);
-						}
-
-						glFunc->glDrawArrays(GL_POINTS, 0, count);
-
-						s = e;
+						// for entity picking, don't change the color, we just need to know whether the point is visible
+						ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
 					}
 				}
-				else
-				{
-					size_t chunkCount = ccChunk::Count(m_points);
-					for (size_t k = 0; k < chunkCount; ++k)
-					{
-						size_t chunkSize = ccChunk::Size(k, m_points);
-
-						// points
-						glChunkVertexPointer(context, k, toDisplay.decimStep, useVBOs);
-						// normals
-						if (glParams.showNorms)
-						{
-							glChunkNormalPointer(context, k, toDisplay.decimStep, useVBOs);
-						}
-						// SF colors
-						if (colorRampShader)
-						{
-							float* _sfColors  = s_rgbBuffer3f;
-							size_t chunkStart = ccChunk::StartPos(k);
-							bool   symScale   = m_currentDisplayedScalarField->symmetricalScale();
-							for (size_t j = 0; j < chunkSize; j += toDisplay.decimStep, _sfColors += 3)
-							{
-								// SF value
-								ScalarType sfValue = m_currentDisplayedScalarField->getValue(chunkStart + j);
-								// normalized sf value
-								_sfColors[0] = symScale ? GetSymmetricalNormalizedValue(sfValue, sfSaturationRange) : GetNormalizedValue(sfValue, sfDisplayRange);
-								// flag: whether point is grayed out or not (NaN values are also rejected!)
-								_sfColors[1] = sfDisplayRange.isInRange(sfValue) ? 1.0f : 0.0f;
-								// reference value (to get the true lighting value)
-								_sfColors[2] = 1.0f;
-							}
-							glFunc->glColorPointer(3, GL_FLOAT, 0, s_rgbBuffer3f);
-						}
-						else
-						{
-							glChunkSFPointer(context, k, toDisplay.decimStep, useVBOs);
-						}
-
-						if (toDisplay.decimStep > 1)
-						{
-							chunkSize = chunkSize / static_cast<size_t>(toDisplay.decimStep); // equivalent to floor if value >= 0
-						}
-						glFunc->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(chunkSize));
-					}
-				}
-
-				if (glParams.showNorms)
-				{
-					glFunc->glDisableClientState(GL_NORMAL_ARRAY);
-				}
-				glFunc->glDisableClientState(GL_COLOR_ARRAY);
-				glFunc->glDisableClientState(GL_VERTEX_ARRAY);
 			}
-			else // potentially hidden points
-#endif
+			else
 			{
 				// compressed normals set
 				const ccNormalVectors* compressedNormals = ccNormalVectors::GetUniqueInstance();
 				assert(compressedNormals);
 
-				glFunc->glBegin(GL_POINTS);
-
-				if (glParams.showNorms) // with normals (slowest case!)
+				if (colorRampShader)
 				{
-					if (colorRampShader)
+					for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
 					{
-						if (!m_currentDisplayedScalarField->symmetricalScale())
+						unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
+						assert(pointIndex < m_currentDisplayedScalarField->currentSize());
+						const ScalarType sfVal = m_currentDisplayedScalarField->getValue(pointIndex);
+						if (sfDisplayRange.isInRange(sfVal)) // NaN values are rejected
 						{
-							for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+							glFunc->glColor3f(symmetricalScale ? GetSymmetricalNormalizedValue(sfVal, sfSaturationRange)
+							                                   : GetNormalizedValue(sfVal, sfDisplayRange),
+							                  1.0f,
+							                  1.0f);
+							if (glParams.showNorms)
 							{
-								unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-								assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-								const ScalarType sf = m_currentDisplayedScalarField->getValue(pointIndex);
-								if (sfDisplayRange.isInRange(sf)) // NaN values are rejected
-								{
-									glFunc->glColor3f(GetNormalizedValue(sf, sfDisplayRange), 1.0f, 1.0f);
-									ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
-									ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-								}
-							}
-						}
-						else
-						{
-							for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-							{
-								unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-								assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-								const ScalarType sf = m_currentDisplayedScalarField->getValue(pointIndex);
-								if (sfDisplayRange.isInRange(sf)) // NaN values are rejected
-								{
-									glFunc->glColor3f(GetSymmetricalNormalizedValue(sf, sfSaturationRange), 1.0f, 1.0f);
-									ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
-									ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-								}
-							}
-						}
-					}
-					else
-					{
-						for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-						{
-							unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-							assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-							const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
-							if (col)
-							{
-								ccGL::Color(glFunc, *col);
 								ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
-								ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
 							}
+							ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
 						}
 					}
 				}
-				else // potentially hidden points without normals (a bit faster)
+				else // no color ramp shader
 				{
-					if (colorRampShader)
+					for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
 					{
-						if (!m_currentDisplayedScalarField->symmetricalScale())
+						unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
+						assert(pointIndex < m_currentDisplayedScalarField->currentSize());
+						const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
+						if (col) // is the point visible?
 						{
-							for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+							ccGL::Color(glFunc, *col);
+							if (glParams.showNorms)
 							{
-								unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-								assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-								const ScalarType sf = m_currentDisplayedScalarField->getValue(pointIndex);
-								if (sfDisplayRange.isInRange(sf)) // NaN values are rejected
-								{
-									glFunc->glColor3f(GetNormalizedValue(sf, sfDisplayRange), 1.0f, 1.0f);
-									ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-								}
+								ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
 							}
-						}
-						else
-						{
-							for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-							{
-								unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-								assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-								const ScalarType sf = m_currentDisplayedScalarField->getValue(pointIndex);
-								if (sfDisplayRange.isInRange(sf)) // NaN values are rejected
-								{
-									glFunc->glColor3f(GetSymmetricalNormalizedValue(sf, sfSaturationRange), 1.0f, 1.0f);
-									ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-								}
-							}
-						}
-					}
-					else if (entityPickingMode)
-					{
-						for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-						{
-							unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-							assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-							const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
-							if (col)
-							{
-								// for entity picking, don't change the color, we just need to know whether the point is visible
-								ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-							}
-						}
-					}
-					else
-					{
-						for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-						{
-							unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-							assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-							const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
-							if (col)
-							{
-								ccGL::Color(glFunc, *col);
-								ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-							}
+							ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
 						}
 					}
 				}
-				glFunc->glEnd();
 			}
+
+			glFunc->glEnd();
 
 			if (colorRampShader)
 			{
@@ -4036,8 +4011,6 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 		}
 		else // no visibility table enabled, no scalar field or scalar field with no hidden values
 		{
-			bool useVBOs = context.useVBOs && !toDisplay.indexMap ? updateVBOs(context, glParams) : false; // VBOs are not compatible with LoD
-
 			size_t chunkCount = ccChunk::Count(m_points);
 
 			// sf display acceleration texture (for fast scalar field display)
@@ -4135,6 +4108,16 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 					s_globalVBOCreationFailed = true;
 					prog.clear();
 				}
+			}
+
+			bool useProgram = (nullptr != prog);
+			bool useVBOs    = false;
+			if (context.useVBOs && !toDisplay.indexMap) // VBOs are not compatible with LoD
+			{
+				useVBOs = updateVBOs(context,
+				                     glParams,
+				                     /*noSF=*/useProgram,        // we don't need color VBOs if we use the GLSL program
+				                     /*noNormals=*/!useProgram); // we don't need normal (indexes) VBOs if we don't use the GLSL program
 			}
 
 			if (prog)
@@ -4255,18 +4238,23 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 					const auto& indexMap = (*toDisplay.indexMap);
 
 					// points
-					glLODChunkVertexPointer<QOpenGLFunctions_2_1>(this, glFunc, *toDisplay.indexMap, s, e, nullptr != prog);
+					glLODChunkVertexPointer<QOpenGLFunctions_2_1>(this, glFunc, *toDisplay.indexMap, s, e, useProgram);
 
 					// normals
 					if (glParams.showNorms)
 					{
-						glLODChunkNormalPointer<QOpenGLFunctions_2_1>(m_normals, glFunc, *toDisplay.indexMap, s, e, nullptr != prog);
+						glLODChunkNormalPointer<QOpenGLFunctions_2_1>(m_normals, glFunc, *toDisplay.indexMap, s, e, useProgram);
 					}
 
-					// colors
-					if (glParams.showColors)
+					// SFs
+					if (glParams.showSF)
 					{
-						glLODChunkColorPointer<QOpenGLFunctions_2_1>(m_rgbaColors, glFunc, *toDisplay.indexMap, s, e, nullptr != prog);
+						glLODChunkSFPointer<QOpenGLFunctions_2_1>(m_currentDisplayedScalarField, glFunc, *toDisplay.indexMap, s, e, useProgram);
+					}
+					// colors
+					else if (glParams.showColors)
+					{
+						glLODChunkColorPointer<QOpenGLFunctions_2_1>(m_rgbaColors, glFunc, *toDisplay.indexMap, s, e, useProgram);
 					}
 
 					glFunc->glDrawArrays(GL_POINTS, 0, count);
@@ -4299,22 +4287,22 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 					size_t chunkSize = ccChunk::Size(k, m_points);
 
 					// points
-					glChunkVertexPointer(context, k, toDisplay.decimStep, useVBOs, prog != nullptr);
+					glChunkVertexPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
 
 					// normals
 					if (glParams.showNorms)
 					{
-						glChunkNormalPointer(context, k, toDisplay.decimStep, useVBOs, prog != nullptr);
+						glChunkNormalPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
 					}
 					// SFs
 					if (glParams.showSF)
 					{
-						glChunkSFPointer(context, k, toDisplay.decimStep, useVBOs, prog != nullptr);
+						glChunkSFPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
 					}
 					// colors
 					else if (glParams.showColors)
 					{
-						glChunkColorPointer(context, k, toDisplay.decimStep, useVBOs, prog != nullptr);
+						glChunkColorPointer(context, k, toDisplay.decimStep, useVBOs, useProgram);
 					}
 
 					if (toDisplay.decimStep > 1)
@@ -6129,7 +6117,7 @@ CCCoreLib::ReferenceCloud* ccPointCloud::crop2D(const ccPolyline* poly, unsigned
 	return ref;
 }
 
-bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams& glParams)
+bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams& glParams, bool noSF /*=false*/, bool noNormals /*=false*/)
 {
 	if (isColorOverridden())
 	{
@@ -6158,18 +6146,24 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 			m_vboManager.updateFlags |= vboSet::UPDATE_COLORS;
 		}
 
-		if (glParams.showSF
-		    && (!m_vboManager.hasColors
-		        || !m_vboManager.colorIsSF
-		        || m_vboManager.sourceSF != m_currentDisplayedScalarField
-		        || m_currentDisplayedScalarField->getModificationFlag() == true))
+		if (!noSF) // if SF is not skipped
 		{
-			m_vboManager.updateFlags |= vboSet::UPDATE_COLORS;
+			if (glParams.showSF
+			    && (!m_vboManager.hasColors
+			        || !m_vboManager.colorIsSF
+			        || m_vboManager.sourceSF != m_currentDisplayedScalarField
+			        || m_currentDisplayedScalarField->getModificationFlag() == true))
+			{
+				m_vboManager.updateFlags |= vboSet::UPDATE_COLORS;
+			}
 		}
 
-		if (glParams.showNorms && !m_vboManager.hasNormals)
+		if (!noNormals)
 		{
-			m_vboManager.updateFlags |= vboSet::UPDATE_NORMALS;
+			if (glParams.showNorms && !m_vboManager.hasNormals)
+			{
+				m_vboManager.updateFlags |= vboSet::UPDATE_NORMALS;
+			}
 		}
 
 		// nothing to do?
@@ -6231,9 +6225,6 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 		{
 			int chunkSize = static_cast<int>(ccChunk::Size(chunkIndex, m_points));
 
-			int  chunkUpdateFlags = m_vboManager.updateFlags;
-			bool reallocated      = false;
-
 			if (!m_vboManager.vbos[chunkIndex])
 			{
 				m_vboManager.vbos[chunkIndex] = new VBO;
@@ -6242,7 +6233,8 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 			VBO* currentVBO = m_vboManager.vbos[chunkIndex];
 
 			// allocate memory for current VBO
-			int vboSizeBytes = currentVBO->init(chunkSize, m_vboManager.hasColors, m_vboManager.hasNormals, &reallocated);
+			int allocationFlags = 0;
+			int vboSizeBytes    = currentVBO->init(chunkSize, m_vboManager.hasColors, m_vboManager.hasNormals, &allocationFlags);
 
 			QOpenGLFunctions_2_1* glFunc = context.glFunctions<QOpenGLFunctions_2_1>();
 			if (glFunc)
@@ -6253,12 +6245,7 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 			if (vboSizeBytes > 0)
 			{
 				// ccLog::Print(QString("[VBO] VBO #%1 initialized (ID=%2)").arg(chunkIndex).arg(m_vboManager.vbos[chunkIndex]->bufferId()));
-
-				if (reallocated)
-				{
-					// if the vbo is reallocated, then all its content has been cleared!
-					chunkUpdateFlags = vboSet::UPDATE_ALL;
-				}
+				int chunkUpdateFlags = m_vboManager.updateFlags | allocationFlags;
 
 				// load points
 				if (chunkUpdateFlags & vboSet::UPDATE_POINTS)
@@ -6270,6 +6257,7 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 				// load colors
 				if (chunkUpdateFlags & vboSet::UPDATE_COLORS)
 				{
+#if 0
 					if (glParams.showSF)
 					{
 						// copy SF colors in static array
@@ -6312,7 +6300,9 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 						// upadte 'modification' flag for current displayed SF
 						m_vboManager.sourceSF->setModificationFlag(false);
 					}
-					else if (glParams.showColors)
+					else
+#endif
+					if (glParams.showColors)
 					{
 						currentVBO->colorBuffer.bind();
 						currentVBO->colorBuffer.write(0, ccChunk::Start(*m_rgbaColors, chunkIndex), sizeof(ColorCompType) * chunkSize * 4);
@@ -6393,105 +6383,6 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 	m_vboManager.updateFlags = 0;
 
 	return true;
-}
-
-int ccPointCloud::VBO::init(int count, bool withColors, bool withNormals, bool* reallocated /*=nullptr*/)
-{
-	auto resizeVBO = [reallocated](QOpenGLBuffer& buffer, int sizeBytes) -> bool
-	{
-		if (!buffer.isCreated())
-		{
-			if (!buffer.create())
-			{
-				return false;
-			}
-
-			buffer.setUsagePattern(QOpenGLBuffer::DynamicDraw); //"StaticDraw: The data will be set once and used many times for drawing operations."
-			                                                    //"DynamicDraw: The data will be modified repeatedly and used many times for drawing operations.
-		}
-
-		if (!buffer.bind())
-		{
-			ccLog::Warning("[ccPointCloud::VBO::init] Failed to bind VBO to active context!");
-			buffer.destroy();
-			return false;
-		}
-
-		if (sizeBytes != buffer.size())
-		{
-			buffer.allocate(sizeBytes);
-			if (reallocated)
-			{
-				*reallocated = true;
-			}
-
-			if (buffer.size() != sizeBytes)
-			{
-				ccLog::Warning("[ccPointCloud::VBO::init] Not enough (GPU) memory!");
-				buffer.release();
-				buffer.destroy();
-				return false;
-			}
-		}
-
-		buffer.release();
-		return true;
-	};
-
-	// vertices
-	int vertexSizeBytes = 0;
-	{
-		vertexSizeBytes = sizeof(PointCoordinateType) * count * 3;
-
-		if (!resizeVBO(vertexBuffer, vertexSizeBytes))
-		{
-			// no message as it will probably happen on a lot on (old) graphic cards
-			return -1;
-		}
-	}
-
-	// colors
-	int colorSizeBytes = 0;
-	if (withColors)
-	{
-		colorSizeBytes = sizeof(ColorCompType) * count * 4;
-
-		if (!resizeVBO(colorBuffer, colorSizeBytes))
-		{
-			// no message as it will probably happen on a lot on (old) graphic cards
-			return -1;
-		}
-	}
-	else
-	{
-		colorBuffer.destroy();
-	}
-
-	// normal indexes (as floats)
-	int normalSizeBytes = 0;
-	if (withNormals)
-	{
-		normalSizeBytes = sizeof(float) * count;
-
-		if (!resizeVBO(normalIndexBuffer, normalSizeBytes))
-		{
-			// no message as it will probably happen on a lot on (old) graphic cards
-			return -1;
-		}
-	}
-	else
-	{
-		normalIndexBuffer.destroy();
-	}
-
-	return vertexSizeBytes + colorSizeBytes + normalSizeBytes;
-}
-
-void ccPointCloud::VBO::destroy()
-{
-	vertexBuffer.destroy();
-	colorBuffer.destroy();
-	normalIndexBuffer.destroy();
 }
 
 size_t ccPointCloud::vboSize() const

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -2635,7 +2635,18 @@ inline float GetSymmetricalNormalizedValue(ScalarType sfVal, const ccScalarField
 // the GL type depends on the PointCoordinateType 'size' (float or double)
 static GLenum GL_COORD_TYPE = sizeof(PointCoordinateType) == 4 ? GL_FLOAT : GL_DOUBLE;
 
-void ccPointCloud::glChunkVertexPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs)
+// Attribute indexes that we bound when creating the programs
+static const GLuint ATTR_POS = 0;
+static const GLuint ATTR_NOR = 1;
+static const GLuint ATTR_COL = 2;
+
+// Global OpenGL resources
+static QMap<int, QSharedPointer<QOpenGLShaderProgram>> s_programs;
+static GLuint                                          s_vboVertex  = 0;
+static GLuint                                          s_vboNormals = 0;
+static GLuint                                          s_vboColor   = 0;
+
+void ccPointCloud::glChunkVertexPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs, bool useProg /*=false*/)
 {
 	QOpenGLFunctions_2_1* glFunc = context.glFunctions<QOpenGLFunctions_2_1>();
 	assert(glFunc != nullptr);
@@ -2644,23 +2655,45 @@ void ccPointCloud::glChunkVertexPointer(const CC_DRAW_CONTEXT& context, size_t c
 	    && m_vboManager.state == vboSet::INITIALIZED
 	    && m_vboManager.vbos.size() > static_cast<size_t>(chunkIndex)
 	    && m_vboManager.vbos[chunkIndex]
-	    && m_vboManager.vbos[chunkIndex]->isCreated())
+	    && m_vboManager.vbos[chunkIndex]->vertexBuffer.isCreated())
 	{
 		// we can use VBOs directly
-		if (m_vboManager.vbos[chunkIndex]->bind())
+		if (m_vboManager.vbos[chunkIndex]->vertexBuffer.bind())
 		{
-			glFunc->glVertexPointer(3, GL_COORD_TYPE, decimStep * 3 * sizeof(PointCoordinateType), nullptr);
-			m_vboManager.vbos[chunkIndex]->release();
+			if (useProg)
+			{
+				glFunc->glEnableVertexAttribArray(ATTR_POS);
+				glFunc->glVertexAttribPointer(ATTR_POS, 3, GL_COORD_TYPE, GL_FALSE, decimStep * 3 * sizeof(PointCoordinateType), nullptr);
+			}
+			else
+			{
+				glFunc->glVertexPointer(3, GL_COORD_TYPE, decimStep * 3 * sizeof(PointCoordinateType), nullptr);
+			}
+			m_vboManager.vbos[chunkIndex]->vertexBuffer.release();
 		}
 		else
 		{
 			ccLog::Warning("[VBO] Failed to bind VBO?! We'll deactivate them then...");
 			m_vboManager.state = vboSet::FAILED;
 			// recall the method
-			glChunkVertexPointer(context, chunkIndex, decimStep, false);
+			glChunkVertexPointer(context, chunkIndex, decimStep, false, useProg);
 		}
 	}
-	else
+	else if (useProg) // use a program but no pre-saved VBOs (only the global one)
+	{
+		if (s_vboVertex != 0)
+		{
+			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVertex);
+			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(ccChunk::Size(chunkIndex, m_points) * 3 * sizeof(PointCoordinateType)), ccChunk::Start(m_points, chunkIndex), GL_DYNAMIC_DRAW);
+			glFunc->glEnableVertexAttribArray(ATTR_POS);
+			glFunc->glVertexAttribPointer(ATTR_POS, 3, GL_COORD_TYPE, GL_FALSE, decimStep * 3 * sizeof(PointCoordinateType), nullptr);
+		}
+		else
+		{
+			assert(false);
+		}
+	}
+	else // no program, no VBOs
 	{
 		// standard OpenGL copy
 		glFunc->glVertexPointer(3, GL_COORD_TYPE, decimStep * 3 * sizeof(PointCoordinateType), ccChunk::Start(m_points, chunkIndex));
@@ -2681,37 +2714,65 @@ static PointCoordinateType s_normalBuffer[MAX_POINT_COUNT_PER_LOD_RENDER_PASS * 
 static ColorCompType       s_rgbBuffer4ub[MAX_POINT_COUNT_PER_LOD_RENDER_PASS * 4];
 static float               s_rgbBuffer3f[MAX_POINT_COUNT_PER_LOD_RENDER_PASS * 3];
 
-void ccPointCloud::glChunkNormalPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs)
+void ccPointCloud::glChunkNormalPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs, bool useProg /*=false*/)
 {
-	assert(m_normals);
+	if (!m_normals)
+	{
+		assert(false);
+		return;
+	}
 
 	QOpenGLFunctions_2_1* glFunc = context.glFunctions<QOpenGLFunctions_2_1>();
 	assert(glFunc != nullptr);
 
 	if (useVBOs
+	    && useProg
 	    && m_vboManager.state == vboSet::INITIALIZED
 	    && m_vboManager.hasNormals
 	    && m_vboManager.vbos.size() > static_cast<size_t>(chunkIndex)
 	    && m_vboManager.vbos[chunkIndex]
-	    && m_vboManager.vbos[chunkIndex]->isCreated())
+	    && m_vboManager.vbos[chunkIndex]->normalIndexBuffer.isCreated())
 	{
-		// we can use VBOs directly
-		if (m_vboManager.vbos[chunkIndex]->bind())
+		// we can use VBOs and a program
+		if (m_vboManager.vbos[chunkIndex]->normalIndexBuffer.bind())
 		{
-			const GLbyte* start           = nullptr; // fake pointer used to prevent warnings on Linux
-			int           normalDataShift = m_vboManager.vbos[chunkIndex]->normalShift;
-			glFunc->glNormalPointer(GL_COORD_TYPE, decimStep * 3 * sizeof(PointCoordinateType), static_cast<const GLvoid*>(start + normalDataShift));
-			m_vboManager.vbos[chunkIndex]->release();
+			glFunc->glEnableVertexAttribArray(ATTR_NOR);
+			glFunc->glVertexAttribPointer(ATTR_NOR, 1, GL_FLOAT, GL_FALSE, decimStep * sizeof(float), nullptr);
+			m_vboManager.vbos[chunkIndex]->normalIndexBuffer.release();
 		}
 		else
 		{
 			ccLog::Warning("[VBO] Failed to bind VBO?! We'll deactivate them then...");
 			m_vboManager.state = vboSet::FAILED;
 			// recall the method
-			glChunkNormalPointer(context, chunkIndex, decimStep, false);
+			glChunkNormalPointer(context, chunkIndex, decimStep, false, useProg);
 		}
 	}
-	else if (m_normals)
+	else if (useProg) // use a program but no pre-saved VBOs (only the global one)
+	{
+		if (s_vboNormals != 0)
+		{
+			float* _normalIndexes = reinterpret_cast<float*>(s_normalBuffer);
+			size_t s              = ccChunk::StartPos(chunkIndex);
+			size_t e              = s + ccChunk::Size(chunkIndex, m_normals->size());
+			size_t count          = 0;
+			for (size_t j = s; j < e; j += decimStep)
+			{
+				*_normalIndexes++ = static_cast<float>(m_normals->at(j));
+				++count;
+			}
+
+			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboNormals);
+			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(count * sizeof(float)), s_normalBuffer, GL_DYNAMIC_DRAW);
+			glFunc->glEnableVertexAttribArray(ATTR_NOR);
+			glFunc->glVertexAttribPointer(ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+		}
+		else
+		{
+			assert(false);
+		}
+	}
+	else // no program, no VBOs
 	{
 		// we must decode normals in a dedicated static array
 		PointCoordinateType*      _normals        = s_normalBuffer;
@@ -2731,15 +2792,15 @@ void ccPointCloud::glChunkNormalPointer(const CC_DRAW_CONTEXT& context, size_t c
 		}
 		glFunc->glNormalPointer(GL_COORD_TYPE, 0, s_normalBuffer);
 	}
-	else
-	{
-		assert(false);
-	}
 }
 
-void ccPointCloud::glChunkColorPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs)
+void ccPointCloud::glChunkColorPointer(const CC_DRAW_CONTEXT& context, size_t chunkIndex, unsigned decimStep, bool useVBOs, bool useProg /*=false*/)
 {
-	assert(m_rgbaColors);
+	if (!m_rgbaColors)
+	{
+		assert(false);
+		return;
+	}
 	assert(sizeof(ColorCompType) == 1);
 
 	QOpenGLFunctions_2_1* glFunc = context.glFunctions<QOpenGLFunctions_2_1>();
@@ -2750,33 +2811,49 @@ void ccPointCloud::glChunkColorPointer(const CC_DRAW_CONTEXT& context, size_t ch
 	    && m_vboManager.hasColors
 	    && m_vboManager.vbos.size() > static_cast<size_t>(chunkIndex)
 	    && m_vboManager.vbos[chunkIndex]
-	    && m_vboManager.vbos[chunkIndex]->isCreated())
+	    && m_vboManager.vbos[chunkIndex]->colorBuffer.isCreated())
 	{
 		// we can use VBOs directly
-		if (m_vboManager.vbos[chunkIndex]->bind())
+		if (m_vboManager.vbos[chunkIndex]->colorBuffer.bind())
 		{
-			const GLbyte* start          = nullptr; // fake pointer used to prevent warnings on Linux
-			int           colorDataShift = m_vboManager.vbos[chunkIndex]->rgbShift;
-			glFunc->glColorPointer(4, GL_UNSIGNED_BYTE, decimStep * 4 * sizeof(ColorCompType), static_cast<const GLvoid*>(start + colorDataShift));
-			m_vboManager.vbos[chunkIndex]->release();
+			if (useProg)
+			{
+				glFunc->glEnableVertexAttribArray(ATTR_COL);
+				glFunc->glVertexAttribPointer(ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, decimStep * 4 * sizeof(ColorCompType), nullptr);
+			}
+			else
+			{
+				glFunc->glColorPointer(4, GL_UNSIGNED_BYTE, decimStep * 4 * sizeof(ColorCompType), nullptr);
+				m_vboManager.vbos[chunkIndex]->colorBuffer.release();
+			}
 		}
 		else
 		{
 			ccLog::Warning("[VBO] Failed to bind VBO?! We'll deactivate them then...");
 			m_vboManager.state = vboSet::FAILED;
 			// recall the method
-			glChunkColorPointer(context, chunkIndex, decimStep, false);
+			glChunkColorPointer(context, chunkIndex, decimStep, false, useProg);
 		}
 	}
-	else if (m_rgbaColors)
+	else if (useProg) // use a program but no pre-saved VBOs (only the global one)
+	{
+		if (s_vboColor != 0)
+		{
+			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
+			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(ccChunk::Size(chunkIndex, m_rgbaColors->size()) * 4 * sizeof(unsigned char)), ccChunk::Start(*m_rgbaColors, chunkIndex), GL_DYNAMIC_DRAW);
+			glFunc->glEnableVertexAttribArray(ATTR_COL);
+			glFunc->glVertexAttribPointer(ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, decimStep * 4 * sizeof(ColorCompType), nullptr);
+		}
+		else
+		{
+			assert(false);
+		}
+	}
+	else // no program, no VBOs
 	{
 		assert(m_rgbaColors);
 		// standard OpenGL copy
 		glFunc->glColorPointer(4, GL_UNSIGNED_BYTE, decimStep * 4 * sizeof(ColorCompType), ccChunk::Start(*m_rgbaColors, chunkIndex));
-	}
-	else
-	{
-		assert(false);
 	}
 }
 
@@ -2793,16 +2870,14 @@ void ccPointCloud::glChunkSFPointer(const CC_DRAW_CONTEXT& context, size_t chunk
 	    && m_vboManager.hasColors
 	    && m_vboManager.vbos.size() > static_cast<size_t>(chunkIndex)
 	    && m_vboManager.vbos[chunkIndex]
-	    && m_vboManager.vbos[chunkIndex]->isCreated())
+	    && m_vboManager.vbos[chunkIndex]->colorBuffer.isCreated())
 	{
 		assert(m_vboManager.colorIsSF && m_vboManager.sourceSF == m_currentDisplayedScalarField);
 		// we can use VBOs directly
-		if (m_vboManager.vbos[chunkIndex]->bind())
+		if (m_vboManager.vbos[chunkIndex]->colorBuffer.bind())
 		{
-			const GLbyte* start          = nullptr; // fake pointer used to prevent warnings on Linux
-			int           colorDataShift = m_vboManager.vbos[chunkIndex]->rgbShift;
-			glFunc->glColorPointer(4, GL_UNSIGNED_BYTE, decimStep * 4 * sizeof(ColorCompType), static_cast<const GLvoid*>(start + colorDataShift));
-			m_vboManager.vbos[chunkIndex]->release();
+			glFunc->glColorPointer(4, GL_UNSIGNED_BYTE, decimStep * 4 * sizeof(ColorCompType), nullptr);
+			m_vboManager.vbos[chunkIndex]->colorBuffer.release();
 		}
 		else
 		{
@@ -2839,7 +2914,8 @@ void glLODChunkVertexPointer(ccPointCloud*      cloud,
                              QOpenGLFunctions*  glFunc,
                              const LODIndexSet& indexMap,
                              unsigned           startIndex,
-                             unsigned           stopIndex)
+                             unsigned           stopIndex,
+                             bool               useProg = false)
 {
 	assert(startIndex < indexMap.size() && stopIndex <= indexMap.size());
 	assert(cloud && glFunc);
@@ -2853,8 +2929,19 @@ void glLODChunkVertexPointer(ccPointCloud*      cloud,
 		*(_points)++                = P->y;
 		*(_points)++                = P->z;
 	}
-	// standard OpenGL copy
-	glFunc->glVertexPointer(3, GL_COORD_TYPE, 0, s_pointBuffer);
+
+	if (useProg)
+	{
+		glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVertex);
+		glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * 3 * sizeof(PointCoordinateType)), s_pointBuffer, GL_DYNAMIC_DRAW);
+		glFunc->glEnableVertexAttribArray(ATTR_POS);
+		glFunc->glVertexAttribPointer(ATTR_POS, 3, GL_COORD_TYPE, GL_FALSE, 0, nullptr);
+	}
+	else
+	{
+		// standard OpenGL copy
+		glFunc->glVertexPointer(3, GL_COORD_TYPE, 0, s_pointBuffer);
+	}
 }
 
 template <class QOpenGLFunctions>
@@ -2862,27 +2949,53 @@ void glLODChunkNormalPointer(NormsIndexesTableType* normals,
                              QOpenGLFunctions*      glFunc,
                              const LODIndexSet&     indexMap,
                              unsigned               startIndex,
-                             unsigned               stopIndex)
+                             unsigned               stopIndex,
+                             bool                   useProg = false)
 {
 	assert(startIndex < indexMap.size() && stopIndex <= indexMap.size());
 	assert(normals && glFunc);
 
-	// compressed normals set
-	const ccNormalVectors* compressedNormals = ccNormalVectors::GetUniqueInstance();
-	assert(compressedNormals);
-
-	// we must decode normals in a dedicated static array
-	PointCoordinateType* _normals = s_normalBuffer;
-	for (unsigned j = startIndex; j < stopIndex; j++)
+	if (useProg)
 	{
-		unsigned         pointIndex = indexMap[j];
-		const CCVector3& N          = compressedNormals->getNormal(normals->at(pointIndex));
-		*(_normals)++               = N.x;
-		*(_normals)++               = N.y;
-		*(_normals)++               = N.z;
+		if (s_vboNormals != 0)
+		{
+			// with the program, we don't decode normals in a dedicated static array, we just re-order the indexes
+			float* _normalIndexes = reinterpret_cast<float*>(s_normalBuffer);
+			for (unsigned j = startIndex; j < stopIndex; j++)
+			{
+				unsigned pointIndex = indexMap[j];
+				*_normalIndexes++   = static_cast<float>(normals->at(pointIndex));
+			}
+
+			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboNormals);
+			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * sizeof(float)), s_normalBuffer, GL_DYNAMIC_DRAW);
+			glFunc->glEnableVertexAttribArray(ATTR_NOR);
+			glFunc->glVertexAttribPointer(ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
+		}
+		else
+		{
+			assert(false);
+		}
 	}
-	// standard OpenGL copy
-	glFunc->glNormalPointer(GL_COORD_TYPE, 0, s_normalBuffer);
+	else
+	{
+		// compressed normals set
+		const ccNormalVectors* compressedNormals = ccNormalVectors::GetUniqueInstance();
+		assert(compressedNormals);
+
+		// we must decode normals in a dedicated static array
+		PointCoordinateType* _normals = s_normalBuffer;
+		for (unsigned j = startIndex; j < stopIndex; j++)
+		{
+			unsigned         pointIndex = indexMap[j];
+			const CCVector3& N          = compressedNormals->getNormal(normals->at(pointIndex));
+			*(_normals)++               = N.x;
+			*(_normals)++               = N.y;
+			*(_normals)++               = N.z;
+		}
+		// standard OpenGL copy
+		glFunc->glNormalPointer(GL_COORD_TYPE, 0, s_normalBuffer);
+	}
 }
 
 template <class QOpenGLFunctions>
@@ -2890,7 +3003,8 @@ void glLODChunkColorPointer(RGBAColorsTableType* colors,
                             QOpenGLFunctions*    glFunc,
                             const LODIndexSet&   indexMap,
                             unsigned             startIndex,
-                            unsigned             stopIndex)
+                            unsigned             stopIndex,
+                            bool                 useProg = false)
 {
 	assert(startIndex < indexMap.size() && stopIndex <= indexMap.size());
 	assert(colors && glFunc);
@@ -2907,8 +3021,27 @@ void glLODChunkColorPointer(RGBAColorsTableType* colors,
 		*(_rgba)++                      = col.b;
 		*(_rgba)++                      = col.a;
 	}
-	// standard OpenGL copy
-	glFunc->glColorPointer(4, GL_UNSIGNED_BYTE, 0, s_rgbBuffer4ub);
+
+	if (useProg)
+	{
+		if (s_vboColor != 0)
+		{
+			// we must re-order colors in a dedicated static array
+			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
+			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * 4 * sizeof(unsigned char)), s_rgbBuffer4ub, GL_DYNAMIC_DRAW);
+			glFunc->glEnableVertexAttribArray(ATTR_COL);
+			glFunc->glVertexAttribPointer(ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, nullptr);
+		}
+		else
+		{
+			assert(false);
+		}
+	}
+	else
+	{
+		// standard OpenGL copy
+		glFunc->glColorPointer(4, GL_UNSIGNED_BYTE, 0, s_rgbBuffer4ub);
+	}
 }
 
 template <class QOpenGLFunctions>
@@ -2979,645 +3112,602 @@ struct DisplayDesc : LODLevelDesc
 	LODIndexSet* indexMap;
 };
 
+// Simple program builder (GLSL 1.20) for cloud rendering (position, normal, color)
+static QSharedPointer<QOpenGLShaderProgram> BuildSimpleCloudProgram(QOpenGLFunctions_2_1* glFunc, int attributes)
+{
+	if (!glFunc)
+	{
+		assert(false);
+		return nullptr;
+	}
+
+	if (s_programs.contains(attributes))
+	{
+		return s_programs[attributes];
+	}
+
+	QString vertexProgSrc;
+	QString fragmentProgSrc;
+
+	static const char* ColorOnlyFragmentProgSrc =
+	    "#version 120\n"
+	    "varying vec4 vColor;\n"
+	    "void main()\n"
+	    "{\n"
+	    "    gl_FragColor = vColor;\n"
+	    "}\n";
+
+	static const char* ColorAndNormalFragmentProgSrc =
+	    "#version 120\n"
+	    "varying vec4 vColor;\n"
+	    "varying vec3 vNormal;\n"
+	    "void main()\n"
+	    "{\n"
+	    "    vec3 n = normalize(vNormal);\n"
+	    "    vec3 lightDir = normalize(vec3(0.0,0.0,1.0));\n"
+	    "    float diff = max(dot(n, lightDir), 0.0);\n"
+	    "    vec4 base = vColor;\n"
+	    "    gl_FragColor = vec4(base.rgb * diff, base.a);\n"
+	    "}\n";
+
+	switch (attributes)
+	{
+	case ATTR_POS:
+		vertexProgSrc =
+		    "#version 120\n"
+		    "attribute vec3 aPosition;\n"
+		    "varying vec4 vColor;\n"
+		    "void main()\n"
+		    "{\n"
+		    "    vColor = gl_Color;\n"
+		    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
+		    "}\n";
+
+		fragmentProgSrc = ColorOnlyFragmentProgSrc;
+
+		break;
+
+	case ATTR_COL:
+		vertexProgSrc =
+		    "#version 120\n"
+		    "attribute vec3 aPosition;\n"
+		    "attribute vec4 aColor;\n"
+		    "varying vec4 vColor;\n"
+		    "void main()\n"
+		    "{\n"
+		    "    vColor = aColor;\n"
+		    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
+		    "}\n";
+
+		fragmentProgSrc = ColorOnlyFragmentProgSrc;
+		break;
+
+	case ATTR_NOR:
+		vertexProgSrc =
+		    "#version 120\n"
+		    "attribute vec3 aPosition;\n"
+		    "attribute float aNormalIndex;\n"
+		    "varying vec4 vColor;\n"
+		    "varying vec3 vNormal;\n"
+		    "uniform sampler2D uNormalLUT;\n"
+		    "uniform int uLUTWidth;\n"
+		    "uniform int uLUTHeight;\n"
+		    "vec3 fetchNormalFromLUT(float fi)\n"
+		    "{\n"
+		    "	float w  = float(uLUTWidth);\n"
+		    "	float h  = float(uLUTHeight);\n"
+		    "	float tx = mod(fi, w);\n"
+		    "	float ty = floor(fi / w);\n"
+		    "	vec2 uv = vec2((tx + 0.5) / w, (ty + 0.5) / h);\n"
+		    "	vec3 enc = texture2D(uNormalLUT, uv).rgb;\n"
+		    "	vec3 n = enc * 2.0 - 1.0;\n"
+		    "	return normalize(n);\n"
+		    "}\n"
+		    "void main()\n"
+		    "{\n"
+		    "    vColor = gl_Color;\n"
+		    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n"
+		    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
+		    "}\n";
+
+		fragmentProgSrc = ColorAndNormalFragmentProgSrc;
+		break;
+
+	case (ATTR_COL | ATTR_NOR):
+		vertexProgSrc =
+		    "#version 120\n"
+		    "attribute vec3 aPosition;\n"
+		    "attribute float aNormalIndex;\n"
+		    "attribute vec4 aColor;\n"
+		    "varying vec4 vColor;\n"
+		    "varying vec3 vNormal;\n"
+		    "uniform sampler2D uNormalLUT;\n"
+		    "uniform int uLUTWidth;\n"
+		    "uniform int uLUTHeight;\n"
+		    "vec3 fetchNormalFromLUT(float fi)\n"
+		    "{\n"
+		    "	float w  = float(uLUTWidth);\n"
+		    "	float h  = float(uLUTHeight);\n"
+		    "	float tx = mod(fi, w);\n"
+		    "	float ty = floor(fi / w);\n"
+		    "	vec2 uv = vec2((tx + 0.5) / w, (ty + 0.5) / h);\n"
+		    "	vec3 enc = texture2D(uNormalLUT, uv).rgb;\n"
+		    "	vec3 n = enc * 2.0 - 1.0;\n"
+		    "	return normalize(n);\n"
+		    "}\n"
+		    "void main()\n"
+		    "{\n"
+		    "    vColor = aColor;\n"
+		    "    vNormal = gl_NormalMatrix * fetchNormalFromLUT(aNormalIndex);\n"
+		    "    gl_Position = gl_ModelViewProjectionMatrix * vec4(aPosition, 1.0);\n"
+		    "}\n";
+
+		fragmentProgSrc = ColorAndNormalFragmentProgSrc;
+		break;
+
+	default:
+		assert(false);
+		ccLog::Warning("[	] Unsupported feature combination!");
+		return nullptr;
+	}
+
+	QOpenGLShader vertexShader(QOpenGLShader::Vertex);
+	if (false == vertexShader.compileSourceCode(vertexProgSrc))
+	{
+		ccLog::Warning(QString("[BuildSimpleCloudProgram] Vertex shader compilation failed: ") + vertexShader.log());
+		return nullptr;
+	}
+	QOpenGLShader fragmentShader(QOpenGLShader::Fragment);
+	if (false == fragmentShader.compileSourceCode(fragmentProgSrc))
+	{
+		ccLog::Warning(QString("[BuildSimpleCloudProgram] Fragment shader compilation failed: ") + fragmentShader.log());
+		return nullptr;
+	}
+	QSharedPointer<QOpenGLShaderProgram> program(new QOpenGLShaderProgram);
+	program->addShader(&vertexShader);
+	program->addShader(&fragmentShader);
+
+	// bind attribute locations before linking for stable locations
+	program->bindAttributeLocation("aPosition", ATTR_POS);
+	if (attributes & ATTR_COL)
+	{
+		program->bindAttributeLocation("aColor", ATTR_COL);
+	}
+	if (attributes & ATTR_NOR)
+	{
+		program->bindAttributeLocation("aNormalIndex", ATTR_NOR);
+	}
+
+	if (false == program->link())
+	{
+		ccLog::Warning(QString("[BuildSimpleCloudProgram] Shader program linking failed: ") + program->log());
+		return nullptr;
+	}
+
+	s_programs[attributes] = program;
+
+	ccGLDrawContext::CatchGLErrors(glFunc->glGetError(), "ccPointCloud::shader.program.build");
+
+	return program;
+}
+
 void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 {
 	if (m_points.empty())
+	{
 		return;
+	}
 
 	// get the set of OpenGL functions (version 2.1)
 	QOpenGLFunctions_2_1* glFunc = context.glFunctions<QOpenGLFunctions_2_1>();
-	assert(glFunc != nullptr);
-
 	if (glFunc == nullptr)
-		return;
-
-	if (MACRO_Draw3D(context))
 	{
-		// we get display parameters
-		glDrawParams glParams;
-		getDrawingParameters(glParams);
-		// no normals shading without light!
-		if (!MACRO_LightIsEnabled(context))
+		assert(false);
+		return;
+	}
+
+	if (MACRO_Draw2D(context))
+	{
+		if (MACRO_Foreground(context) && !context.sfColorScaleToDisplay)
 		{
-			glParams.showNorms = false;
-		}
-
-		// can't display a SF without... a SF... and an active color scale!
-		assert(!glParams.showSF || hasDisplayedScalarField());
-
-		// color-based entity picking
-		bool         entityPickingMode = MACRO_EntityPicking(context);
-		ccColor::Rgb pickingColor;
-		if (entityPickingMode)
-		{
-			// not fast at all!
-			if (MACRO_FastEntityPicking(context))
+			if (sfColorScaleShown() && sfShown())
 			{
-				return;
-			}
-
-			pickingColor = context.entityPicking.registerEntity(this);
-
-			// minimal display for picking mode!
-			glParams.showNorms  = false;
-			glParams.showColors = false;
-			if (glParams.showSF && !m_currentDisplayedScalarField->mayHaveHiddenValues())
-			{
-				glParams.showSF = false; //--> we keep it only if SF 'NaN' values are potentially hidden
+				// drawScale(context);
+				addColorRampInfo(context);
 			}
 		}
+		return;
+	}
 
-		// L.O.D. display
-		DisplayDesc toDisplay(0, size());
-		if (!entityPickingMode)
+	if (!MACRO_Draw3D(context))
+	{
+		// nothing else to do if we don't draw 3D!
+		return;
+	}
+
+	// retrieve the display parameters
+	glDrawParams glParams;
+	getDrawingParameters(glParams);
+	// no normals shading without light!
+	if (!MACRO_LightIsEnabled(context))
+	{
+		glParams.showNorms = false;
+	}
+
+	// can't display a SF without... a SF... and an active color scale!
+	assert(!glParams.showSF || hasDisplayedScalarField());
+
+	// color-based entity picking
+	bool         entityPickingMode = MACRO_EntityPicking(context);
+	ccColor::Rgb pickingColor;
+	if (entityPickingMode)
+	{
+		// not fast at all!
+		if (MACRO_FastEntityPicking(context))
 		{
-			if (context.decimateCloudOnMove
-			    && m_useLODRendering
-			    && toDisplay.count > context.minLODPointCount
-			    && MACRO_LODActivated(context))
+			return;
+		}
+
+		pickingColor = context.entityPicking.registerEntity(this);
+
+		// minimal display for picking mode!
+		glParams.showNorms  = false;
+		glParams.showColors = false;
+		if (glParams.showSF && !m_currentDisplayedScalarField->mayHaveHiddenValues())
+		{
+			glParams.showSF = false; //--> we keep it only if SF 'NaN' values are potentially hidden
+		}
+	}
+
+	// L.O.D. display
+	DisplayDesc toDisplay(0, size());
+	if (!entityPickingMode)
+	{
+		if (context.decimateCloudOnMove
+		    && m_useLODRendering
+		    && toDisplay.count > context.minLODPointCount
+		    && MACRO_LODActivated(context))
+		{
+			// is there a LoD structure associated yet?
+			if (!m_lod || !m_lod->isBroken())
 			{
-				// is there a LoD structure associated yet?
-				if (!m_lod || !m_lod->isBroken())
+				if (!m_lod || m_lod->isNull())
 				{
-					if (!m_lod || m_lod->isNull())
-					{
-						// auto-init LoD structure
-						// DGM: can't spawn a progress dialog here as the process will be async
-						// ccProgressDialog pDlg(false, context.display ? context.display->asWidget() : 0);
-						initLOD(/*&pDlg*/);
-					}
-					else
-					{
-						assert(m_lod);
-						// Reset the VBO manager if needed:
-						//  We do not want to use the LoD and
-						//  to have the cloud loaded in the VBOs simultaneously.
-						releaseVBOs();
-
-						unsigned char maxLevel          = m_lod->maxLevel();
-						bool          underConstruction = m_lod->isUnderConstruction();
-
-						// if the cloud has less LOD levels than the minimum to display
-						if (underConstruction || maxLevel == 0)
-						{
-							// not yet ready
-							context.moreLODPointsAvailable   = underConstruction;
-							context.higherLODLevelsAvailable = false;
-						}
-						else if (context.stereoPassIndex == 0)
-						{
-							if (context.currentLODLevel == 0)
-							{
-								// get the current viewport and OpenGL matrices
-								ccGLCameraParameters camera;
-								context.display->getGLCameraParameters(camera);
-								// replace the viewport and matrices by the real ones
-								glFunc->glGetIntegerv(GL_VIEWPORT, camera.viewport);
-								glFunc->glGetDoublev(GL_PROJECTION_MATRIX, camera.projectionMat.data());
-								glFunc->glGetDoublev(GL_MODELVIEW_MATRIX, camera.modelViewMat.data());
-								// camera frustum
-								Frustum frustum(camera.modelViewMat, camera.projectionMat);
-
-								// first time: we flag the cells visibility and count the number of visible points
-								m_lod->flagVisibility(frustum, m_clipPlanes.empty() ? nullptr : &m_clipPlanes);
-							}
-
-							unsigned remainingPointsAtThisLevel = 0;
-							toDisplay.startIndex                = 0;
-							toDisplay.count                     = MAX_POINT_COUNT_PER_LOD_RENDER_PASS;
-							toDisplay.indexMap                  = &m_lod->getIndexMap(context.currentLODLevel, toDisplay.count, remainingPointsAtThisLevel);
-							if (toDisplay.count == 0)
-							{
-								// nothing to draw at this level
-								toDisplay.indexMap = nullptr;
-							}
-							else
-							{
-								assert(toDisplay.count == toDisplay.indexMap->size());
-								toDisplay.endIndex = toDisplay.startIndex + toDisplay.count;
-							}
-
-							// could we draw more points at the next level?
-							context.moreLODPointsAvailable   = (remainingPointsAtThisLevel != 0);
-							context.higherLODLevelsAvailable = (!m_lod->allDisplayed() && context.currentLODLevel + 1 <= maxLevel);
-						}
-					}
-				}
-
-				if (!toDisplay.indexMap)
-				{
-					// if we don't have a LoD map, we can only display points at level 0!
-					if (context.currentLODLevel != 0)
-					{
-						return;
-					}
-
-					// we wait for the LOD to be ready
-					// meanwhile we will display less points
-					if (context.minLODPointCount && toDisplay.count > context.minLODPointCount)
-					{
-						GLint maxStride = 2048;
-#ifdef GL_MAX_VERTEX_ATTRIB_STRIDE
-						glFunc->glGetIntegerv(GL_MAX_VERTEX_ATTRIB_STRIDE, &maxStride);
-#endif
-						// maxStride == decimStep * 3 * sizeof(PointCoordinateType)
-						toDisplay.decimStep = static_cast<int>(ceil(static_cast<float>(toDisplay.count) / context.minLODPointCount));
-						toDisplay.decimStep = std::min<unsigned>(toDisplay.decimStep, maxStride / (3 * sizeof(PointCoordinateType)));
-					}
-				}
-			}
-		}
-
-		// ccLog::Print(QString("Rendering %1 points starting from index %2 (LoD = %3 / PN = %4)").arg(toDisplay.count).arg(toDisplay.startIndex).arg(toDisplay.indexMap ? "yes" : "no").arg(pushName ? "yes" : "no"));
-
-		glFunc->glPushAttrib(GL_LIGHTING_BIT | GL_COLOR_BUFFER_BIT | GL_TRANSFORM_BIT | GL_POINT_BIT);
-
-		if (glParams.showSF || glParams.showColors)
-		{
-			glFunc->glColorMaterial(GL_FRONT_AND_BACK, GL_DIFFUSE);
-			glFunc->glEnable(GL_COLOR_MATERIAL);
-			glFunc->glEnable(GL_BLEND);
-		}
-
-		if (entityPickingMode)
-		{
-			ccGL::Color(glFunc, pickingColor);
-		}
-		else if (glParams.showColors && isColorOverridden())
-		{
-			ccGL::Color(glFunc, m_tempColor);
-			glParams.showColors = false;
-		}
-		else
-		{
-			ccGL::Color(glFunc, context.pointsDefaultCol);
-		}
-
-		// in the case we need normals (i.e. lighting)
-		if (glParams.showNorms)
-		{
-			glFunc->glEnable(GL_RESCALE_NORMAL);
-			glFunc->glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT, CC_DEFAULT_CLOUD_AMBIENT_COLOR.rgba);
-			glFunc->glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, CC_DEFAULT_CLOUD_SPECULAR_COLOR.rgba);
-			glFunc->glMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, CC_DEFAULT_CLOUD_DIFFUSE_COLOR.rgba);
-			glFunc->glMaterialfv(GL_FRONT_AND_BACK, GL_EMISSION, CC_DEFAULT_CLOUD_EMISSION_COLOR.rgba);
-			glFunc->glMaterialf(GL_FRONT_AND_BACK, GL_SHININESS, CC_DEFAULT_CLOUD_SHININESS);
-			glFunc->glEnable(GL_LIGHTING);
-
-			if (glParams.showSF)
-			{
-				// we must get rid of lights 'color' if a scalar field is displayed!
-				ccMaterial::MakeLightsNeutral(context.qGLContext);
-			}
-		}
-
-		/*** DISPLAY ***/
-
-		// rounded points
-		if (context.drawRoundedPoints)
-		{
-			glFunc->glPushAttrib(GL_POINT_BIT);
-			// DGM: alpha/blending doesn't work well because it creates a halo around points with a potentially wrong color (due to the display order)
-			// glFunc->glDisable(GL_BLEND);
-			glFunc->glEnable(GL_POINT_SMOOTH);
-			// glFunc->glEnable(GL_ALPHA_TEST);
-			// glFunc->glAlphaFunc(GL_GREATER, 0.5);
-			// glFunc->glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-			// glFunc->glEnable(GL_BLEND);
-		}
-
-		// custom point size?
-		if (m_pointSize != 0)
-		{
-			glFunc->glPointSize(static_cast<GLfloat>(m_pointSize));
-		}
-
-		// main display procedure
-		{
-			// if some points are hidden (= visibility table instantiated), we can't use display arrays :(
-			if (isVisibilityTableInstantiated())
-			{
-				assert(m_pointsVisibility.size() == m_points.size());
-				// compressed normals set
-				const ccNormalVectors* compressedNormals = ccNormalVectors::GetUniqueInstance();
-				assert(compressedNormals);
-
-				glFunc->glBegin(GL_POINTS);
-
-				if (!entityPickingMode)
-				{
-					for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-					{
-						// we must test each point visibility
-						unsigned pointIndex = toDisplay.indexMap ? toDisplay.indexMap->at(j) : j;
-						if (m_pointsVisibility.empty() || m_pointsVisibility[pointIndex] == CCCoreLib::POINT_VISIBLE)
-						{
-							if (glParams.showSF)
-							{
-								assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-								const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
-								// we force display of points hidden because of their scalar field value
-								// to be sure that the user doesn't miss them (during manual segmentation for instance)
-								ccGL::Color(glFunc, col ? *col : ccColor::lightGreyRGB); // Make sure all points are visible. No alpha used on purpose
-							}
-							else if (glParams.showColors)
-							{
-								ccGL::Color(glFunc, m_rgbaColors->getValue(pointIndex));
-							}
-							if (glParams.showNorms)
-							{
-								ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
-							}
-							ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-						}
-					}
+					// auto-init LoD structure
+					// DGM: can't spawn a progress dialog here as the process will be async
+					// ccProgressDialog pDlg(false, context.display ? context.display->asWidget() : 0);
+					initLOD(/*&pDlg*/);
 				}
 				else
 				{
-					for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+					assert(m_lod);
+					// Reset the VBO manager if needed:
+					//  We do not want to use the LoD and
+					//  to have the cloud loaded in the VBOs simultaneously.
+					releaseVBOs();
+
+					unsigned char maxLevel          = m_lod->maxLevel();
+					bool          underConstruction = m_lod->isUnderConstruction();
+
+					// if the cloud has less LOD levels than the minimum to display
+					if (underConstruction || maxLevel == 0)
 					{
-						// we must test each point visibility
-						unsigned pointIndex = toDisplay.indexMap ? toDisplay.indexMap->at(j) : j;
-						if (m_pointsVisibility.empty() || m_pointsVisibility[pointIndex] == CCCoreLib::POINT_VISIBLE)
+						// not yet ready
+						context.moreLODPointsAvailable   = underConstruction;
+						context.higherLODLevelsAvailable = false;
+					}
+					else if (context.stereoPassIndex == 0)
+					{
+						if (context.currentLODLevel == 0)
 						{
-							// in color-based picking mode, we only display the points
-							ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
+							// get the current viewport and OpenGL matrices
+							ccGLCameraParameters camera;
+							context.display->getGLCameraParameters(camera);
+							// replace the viewport and matrices by the real ones
+							glFunc->glGetIntegerv(GL_VIEWPORT, camera.viewport);
+							glFunc->glGetDoublev(GL_PROJECTION_MATRIX, camera.projectionMat.data());
+							glFunc->glGetDoublev(GL_MODELVIEW_MATRIX, camera.modelViewMat.data());
+							// camera frustum
+							Frustum frustum(camera.modelViewMat, camera.projectionMat);
+
+							// first time: we flag the cells visibility and count the number of visible points
+							m_lod->flagVisibility(frustum, m_clipPlanes.empty() ? nullptr : &m_clipPlanes);
 						}
-					}
-				}
 
-				glFunc->glEnd();
-			}
-			else if (glParams.showSF) // no visibility table enabled + scalar field
-			{
-				assert(m_currentDisplayedScalarField);
-
-				// if some points may not be displayed, we'll have to be smarter!
-				bool hiddenPoints = m_currentDisplayedScalarField->mayHaveHiddenValues();
-
-				// whether VBOs are available (for faster display) or not
-				bool useVBOs = false;
-				if (!hiddenPoints && context.useVBOs && !toDisplay.indexMap) // VBOs are not compatible with LoD
-				{
-					// can't use VBOs if some points are hidden
-					useVBOs = updateVBOs(context, glParams);
-				}
-
-				// color ramp shader initialization
-				ccColorRampShader* colorRampShader = context.colorRampShader;
-				{
-					// color ramp shader is not compatible with VBOs (and VBOs are faster)
-					if (useVBOs)
-					{
-						colorRampShader = nullptr;
-					}
-					// FIXME: color ramp shader doesn't support log scale yet!
-					if (m_currentDisplayedScalarField->logScale())
-					{
-						colorRampShader = nullptr;
-					}
-					// the shader can't be used during color-based color picking
-					if (entityPickingMode)
-					{
-						colorRampShader = nullptr;
-					}
-				}
-
-				const ccScalarField::Range& sfDisplayRange    = m_currentDisplayedScalarField->displayRange();
-				const ccScalarField::Range& sfSaturationRange = m_currentDisplayedScalarField->saturationRange();
-
-				if (colorRampShader)
-				{
-					// max available space for fragment's shader uniforms
-					GLint maxBytes = 0;
-					glFunc->glGetIntegerv(GL_MAX_FRAGMENT_UNIFORM_COMPONENTS, &maxBytes);
-					GLint    maxComponents = (maxBytes >> 2) - 4; // leave space for the other uniforms!
-					unsigned steps         = m_currentDisplayedScalarField->getColorRampSteps();
-					assert(steps != 0);
-
-					if (steps > ccColorRampShader::MaxColorRampSize() || maxComponents < static_cast<GLint>(steps))
-					{
-						ccLog::WarningDebug("Color ramp steps exceed shader limits!");
-						colorRampShader = nullptr;
-					}
-					else
-					{
-						float sfMinSatRel = 0.0f;
-						float sfMaxSatRel = 1.0f;
-						if (!m_currentDisplayedScalarField->symmetricalScale())
+						unsigned remainingPointsAtThisLevel = 0;
+						toDisplay.startIndex                = 0;
+						toDisplay.count                     = MAX_POINT_COUNT_PER_LOD_RENDER_PASS;
+						toDisplay.indexMap                  = &m_lod->getIndexMap(context.currentLODLevel, toDisplay.count, remainingPointsAtThisLevel);
+						if (toDisplay.count == 0)
 						{
-							sfMinSatRel = GetNormalizedValue(sfSaturationRange.start(), sfDisplayRange); // doesn't need to be between 0 and 1!
-							sfMaxSatRel = GetNormalizedValue(sfSaturationRange.stop(), sfDisplayRange);  // doesn't need to be between 0 and 1!
+							// nothing to draw at this level
+							toDisplay.indexMap = nullptr;
 						}
 						else
 						{
-							// we can only handle 'maximum' saturation
-							sfMinSatRel = GetSymmetricalNormalizedValue(-sfSaturationRange.stop(), sfSaturationRange);
-							sfMaxSatRel = GetSymmetricalNormalizedValue(sfSaturationRange.stop(), sfSaturationRange);
-							// we'll have to handle the 'minimum' saturation manually!
+							assert(toDisplay.count == toDisplay.indexMap->size());
+							toDisplay.endIndex = toDisplay.startIndex + toDisplay.count;
 						}
 
-						const ccColorScale::Shared& colorScale = m_currentDisplayedScalarField->getColorScale();
-						assert(colorScale);
-
-						colorRampShader->bind();
-						if (!colorRampShader->setup(glFunc, sfMinSatRel, sfMaxSatRel, steps, colorScale))
-						{
-							// An error occurred during shader initialization?
-							ccLog::WarningDebug("Failed to init ColorRamp shader!");
-							colorRampShader->release();
-							colorRampShader = nullptr;
-						}
-						else if (glParams.showNorms)
-						{
-							// we must get rid of lights material (other than ambient) for the red and green fields
-							glFunc->glPushAttrib(GL_LIGHTING_BIT);
-
-							// we use the ambient light to pass the scalar value (and 'grayed' marker) without any
-							// modification from the GPU pipeline, even if normals are enabled!
-							glFunc->glDisable(GL_COLOR_MATERIAL);
-							glFunc->glColorMaterial(GL_FRONT_AND_BACK, GL_DIFFUSE);
-							glFunc->glColorMaterial(GL_FRONT_AND_BACK, GL_AMBIENT);
-							glFunc->glEnable(GL_COLOR_MATERIAL);
-
-							GLint maxLightCount;
-							glFunc->glGetIntegerv(GL_MAX_LIGHTS, &maxLightCount);
-							for (GLint i = 0; i < maxLightCount; ++i)
-							{
-								if (glFunc->glIsEnabled(GL_LIGHT0 + i))
-								{
-									float diffuse[4];
-									float ambiant[4];
-									float specular[4];
-
-									glFunc->glGetLightfv(GL_LIGHT0 + i, GL_AMBIENT, ambiant);
-									glFunc->glGetLightfv(GL_LIGHT0 + i, GL_DIFFUSE, diffuse);
-									glFunc->glGetLightfv(GL_LIGHT0 + i, GL_SPECULAR, specular);
-
-									ambiant[0] = ambiant[1] = 1.0f;
-									diffuse[0] = diffuse[1] = 0.0f;
-									specular[0] = specular[1] = 0.0f;
-
-									glFunc->glLightfv(GL_LIGHT0 + i, GL_DIFFUSE, diffuse);
-									glFunc->glLightfv(GL_LIGHT0 + i, GL_AMBIENT, ambiant);
-									glFunc->glLightfv(GL_LIGHT0 + i, GL_SPECULAR, specular);
-								}
-							}
-						}
-					}
-				}
-
-				// if all points should be displayed (fastest case)
-				if (!hiddenPoints)
-				{
-					glFunc->glEnableClientState(GL_VERTEX_ARRAY);
-					glFunc->glEnableClientState(GL_COLOR_ARRAY);
-					if (glParams.showNorms)
-					{
-						glFunc->glEnableClientState(GL_NORMAL_ARRAY);
-					}
-
-					if (toDisplay.indexMap) // LoD display
-					{
-						unsigned s = toDisplay.startIndex;
-						while (s < toDisplay.endIndex)
-						{
-							unsigned count = std::min(MAX_POINT_COUNT_PER_LOD_RENDER_PASS, toDisplay.endIndex - s);
-							unsigned e     = s + count;
-
-							// points
-							glLODChunkVertexPointer<QOpenGLFunctions_2_1>(this, glFunc, *toDisplay.indexMap, s, e);
-							// normals
-							if (glParams.showNorms)
-							{
-								glLODChunkNormalPointer<QOpenGLFunctions_2_1>(m_normals, glFunc, *toDisplay.indexMap, s, e);
-							}
-							// SF colors
-							if (colorRampShader)
-							{
-								float* _sfColors = s_rgbBuffer3f;
-								bool   symScale  = m_currentDisplayedScalarField->symmetricalScale();
-								for (unsigned j = s; j < e; j++, _sfColors += 3)
-								{
-									unsigned   pointIndex = toDisplay.indexMap->at(j);
-									ScalarType sfVal      = m_currentDisplayedScalarField->getValue(pointIndex);
-									// normalized sf value
-									_sfColors[0] = symScale ? GetSymmetricalNormalizedValue(sfVal, sfSaturationRange) : GetNormalizedValue(sfVal, sfDisplayRange);
-									// flag: whether point is grayed out or not (NaN values are also rejected!)
-									_sfColors[1] = sfDisplayRange.isInRange(sfVal) ? 1.0f : 0.0f;
-									// reference value (to get the true lighting value)
-									_sfColors[2] = 1.0f;
-								}
-								glFunc->glColorPointer(3, GL_FLOAT, 0, s_rgbBuffer3f);
-							}
-							else
-							{
-								glLODChunkSFPointer<QOpenGLFunctions_2_1>(m_currentDisplayedScalarField, glFunc, *toDisplay.indexMap, s, e);
-							}
-
-							glFunc->glDrawArrays(GL_POINTS, 0, count);
-
-							s = e;
-						}
-					}
-					else
-					{
-						size_t chunkCount = ccChunk::Count(m_points);
-						for (size_t k = 0; k < chunkCount; ++k)
-						{
-							size_t chunkSize = ccChunk::Size(k, m_points);
-
-							// points
-							glChunkVertexPointer(context, k, toDisplay.decimStep, useVBOs);
-							// normals
-							if (glParams.showNorms)
-							{
-								glChunkNormalPointer(context, k, toDisplay.decimStep, useVBOs);
-							}
-							// SF colors
-							if (colorRampShader)
-							{
-								float* _sfColors  = s_rgbBuffer3f;
-								size_t chunkStart = ccChunk::StartPos(k);
-								bool   symScale   = m_currentDisplayedScalarField->symmetricalScale();
-								for (size_t j = 0; j < chunkSize; j += toDisplay.decimStep, _sfColors += 3)
-								{
-									// SF value
-									ScalarType sfValue = m_currentDisplayedScalarField->getValue(chunkStart + j);
-									// normalized sf value
-									_sfColors[0] = symScale ? GetSymmetricalNormalizedValue(sfValue, sfSaturationRange) : GetNormalizedValue(sfValue, sfDisplayRange);
-									// flag: whether point is grayed out or not (NaN values are also rejected!)
-									_sfColors[1] = sfDisplayRange.isInRange(sfValue) ? 1.0f : 0.0f;
-									// reference value (to get the true lighting value)
-									_sfColors[2] = 1.0f;
-								}
-								glFunc->glColorPointer(3, GL_FLOAT, 0, s_rgbBuffer3f);
-							}
-							else
-							{
-								glChunkSFPointer(context, k, toDisplay.decimStep, useVBOs);
-							}
-
-							if (toDisplay.decimStep > 1)
-							{
-								chunkSize = static_cast<unsigned>(static_cast<double>(chunkSize) / toDisplay.decimStep); // static_cast is equivalent to floor if value >= 0
-							}
-							glFunc->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(chunkSize));
-						}
-					}
-
-					if (glParams.showNorms)
-					{
-						glFunc->glDisableClientState(GL_NORMAL_ARRAY);
-					}
-					glFunc->glDisableClientState(GL_COLOR_ARRAY);
-					glFunc->glDisableClientState(GL_VERTEX_ARRAY);
-				}
-				else // potentially hidden points
-				{
-					// compressed normals set
-					const ccNormalVectors* compressedNormals = ccNormalVectors::GetUniqueInstance();
-					assert(compressedNormals);
-
-					glFunc->glBegin(GL_POINTS);
-
-					if (glParams.showNorms) // with normals (slowest case!)
-					{
-						if (colorRampShader)
-						{
-							if (!m_currentDisplayedScalarField->symmetricalScale())
-							{
-								for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-								{
-									unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-									assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-									const ScalarType sf = m_currentDisplayedScalarField->getValue(pointIndex);
-									if (sfDisplayRange.isInRange(sf)) // NaN values are rejected
-									{
-										glFunc->glColor3f(GetNormalizedValue(sf, sfDisplayRange), 1.0f, 1.0f);
-										ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
-										ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-									}
-								}
-							}
-							else
-							{
-								for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-								{
-									unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-									assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-									const ScalarType sf = m_currentDisplayedScalarField->getValue(pointIndex);
-									if (sfDisplayRange.isInRange(sf)) // NaN values are rejected
-									{
-										glFunc->glColor3f(GetSymmetricalNormalizedValue(sf, sfSaturationRange), 1.0f, 1.0f);
-										ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
-										ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-									}
-								}
-							}
-						}
-						else
-						{
-							for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-							{
-								unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-								assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-								const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
-								if (col)
-								{
-									ccGL::Color(glFunc, *col);
-									ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
-									ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-								}
-							}
-						}
-					}
-					else // potentially hidden points without normals (a bit faster)
-					{
-						if (colorRampShader)
-						{
-							if (!m_currentDisplayedScalarField->symmetricalScale())
-							{
-								for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-								{
-									unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-									assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-									const ScalarType sf = m_currentDisplayedScalarField->getValue(pointIndex);
-									if (sfDisplayRange.isInRange(sf)) // NaN values are rejected
-									{
-										glFunc->glColor3f(GetNormalizedValue(sf, sfDisplayRange), 1.0f, 1.0f);
-										ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-									}
-								}
-							}
-							else
-							{
-								for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-								{
-									unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-									assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-									const ScalarType sf = m_currentDisplayedScalarField->getValue(pointIndex);
-									if (sfDisplayRange.isInRange(sf)) // NaN values are rejected
-									{
-										glFunc->glColor3f(GetSymmetricalNormalizedValue(sf, sfSaturationRange), 1.0f, 1.0f);
-										ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-									}
-								}
-							}
-						}
-						else if (entityPickingMode)
-						{
-							for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-							{
-								unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-								assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-								const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
-								if (col)
-								{
-									// for entity picking, don't change the color, we just need to know whether the point is visible
-									ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-								}
-							}
-						}
-						else
-						{
-							for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
-							{
-								unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
-								assert(pointIndex < m_currentDisplayedScalarField->currentSize());
-								const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
-								if (col)
-								{
-									ccGL::Color(glFunc, *col);
-									ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
-								}
-							}
-						}
-					}
-					glFunc->glEnd();
-				}
-
-				if (colorRampShader)
-				{
-					colorRampShader->release();
-
-					if (glParams.showNorms)
-					{
-						glFunc->glPopAttrib(); // GL_LIGHTING_BIT
+						// could we draw more points at the next level?
+						context.moreLODPointsAvailable   = (remainingPointsAtThisLevel != 0);
+						context.higherLODLevelsAvailable = (!m_lod->allDisplayed() && context.currentLODLevel + 1 <= maxLevel);
 					}
 				}
 			}
-			else // no visibility table enabled, no scalar field
+
+			if (!toDisplay.indexMap)
 			{
-				bool useVBOs = context.useVBOs && !toDisplay.indexMap ? updateVBOs(context, glParams) : false; // VBOs are not compatible with LoD
+				// if we don't have a LoD map, we can only display points at level 0!
+				if (context.currentLODLevel != 0)
+				{
+					return;
+				}
 
-				size_t chunkCount = ccChunk::Count(m_points);
+				// we wait for the LOD to be ready
+				// meanwhile we will display less points
+				if (context.minLODPointCount && toDisplay.count > context.minLODPointCount)
+				{
+					GLint maxStride = 2048;
+#ifdef GL_MAX_VERTEX_ATTRIB_STRIDE
+					glFunc->glGetIntegerv(GL_MAX_VERTEX_ATTRIB_STRIDE, &maxStride);
+#endif
+					// maxStride == decimStep * 3 * sizeof(PointCoordinateType)
+					toDisplay.decimStep = static_cast<int>(ceil(static_cast<float>(toDisplay.count) / context.minLODPointCount));
+					toDisplay.decimStep = std::min<unsigned>(toDisplay.decimStep, maxStride / (3 * sizeof(PointCoordinateType)));
+				}
+			}
+		}
+	}
 
+	// ccLog::Print(QString("Rendering %1 points starting from index %2 (LoD = %3 / PN = %4)").arg(toDisplay.count).arg(toDisplay.startIndex).arg(toDisplay.indexMap ? "yes" : "no").arg(pushName ? "yes" : "no"));
+
+	glFunc->glPushAttrib(GL_LIGHTING_BIT | GL_COLOR_BUFFER_BIT | GL_TRANSFORM_BIT | GL_POINT_BIT);
+
+	if (glParams.showSF || glParams.showColors)
+	{
+		glFunc->glColorMaterial(GL_FRONT_AND_BACK, GL_DIFFUSE);
+		glFunc->glEnable(GL_COLOR_MATERIAL);
+		glFunc->glEnable(GL_BLEND);
+	}
+
+	if (entityPickingMode)
+	{
+		ccGL::Color(glFunc, pickingColor);
+	}
+	else if (glParams.showColors && isColorOverridden())
+	{
+		ccGL::Color(glFunc, m_tempColor);
+		glParams.showColors = false;
+	}
+	else
+	{
+		ccGL::Color(glFunc, context.pointsDefaultCol);
+	}
+
+	// in the case we need normals (i.e. lighting)
+	if (glParams.showNorms)
+	{
+		glFunc->glEnable(GL_RESCALE_NORMAL);
+		glFunc->glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT, CC_DEFAULT_CLOUD_AMBIENT_COLOR.rgba);
+		glFunc->glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, CC_DEFAULT_CLOUD_SPECULAR_COLOR.rgba);
+		glFunc->glMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, CC_DEFAULT_CLOUD_DIFFUSE_COLOR.rgba);
+		glFunc->glMaterialfv(GL_FRONT_AND_BACK, GL_EMISSION, CC_DEFAULT_CLOUD_EMISSION_COLOR.rgba);
+		glFunc->glMaterialf(GL_FRONT_AND_BACK, GL_SHININESS, CC_DEFAULT_CLOUD_SHININESS);
+		glFunc->glEnable(GL_LIGHTING);
+
+		if (glParams.showSF)
+		{
+			// we must get rid of lights 'color' if a scalar field is displayed!
+			ccMaterial::MakeLightsNeutral(context.qGLContext);
+		}
+	}
+
+	/*** DISPLAY ***/
+
+	// rounded points
+	if (context.drawRoundedPoints)
+	{
+		glFunc->glPushAttrib(GL_POINT_BIT);
+		// DGM: alpha/blending doesn't work well because it creates a halo around points with a potentially wrong color (due to the display order)
+		// glFunc->glDisable(GL_BLEND);
+		glFunc->glEnable(GL_POINT_SMOOTH);
+		// glFunc->glEnable(GL_ALPHA_TEST);
+		// glFunc->glAlphaFunc(GL_GREATER, 0.5);
+		// glFunc->glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+		// glFunc->glEnable(GL_BLEND);
+	}
+
+	// custom point size?
+	if (m_pointSize != 0)
+	{
+		glFunc->glPointSize(static_cast<GLfloat>(m_pointSize));
+	}
+
+	// main display procedure
+	{
+		// if some points are hidden (= visibility table instantiated), we can't use display arrays :(
+		if (isVisibilityTableInstantiated())
+		{
+			assert(m_pointsVisibility.size() == m_points.size());
+			// compressed normals set
+			const ccNormalVectors* compressedNormals = ccNormalVectors::GetUniqueInstance();
+			assert(compressedNormals);
+
+			glFunc->glBegin(GL_POINTS);
+
+			if (!entityPickingMode)
+			{
+				for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+				{
+					// we must test each point visibility
+					unsigned pointIndex = toDisplay.indexMap ? toDisplay.indexMap->at(j) : j;
+					if (m_pointsVisibility.empty() || m_pointsVisibility[pointIndex] == CCCoreLib::POINT_VISIBLE)
+					{
+						if (glParams.showSF)
+						{
+							assert(pointIndex < m_currentDisplayedScalarField->currentSize());
+							const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
+							// we force display of points hidden because of their scalar field value
+							// to be sure that the user doesn't miss them (during manual segmentation for instance)
+							ccGL::Color(glFunc, col ? *col : ccColor::lightGreyRGB); // Make sure all points are visible. No alpha used on purpose
+						}
+						else if (glParams.showColors)
+						{
+							ccGL::Color(glFunc, m_rgbaColors->getValue(pointIndex));
+						}
+						if (glParams.showNorms)
+						{
+							ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
+						}
+						ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
+					}
+				}
+			}
+			else
+			{
+				for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+				{
+					// we must test each point visibility
+					unsigned pointIndex = toDisplay.indexMap ? toDisplay.indexMap->at(j) : j;
+					if (m_pointsVisibility.empty() || m_pointsVisibility[pointIndex] == CCCoreLib::POINT_VISIBLE)
+					{
+						// in color-based picking mode, we only display the points
+						ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
+					}
+				}
+			}
+
+			glFunc->glEnd();
+		}
+		else if (glParams.showSF) // no visibility table enabled + scalar field
+		{
+			assert(m_currentDisplayedScalarField);
+
+			// if some points may not be displayed, we'll have to be smarter!
+			bool hiddenPoints = m_currentDisplayedScalarField->mayHaveHiddenValues();
+
+			// whether VBOs are available (for faster display) or not
+			bool useVBOs = false;
+			if (!hiddenPoints && context.useVBOs && !toDisplay.indexMap) // VBOs are not compatible with LoD
+			{
+				// can't use VBOs if some points are hidden
+				useVBOs = updateVBOs(context, glParams);
+			}
+
+			// color ramp shader initialization
+			ccColorRampShader* colorRampShader = context.colorRampShader;
+			{
+				// color ramp shader is not compatible with VBOs (and VBOs are faster)
+				if (useVBOs)
+				{
+					colorRampShader = nullptr;
+				}
+				// FIXME: color ramp shader doesn't support log scale yet!
+				if (m_currentDisplayedScalarField->logScale())
+				{
+					colorRampShader = nullptr;
+				}
+				// the shader can't be used during color-based color picking
+				if (entityPickingMode)
+				{
+					colorRampShader = nullptr;
+				}
+			}
+
+			const ccScalarField::Range& sfDisplayRange    = m_currentDisplayedScalarField->displayRange();
+			const ccScalarField::Range& sfSaturationRange = m_currentDisplayedScalarField->saturationRange();
+
+			if (colorRampShader)
+			{
+				// max available space for fragment's shader uniforms
+				GLint maxBytes = 0;
+				glFunc->glGetIntegerv(GL_MAX_FRAGMENT_UNIFORM_COMPONENTS, &maxBytes);
+				GLint    maxComponents = (maxBytes >> 2) - 4; // leave space for the other uniforms!
+				unsigned steps         = m_currentDisplayedScalarField->getColorRampSteps();
+				assert(steps != 0);
+
+				if (steps > ccColorRampShader::MaxColorRampSize() || maxComponents < static_cast<GLint>(steps))
+				{
+					ccLog::WarningDebug("Color ramp steps exceed shader limits!");
+					colorRampShader = nullptr;
+				}
+				else
+				{
+					float sfMinSatRel = 0.0f;
+					float sfMaxSatRel = 1.0f;
+					if (!m_currentDisplayedScalarField->symmetricalScale())
+					{
+						sfMinSatRel = GetNormalizedValue(sfSaturationRange.start(), sfDisplayRange); // doesn't need to be between 0 and 1!
+						sfMaxSatRel = GetNormalizedValue(sfSaturationRange.stop(), sfDisplayRange);  // doesn't need to be between 0 and 1!
+					}
+					else
+					{
+						// we can only handle 'maximum' saturation
+						sfMinSatRel = GetSymmetricalNormalizedValue(-sfSaturationRange.stop(), sfSaturationRange);
+						sfMaxSatRel = GetSymmetricalNormalizedValue(sfSaturationRange.stop(), sfSaturationRange);
+						// we'll have to handle the 'minimum' saturation manually!
+					}
+
+					const ccColorScale::Shared& colorScale = m_currentDisplayedScalarField->getColorScale();
+					assert(colorScale);
+
+					colorRampShader->bind();
+					if (!colorRampShader->setup(glFunc, sfMinSatRel, sfMaxSatRel, steps, colorScale))
+					{
+						// An error occurred during shader initialization?
+						ccLog::WarningDebug("Failed to init ColorRamp shader!");
+						colorRampShader->release();
+						colorRampShader = nullptr;
+					}
+					else if (glParams.showNorms)
+					{
+						// we must get rid of lights material (other than ambient) for the red and green fields
+						glFunc->glPushAttrib(GL_LIGHTING_BIT);
+
+						// we use the ambient light to pass the scalar value (and 'grayed' marker) without any
+						// modification from the GPU pipeline, even if normals are enabled!
+						glFunc->glDisable(GL_COLOR_MATERIAL);
+						glFunc->glColorMaterial(GL_FRONT_AND_BACK, GL_DIFFUSE);
+						glFunc->glColorMaterial(GL_FRONT_AND_BACK, GL_AMBIENT);
+						glFunc->glEnable(GL_COLOR_MATERIAL);
+
+						GLint maxLightCount;
+						glFunc->glGetIntegerv(GL_MAX_LIGHTS, &maxLightCount);
+						for (GLint i = 0; i < maxLightCount; ++i)
+						{
+							if (glFunc->glIsEnabled(GL_LIGHT0 + i))
+							{
+								float diffuse[4];
+								float ambiant[4];
+								float specular[4];
+
+								glFunc->glGetLightfv(GL_LIGHT0 + i, GL_AMBIENT, ambiant);
+								glFunc->glGetLightfv(GL_LIGHT0 + i, GL_DIFFUSE, diffuse);
+								glFunc->glGetLightfv(GL_LIGHT0 + i, GL_SPECULAR, specular);
+
+								ambiant[0] = ambiant[1] = 1.0f;
+								diffuse[0] = diffuse[1] = 0.0f;
+								specular[0] = specular[1] = 0.0f;
+
+								glFunc->glLightfv(GL_LIGHT0 + i, GL_DIFFUSE, diffuse);
+								glFunc->glLightfv(GL_LIGHT0 + i, GL_AMBIENT, ambiant);
+								glFunc->glLightfv(GL_LIGHT0 + i, GL_SPECULAR, specular);
+							}
+						}
+					}
+				}
+			}
+
+			// if all points should be displayed (fastest case)
+			if (!hiddenPoints)
+			{
 				glFunc->glEnableClientState(GL_VERTEX_ARRAY);
+				glFunc->glEnableClientState(GL_COLOR_ARRAY);
 				if (glParams.showNorms)
+				{
 					glFunc->glEnableClientState(GL_NORMAL_ARRAY);
-				if (glParams.showColors)
-					glFunc->glEnableClientState(GL_COLOR_ARRAY);
+				}
 
 				if (toDisplay.indexMap) // LoD display
 				{
@@ -3631,17 +3721,40 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 						glLODChunkVertexPointer<QOpenGLFunctions_2_1>(this, glFunc, *toDisplay.indexMap, s, e);
 						// normals
 						if (glParams.showNorms)
+						{
 							glLODChunkNormalPointer<QOpenGLFunctions_2_1>(m_normals, glFunc, *toDisplay.indexMap, s, e);
-						// colors
-						if (glParams.showColors)
-							glLODChunkColorPointer<QOpenGLFunctions_2_1>(m_rgbaColors, glFunc, *toDisplay.indexMap, s, e);
+						}
+						// SF colors
+						if (colorRampShader)
+						{
+							float* _sfColors = s_rgbBuffer3f;
+							bool   symScale  = m_currentDisplayedScalarField->symmetricalScale();
+							for (unsigned j = s; j < e; j++, _sfColors += 3)
+							{
+								unsigned   pointIndex = toDisplay.indexMap->at(j);
+								ScalarType sfVal      = m_currentDisplayedScalarField->getValue(pointIndex);
+								// normalized sf value
+								_sfColors[0] = symScale ? GetSymmetricalNormalizedValue(sfVal, sfSaturationRange) : GetNormalizedValue(sfVal, sfDisplayRange);
+								// flag: whether point is grayed out or not (NaN values are also rejected!)
+								_sfColors[1] = sfDisplayRange.isInRange(sfVal) ? 1.0f : 0.0f;
+								// reference value (to get the true lighting value)
+								_sfColors[2] = 1.0f;
+							}
+							glFunc->glColorPointer(3, GL_FLOAT, 0, s_rgbBuffer3f);
+						}
+						else
+						{
+							glLODChunkSFPointer<QOpenGLFunctions_2_1>(m_currentDisplayedScalarField, glFunc, *toDisplay.indexMap, s, e);
+						}
 
 						glFunc->glDrawArrays(GL_POINTS, 0, count);
+
 						s = e;
 					}
 				}
 				else
 				{
+					size_t chunkCount = ccChunk::Count(m_points);
 					for (size_t k = 0; k < chunkCount; ++k)
 					{
 						size_t chunkSize = ccChunk::Size(k, m_points);
@@ -3650,51 +3763,420 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 						glChunkVertexPointer(context, k, toDisplay.decimStep, useVBOs);
 						// normals
 						if (glParams.showNorms)
+						{
 							glChunkNormalPointer(context, k, toDisplay.decimStep, useVBOs);
-						// colors
-						if (glParams.showColors)
-							glChunkColorPointer(context, k, toDisplay.decimStep, useVBOs);
+						}
+						// SF colors
+						if (colorRampShader)
+						{
+							float* _sfColors  = s_rgbBuffer3f;
+							size_t chunkStart = ccChunk::StartPos(k);
+							bool   symScale   = m_currentDisplayedScalarField->symmetricalScale();
+							for (size_t j = 0; j < chunkSize; j += toDisplay.decimStep, _sfColors += 3)
+							{
+								// SF value
+								ScalarType sfValue = m_currentDisplayedScalarField->getValue(chunkStart + j);
+								// normalized sf value
+								_sfColors[0] = symScale ? GetSymmetricalNormalizedValue(sfValue, sfSaturationRange) : GetNormalizedValue(sfValue, sfDisplayRange);
+								// flag: whether point is grayed out or not (NaN values are also rejected!)
+								_sfColors[1] = sfDisplayRange.isInRange(sfValue) ? 1.0f : 0.0f;
+								// reference value (to get the true lighting value)
+								_sfColors[2] = 1.0f;
+							}
+							glFunc->glColorPointer(3, GL_FLOAT, 0, s_rgbBuffer3f);
+						}
+						else
+						{
+							glChunkSFPointer(context, k, toDisplay.decimStep, useVBOs);
+						}
 
 						if (toDisplay.decimStep > 1)
 						{
-							chunkSize = static_cast<unsigned>(static_cast<double>(chunkSize) / toDisplay.decimStep); // static_cast is equivalent to floor if value >= 0
+							chunkSize = chunkSize / static_cast<size_t>(toDisplay.decimStep); // equivalent to floor if value >= 0
 						}
 						glFunc->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(chunkSize));
 					}
 				}
 
+				if (glParams.showNorms)
+				{
+					glFunc->glDisableClientState(GL_NORMAL_ARRAY);
+				}
+				glFunc->glDisableClientState(GL_COLOR_ARRAY);
+				glFunc->glDisableClientState(GL_VERTEX_ARRAY);
+			}
+			else // potentially hidden points
+			{
+				// compressed normals set
+				const ccNormalVectors* compressedNormals = ccNormalVectors::GetUniqueInstance();
+				assert(compressedNormals);
+
+				glFunc->glBegin(GL_POINTS);
+
+				if (glParams.showNorms) // with normals (slowest case!)
+				{
+					if (colorRampShader)
+					{
+						if (!m_currentDisplayedScalarField->symmetricalScale())
+						{
+							for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+							{
+								unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
+								assert(pointIndex < m_currentDisplayedScalarField->currentSize());
+								const ScalarType sf = m_currentDisplayedScalarField->getValue(pointIndex);
+								if (sfDisplayRange.isInRange(sf)) // NaN values are rejected
+								{
+									glFunc->glColor3f(GetNormalizedValue(sf, sfDisplayRange), 1.0f, 1.0f);
+									ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
+									ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
+								}
+							}
+						}
+						else
+						{
+							for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+							{
+								unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
+								assert(pointIndex < m_currentDisplayedScalarField->currentSize());
+								const ScalarType sf = m_currentDisplayedScalarField->getValue(pointIndex);
+								if (sfDisplayRange.isInRange(sf)) // NaN values are rejected
+								{
+									glFunc->glColor3f(GetSymmetricalNormalizedValue(sf, sfSaturationRange), 1.0f, 1.0f);
+									ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
+									ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
+								}
+							}
+						}
+					}
+					else
+					{
+						for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+						{
+							unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
+							assert(pointIndex < m_currentDisplayedScalarField->currentSize());
+							const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
+							if (col)
+							{
+								ccGL::Color(glFunc, *col);
+								ccGL::Normal3v(glFunc, compressedNormals->getNormal(m_normals->getValue(pointIndex)).u);
+								ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
+							}
+						}
+					}
+				}
+				else // potentially hidden points without normals (a bit faster)
+				{
+					if (colorRampShader)
+					{
+						if (!m_currentDisplayedScalarField->symmetricalScale())
+						{
+							for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+							{
+								unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
+								assert(pointIndex < m_currentDisplayedScalarField->currentSize());
+								const ScalarType sf = m_currentDisplayedScalarField->getValue(pointIndex);
+								if (sfDisplayRange.isInRange(sf)) // NaN values are rejected
+								{
+									glFunc->glColor3f(GetNormalizedValue(sf, sfDisplayRange), 1.0f, 1.0f);
+									ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
+								}
+							}
+						}
+						else
+						{
+							for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+							{
+								unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
+								assert(pointIndex < m_currentDisplayedScalarField->currentSize());
+								const ScalarType sf = m_currentDisplayedScalarField->getValue(pointIndex);
+								if (sfDisplayRange.isInRange(sf)) // NaN values are rejected
+								{
+									glFunc->glColor3f(GetSymmetricalNormalizedValue(sf, sfSaturationRange), 1.0f, 1.0f);
+									ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
+								}
+							}
+						}
+					}
+					else if (entityPickingMode)
+					{
+						for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+						{
+							unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
+							assert(pointIndex < m_currentDisplayedScalarField->currentSize());
+							const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
+							if (col)
+							{
+								// for entity picking, don't change the color, we just need to know whether the point is visible
+								ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
+							}
+						}
+					}
+					else
+					{
+						for (unsigned j = toDisplay.startIndex; j < toDisplay.endIndex; j += toDisplay.decimStep)
+						{
+							unsigned pointIndex = (toDisplay.indexMap ? toDisplay.indexMap->at(j) : j);
+							assert(pointIndex < m_currentDisplayedScalarField->currentSize());
+							const ccColor::Rgb* col = m_currentDisplayedScalarField->getValueColor(pointIndex);
+							if (col)
+							{
+								ccGL::Color(glFunc, *col);
+								ccGL::Vertex3v(glFunc, m_points[pointIndex].u);
+							}
+						}
+					}
+				}
+				glFunc->glEnd();
+			}
+
+			if (colorRampShader)
+			{
+				colorRampShader->release();
+
+				if (glParams.showNorms)
+				{
+					glFunc->glPopAttrib(); // GL_LIGHTING_BIT
+				}
+			}
+		}
+		else // no visibility table enabled, no scalar field
+		{
+			bool useVBOs = context.useVBOs && !toDisplay.indexMap ? updateVBOs(context, glParams) : false; // VBOs are not compatible with LoD
+
+			size_t chunkCount = ccChunk::Count(m_points);
+
+			// normal acceleration texture (for fast normals display)
+			static bool                    s_globalVBOCreationFailed = false;
+			static bool                    s_normalLUTTextureFailed  = false;
+			QSharedPointer<QOpenGLTexture> lutTex;
+
+			QSharedPointer<QOpenGLShaderProgram> prog;
+			if (glParams.showNorms
+			    && (false == s_normalLUTTextureFailed)
+			    && (false == s_globalVBOCreationFailed))
+			{
+				int attributes = ATTR_POS;
+				if (glParams.showNorms)
+				{
+					attributes |= ATTR_NOR;
+				}
+				if (glParams.showColors || glParams.showSF)
+				{
+					attributes |= ATTR_COL;
+				}
+
+				prog = BuildSimpleCloudProgram(glFunc, attributes);
+				if (!prog.isNull())
+				{
+					// create or retrieve the LUT texture
+					lutTex = ccNormalVectors::GetNormalLUTTexture(glFunc);
+					if (lutTex.isNull())
+					{
+						ccLog::Warning("Failed to create normals LUT texture! Cannot render fast normals.");
+						s_normalLUTTextureFailed = true;
+						prog.clear();
+					}
+				}
+			}
+
+			// static VBO handles reused between calls
+			if (prog && s_vboVertex == 0)
+			{
+				glFunc->glGenBuffers(1, &s_vboVertex);
+				if (0 == s_vboVertex)
+				{
+					s_globalVBOCreationFailed = true;
+					prog.clear();
+				}
+			}
+
+			if (prog && s_vboNormals == 0)
+			{
+				glFunc->glGenBuffers(1, &s_vboNormals);
+				if (0 == s_vboNormals)
+				{
+					s_globalVBOCreationFailed = true;
+					prog.clear();
+				}
+			}
+
+			if (prog && s_vboColor == 0)
+			{
+				glFunc->glGenBuffers(1, &s_vboColor);
+				if (0 == s_vboColor)
+				{
+					s_globalVBOCreationFailed = true;
+					prog.clear();
+				}
+			}
+
+			if (prog)
+			{
+				prog->bind();
+
+				if (lutTex)
+				{
+					// bind texture to unit 0
+					glFunc->glActiveTexture(GL_TEXTURE0);
+					glFunc->glBindTexture(GL_TEXTURE_2D, lutTex->textureId());
+
+					// set sampler uniform to unit 0
+					int locSampler = prog->uniformLocation("uNormalLUT");
+					if (locSampler >= 0)
+					{
+						glFunc->glUniform1i(locSampler, 0);
+					}
+					// set LUT dimensions
+					int locW = prog->uniformLocation("uLUTWidth");
+					if (locW >= 0)
+					{
+						glFunc->glUniform1i(locW, lutTex->width());
+					}
+					int locH = prog->uniformLocation("uLUTHeight");
+					if (locH >= 0)
+					{
+						glFunc->glUniform1i(locH, lutTex->height());
+					}
+				}
+			}
+			else
+			{
+				glFunc->glEnableClientState(GL_VERTEX_ARRAY);
+				if (glParams.showNorms)
+				{
+					glFunc->glEnableClientState(GL_NORMAL_ARRAY);
+				}
+				if (glParams.showColors)
+				{
+					glFunc->glEnableClientState(GL_COLOR_ARRAY);
+				}
+			}
+
+			if (toDisplay.indexMap) // LoD display
+			{
+				unsigned s = toDisplay.startIndex;
+				while (s < toDisplay.endIndex)
+				{
+					unsigned count = std::min(MAX_POINT_COUNT_PER_LOD_RENDER_PASS, toDisplay.endIndex - s);
+					unsigned e     = s + count;
+
+					const auto& indexMap = (*toDisplay.indexMap);
+
+					// points
+					glLODChunkVertexPointer<QOpenGLFunctions_2_1>(this, glFunc, *toDisplay.indexMap, s, e, nullptr != prog);
+
+					// normals
+					if (glParams.showNorms)
+					{
+						glLODChunkNormalPointer<QOpenGLFunctions_2_1>(m_normals, glFunc, *toDisplay.indexMap, s, e, nullptr != prog);
+					}
+
+					// colors
+					if (glParams.showColors)
+					{
+						glLODChunkColorPointer<QOpenGLFunctions_2_1>(m_rgbaColors, glFunc, *toDisplay.indexMap, s, e, nullptr != prog);
+					}
+
+					glFunc->glDrawArrays(GL_POINTS, 0, count);
+
+					if (prog)
+					{
+						glFunc->glDisableVertexAttribArray(ATTR_POS);
+						if (glParams.showNorms)
+						{
+							glFunc->glDisableVertexAttribArray(ATTR_NOR);
+						}
+						if (glParams.showColors)
+						{
+							glFunc->glDisableVertexAttribArray(ATTR_COL);
+						}
+						// unbind array buffer
+						glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);
+					}
+					s = e;
+				}
+			}
+			else
+			{
+				for (size_t k = 0; k < chunkCount; ++k)
+				{
+					size_t chunkSize = ccChunk::Size(k, m_points);
+
+					// points
+					glChunkVertexPointer(context, k, toDisplay.decimStep, useVBOs, prog != nullptr);
+
+					// normals
+					if (glParams.showNorms)
+					{
+						glChunkNormalPointer(context, k, toDisplay.decimStep, useVBOs, prog != nullptr);
+					}
+					// colors
+					if (glParams.showColors)
+					{
+						glChunkColorPointer(context, k, toDisplay.decimStep, useVBOs, prog != nullptr);
+					}
+
+					if (toDisplay.decimStep > 1)
+					{
+						chunkSize = chunkSize / static_cast<size_t>(toDisplay.decimStep); // equivalent to floor if value >= 0
+					}
+
+					glFunc->glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(chunkSize));
+
+					if (prog)
+					{
+						glFunc->glDisableVertexAttribArray(ATTR_POS);
+						if (glParams.showNorms)
+						{
+							glFunc->glDisableVertexAttribArray(ATTR_NOR);
+						}
+						if (glParams.showColors)
+						{
+							glFunc->glDisableVertexAttribArray(ATTR_COL);
+						}
+
+						// unbind array buffer
+						glFunc->glBindBuffer(GL_ARRAY_BUFFER, 0);
+					}
+				}
+			}
+
+			if (prog)
+			{
+				prog->release();
+
+				if (glParams.showNorms)
+				{
+					glFunc->glBindTexture(GL_TEXTURE_2D, 0);
+				}
+			}
+			else
+			{
 				glFunc->glDisableClientState(GL_VERTEX_ARRAY);
 				if (glParams.showNorms)
+				{
 					glFunc->glDisableClientState(GL_NORMAL_ARRAY);
+				}
 				if (glParams.showColors)
+				{
 					glFunc->glDisableClientState(GL_COLOR_ARRAY);
+				}
 			}
-		}
-
-		/*** END DISPLAY ***/
-
-		if (context.drawRoundedPoints)
-		{
-			glFunc->glPopAttrib(); // GL_POINT_BIT
-		}
-
-		glFunc->glPopAttrib(); // GL_LIGHTING_BIT | GL_COLOR_BUFFER_BIT | GL_TRANSFORM_BIT | GL_POINT_BIT --> will switch the light off
-
-		if (m_normalsDrawnAsLines)
-		{
-			drawNormalsAsLines(context);
 		}
 	}
-	else if (MACRO_Draw2D(context))
+
+	/*** END DISPLAY ***/
+
+	if (context.drawRoundedPoints)
 	{
-		if (MACRO_Foreground(context) && !context.sfColorScaleToDisplay)
-		{
-			if (sfColorScaleShown() && sfShown())
-			{
-				// drawScale(context);
-				addColorRampInfo(context);
-			}
-		}
+		glFunc->glPopAttrib(); // GL_POINT_BIT
+	}
+
+	glFunc->glPopAttrib(); // GL_LIGHTING_BIT | GL_COLOR_BUFFER_BIT | GL_TRANSFORM_BIT | GL_POINT_BIT --> will switch the light off
+
+	if (m_normalsDrawnAsLines)
+	{
+		drawNormalsAsLines(context);
 	}
 }
 
@@ -5442,9 +5924,6 @@ CCCoreLib::ReferenceCloud* ccPointCloud::crop2D(const ccPolyline* poly, unsigned
 	return ref;
 }
 
-// DGM: normals are so slow to display that it's a waste of memory and time to load them in VBOs!
-#define DONT_LOAD_NORMALS_IN_VBOS
-
 bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams& glParams)
 {
 	if (isColorOverridden())
@@ -5483,12 +5962,11 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 			m_vboManager.updateFlags |= vboSet::UPDATE_COLORS;
 		}
 
-#ifndef DONT_LOAD_NORMALS_IN_VBOS
 		if (glParams.showNorms && !m_vboManager.hasNormals)
 		{
-			updateFlags |= UPDATE_NORMALS;
+			m_vboManager.updateFlags |= vboSet::UPDATE_NORMALS;
 		}
-#endif
+
 		// nothing to do?
 		if (m_vboManager.updateFlags == 0)
 		{
@@ -5536,18 +6014,12 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 		// DGM: the context should be already active as this method should only be called from 'drawMeOnly'
 		assert(!glParams.showSF || m_currentDisplayedScalarField);
 		assert(!glParams.showColors || m_rgbaColors);
-#ifndef DONT_LOAD_NORMALS_IN_VBOS
-		assert(!glParams.showNorms || (m_normals && m_normals->chunksCount() >= chunksCount));
-#endif
+		assert(!glParams.showNorms || m_normals);
 
-		m_vboManager.hasColors = glParams.showSF || glParams.showColors;
-		m_vboManager.colorIsSF = glParams.showSF;
-		m_vboManager.sourceSF  = glParams.showSF ? m_currentDisplayedScalarField : nullptr;
-#ifndef DONT_LOAD_NORMALS_IN_VBOS
+		m_vboManager.hasColors  = glParams.showSF || glParams.showColors;
+		m_vboManager.colorIsSF  = glParams.showSF;
+		m_vboManager.sourceSF   = glParams.showSF ? m_currentDisplayedScalarField : nullptr;
 		m_vboManager.hasNormals = glParams.showNorms;
-#else
-		m_vboManager.hasNormals = false;
-#endif
 
 		// process each chunk
 		for (size_t chunkIndex = 0; chunkIndex < chunksCount; ++chunkIndex)
@@ -5583,16 +6055,17 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 					chunkUpdateFlags = vboSet::UPDATE_ALL;
 				}
 
-				currentVBO->bind();
-
 				// load points
 				if (chunkUpdateFlags & vboSet::UPDATE_POINTS)
 				{
-					currentVBO->write(0, ccChunk::Start(m_points, chunkIndex), sizeof(PointCoordinateType) * chunkSize * 3);
+					currentVBO->vertexBuffer.bind();
+					currentVBO->vertexBuffer.write(0, ccChunk::Start(m_points, chunkIndex), sizeof(PointCoordinateType) * chunkSize * 3);
+					currentVBO->vertexBuffer.release();
 				}
 				// load colors
 				if (chunkUpdateFlags & vboSet::UPDATE_COLORS)
 				{
+					currentVBO->colorBuffer.bind();
 					if (glParams.showSF)
 					{
 						// copy SF colors in static array
@@ -5629,33 +6102,31 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 							}
 						}
 						// then send them in VRAM
-						currentVBO->write(currentVBO->rgbShift, s_rgbBuffer4ub, sizeof(ColorCompType) * chunkSize * 4);
+						currentVBO->colorBuffer.write(0, s_rgbBuffer4ub, sizeof(ColorCompType) * chunkSize * 4);
 						// upadte 'modification' flag for current displayed SF
 						m_vboManager.sourceSF->setModificationFlag(false);
 					}
 					else if (glParams.showColors)
 					{
-						currentVBO->write(currentVBO->rgbShift, ccChunk::Start(*m_rgbaColors, chunkIndex), sizeof(ColorCompType) * chunkSize * 4);
+						currentVBO->colorBuffer.write(0, ccChunk::Start(*m_rgbaColors, chunkIndex), sizeof(ColorCompType) * chunkSize * 4);
 					}
+					currentVBO->colorBuffer.release();
 				}
-#ifndef DONT_LOAD_NORMALS_IN_VBOS
+
 				// load normals
-				if (glParams.showNorms && (chunkUpdateFlags & UPDATE_NORMALS))
+				if (glParams.showNorms && (chunkUpdateFlags & vboSet::UPDATE_NORMALS))
 				{
 					// we must decode the normals first!
-					CompressedNormType*  inNorms  = m_normals->chunkStartPtr(chunkIndex);
-					PointCoordinateType* outNorms = s_normalBuffer;
+					CompressedNormType* inNorms  = ccChunk::Start(*m_normals, chunkIndex);
+					float*              outNorms = reinterpret_cast<float*>(s_normalBuffer);
 					for (int j = 0; j < chunkSize; ++j)
 					{
-						const CCVector3& N = ccNormalVectors::GetNormal(*inNorms++);
-						*(outNorms)++      = N.x;
-						*(outNorms)++      = N.y;
-						*(outNorms)++      = N.z;
+						*(outNorms)++ = static_cast<float>(*inNorms++);
 					}
-					currentVBO->write(currentVBO->normalShift, s_normalBuffer, sizeof(PointCoordinateType) * chunkSize * 3);
+					currentVBO->normalIndexBuffer.bind();
+					currentVBO->normalIndexBuffer.write(0, s_normalBuffer, sizeof(float) * chunkSize);
+					currentVBO->normalIndexBuffer.release();
 				}
-#endif
-				currentVBO->release();
 
 				// if an error is detected
 				QOpenGLFunctions_2_1* glFunc = context.glFunctions<QOpenGLFunctions_2_1>();
@@ -5719,60 +6190,101 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 
 int ccPointCloud::VBO::init(int count, bool withColors, bool withNormals, bool* reallocated /*=nullptr*/)
 {
-	// required memory
-	int totalSizeBytes = sizeof(PointCoordinateType) * count * 3;
-	if (withColors)
+	auto resizeVBO = [reallocated](QOpenGLBuffer& buffer, int sizeBytes) -> bool
 	{
-		rgbShift = totalSizeBytes;
-		totalSizeBytes += sizeof(ColorCompType) * count * 4;
-	}
-	if (withNormals)
-	{
-		normalShift = totalSizeBytes;
-		totalSizeBytes += sizeof(PointCoordinateType) * count * 3;
-	}
+		if (!buffer.isCreated())
+		{
+			if (!buffer.create())
+			{
+				return false;
+			}
 
-	if (!isCreated())
+			buffer.setUsagePattern(QOpenGLBuffer::DynamicDraw); //"StaticDraw: The data will be set once and used many times for drawing operations."
+			                                                    //"DynamicDraw: The data will be modified repeatedly and used many times for drawing operations.
+		}
+
+		if (!buffer.bind())
+		{
+			ccLog::Warning("[ccPointCloud::VBO::init] Failed to bind VBO to active context!");
+			buffer.destroy();
+			return false;
+		}
+
+		if (sizeBytes != buffer.size())
+		{
+			buffer.allocate(sizeBytes);
+			if (reallocated)
+			{
+				*reallocated = true;
+			}
+
+			if (buffer.size() != sizeBytes)
+			{
+				ccLog::Warning("[ccPointCloud::VBO::init] Not enough (GPU) memory!");
+				buffer.release();
+				buffer.destroy();
+				return false;
+			}
+		}
+
+		buffer.release();
+		return true;
+	};
+
+	// vertices
+	int vertexSizeBytes = 0;
 	{
-		if (!create())
+		vertexSizeBytes = sizeof(PointCoordinateType) * count * 3;
+
+		if (!resizeVBO(vertexBuffer, vertexSizeBytes))
 		{
 			// no message as it will probably happen on a lot on (old) graphic cards
 			return -1;
 		}
-
-		setUsagePattern(QOpenGLBuffer::DynamicDraw); //"StaticDraw: The data will be set once and used many times for drawing operations."
-		                                             //"DynamicDraw: The data will be modified repeatedly and used many times for drawing operations.
 	}
 
-	if (!bind())
+	// colors
+	int colorSizeBytes = 0;
+	if (withColors)
 	{
-		ccLog::Warning("[ccPointCloud::VBO::init] Failed to bind VBO to active context!");
-		destroy();
-		return -1;
-	}
+		colorSizeBytes = sizeof(ColorCompType) * count * 4;
 
-	if (totalSizeBytes != size())
-	{
-		allocate(totalSizeBytes);
-		if (reallocated)
-			*reallocated = true;
-
-		if (size() != totalSizeBytes)
+		if (!resizeVBO(colorBuffer, colorSizeBytes))
 		{
-			ccLog::Warning("[ccPointCloud::VBO::init] Not enough (GPU) memory!");
-			release();
-			destroy();
+			// no message as it will probably happen on a lot on (old) graphic cards
 			return -1;
 		}
 	}
 	else
 	{
-		// nothing to do
+		colorBuffer.destroy();
 	}
 
-	release();
+	// normal indexes (as floats)
+	int normalSizeBytes = 0;
+	if (withNormals)
+	{
+		normalSizeBytes = sizeof(float) * count;
 
-	return totalSizeBytes;
+		if (!resizeVBO(normalIndexBuffer, normalSizeBytes))
+		{
+			// no message as it will probably happen on a lot on (old) graphic cards
+			return -1;
+		}
+	}
+	else
+	{
+		normalIndexBuffer.destroy();
+	}
+
+	return vertexSizeBytes + colorSizeBytes + normalSizeBytes;
+}
+
+void ccPointCloud::VBO::destroy()
+{
+	vertexBuffer.destroy();
+	colorBuffer.destroy();
+	normalIndexBuffer.destroy();
 }
 
 size_t ccPointCloud::vboSize() const

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -3667,10 +3667,6 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 			{
 				attributes |= ccGLSL::ATTR_VIS;
 			}
-			if (!m_clipPlanes.empty())
-			{
-				attributes |= ccGLSL::ATTR_CLIP;
-			}
 
 			prog = ccGLSL::BuildDisplayProgram(glFunc, attributes, glParams.showSF ? m_currentDisplayedScalarField : nullptr);
 

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -3285,8 +3285,8 @@ struct DisplayDesc : LODLevelDesc
 	LODIndexSet* indexMap;
 };
 
-// Simple program builder (GLSL 1.20) for cloud rendering (position, normal, color)
-static QSharedPointer<QOpenGLShaderProgram> BuildSimpleCloudProgram(QOpenGLFunctions_2_1* glFunc, int attributes, ccScalarField* sf /*=nullptr*/)
+// GLSL program builder (GLSL 1.20) for cloud rendering (position, normal, color, scalar values)
+static QSharedPointer<QOpenGLShaderProgram> BuildCloudDisplayProgram(QOpenGLFunctions_2_1* glFunc, int attributes, ccScalarField* sf /*=nullptr*/)
 {
 	if (!glFunc)
 	{
@@ -3494,13 +3494,13 @@ static QSharedPointer<QOpenGLShaderProgram> BuildSimpleCloudProgram(QOpenGLFunct
 	QOpenGLShader vertexShader(QOpenGLShader::Vertex);
 	if (false == vertexShader.compileSourceCode(vertexProgSrc))
 	{
-		ccLog::Warning(QString("[BuildSimpleCloudProgram] Vertex shader compilation failed: ") + vertexShader.log());
+		ccLog::Warning(QString("[BuildCloudDisplayProgram] Vertex shader compilation failed: ") + vertexShader.log());
 		return nullptr;
 	}
 	QOpenGLShader fragmentShader(QOpenGLShader::Fragment);
 	if (false == fragmentShader.compileSourceCode(fragmentProgSrc))
 	{
-		ccLog::Warning(QString("[BuildSimpleCloudProgram] Fragment shader compilation failed: ") + fragmentShader.log());
+		ccLog::Warning(QString("[BuildCloudDisplayProgram] Fragment shader compilation failed: ") + fragmentShader.log());
 		return nullptr;
 	}
 	QSharedPointer<QOpenGLShaderProgram> program(new QOpenGLShaderProgram);
@@ -3526,7 +3526,7 @@ static QSharedPointer<QOpenGLShaderProgram> BuildSimpleCloudProgram(QOpenGLFunct
 
 	if (false == program->link())
 	{
-		ccLog::Warning(QString("[BuildSimpleCloudProgram] Shader program linking failed: ") + program->log());
+		ccLog::Warning(QString("[BuildCloudDisplayProgram] Shader program linking failed: ") + program->log());
 		return nullptr;
 	}
 
@@ -4040,7 +4040,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 					attributes |= ATTR_COL;
 				}
 
-				prog = BuildSimpleCloudProgram(glFunc, attributes, glParams.showSF ? m_currentDisplayedScalarField : nullptr);
+				prog = BuildCloudDisplayProgram(glFunc, attributes, glParams.showSF ? m_currentDisplayedScalarField : nullptr);
 
 				if (glParams.showSF && prog)
 				{

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -6065,7 +6065,6 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 				// load colors
 				if (chunkUpdateFlags & vboSet::UPDATE_COLORS)
 				{
-					currentVBO->colorBuffer.bind();
 					if (glParams.showSF)
 					{
 						// copy SF colors in static array
@@ -6102,15 +6101,18 @@ bool ccPointCloud::updateVBOs(const CC_DRAW_CONTEXT& context, const glDrawParams
 							}
 						}
 						// then send them in VRAM
+						currentVBO->colorBuffer.bind();
 						currentVBO->colorBuffer.write(0, s_rgbBuffer4ub, sizeof(ColorCompType) * chunkSize * 4);
+						currentVBO->colorBuffer.release();
 						// upadte 'modification' flag for current displayed SF
 						m_vboManager.sourceSF->setModificationFlag(false);
 					}
 					else if (glParams.showColors)
 					{
+						currentVBO->colorBuffer.bind();
 						currentVBO->colorBuffer.write(0, ccChunk::Start(*m_rgbaColors, chunkIndex), sizeof(ColorCompType) * chunkSize * 4);
+						currentVBO->colorBuffer.release();
 					}
-					currentVBO->colorBuffer.release();
 				}
 
 				// load normals

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -3691,7 +3691,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 			if (glParams.showNorms && prog)
 			{
 				// create or retrieve the LUT texture
-				lutTex = ccNormalVectors::GetNormalLUTTexture(glFunc);
+				lutTex = ccGLSL::GetNormalLUTTexture(glFunc);
 				if (lutTex.isNull())
 				{
 					ccLog::Warning("Failed to create normals LUT texture! Cannot render fast normals.");
@@ -4014,8 +4014,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 
 				if (glParams.showNorms)
 				{
-					glFunc->glUniform1i(prog->uniformLocation("uLight0Enabled"), glFunc->glIsEnabled(GL_LIGHT0) ? 1 : 0);
-					glFunc->glUniform1i(prog->uniformLocation("uLight1Enabled"), glFunc->glIsEnabled(GL_LIGHT1) ? 1 : 0);
+					ccGLSL::SetLightUniforms(glFunc, prog.data());
 				}
 
 				if (lutTex)
@@ -4024,11 +4023,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 					glFunc->glActiveTexture(GL_TEXTURE0);
 					glFunc->glBindTexture(GL_TEXTURE_2D, lutTex->textureId());
 
-					// set sampler uniform to unit 0
-					glFunc->glUniform1i(prog->uniformLocation("uNormalLUT"), 0);
-					// set LUT dimensions
-					glFunc->glUniform1i(prog->uniformLocation("uLUTWidth"), lutTex->width());
-					glFunc->glUniform1i(prog->uniformLocation("uLUTHeight"), lutTex->height());
+					ccGLSL::SetLUTTextureUniforms(glFunc, prog.data(), lutTex.data());
 				}
 
 				if (sfTex && m_currentDisplayedScalarField)
@@ -4037,52 +4032,7 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 					glFunc->glActiveTexture(GL_TEXTURE1);
 					glFunc->glBindTexture(GL_TEXTURE_2D, sfTex->textureId());
 
-					// set sampler uniform to unit 1
-					glFunc->glUniform1i(prog->uniformLocation("uColorScaleTex"), 1);
-					// set texture dimensions
-					glFunc->glUniform1i(prog->uniformLocation("uTexWidth"), sfTex->width());
-					glFunc->glUniform1i(prog->uniformLocation("uTexHeight"), sfTex->height());
-
-					auto   colorScale = m_currentDisplayedScalarField->getColorScale();
-					double offset     = m_currentDisplayedScalarField->getOffset();
-
-					float minVal              = static_cast<float>(m_currentDisplayedScalarField->displayRange().start() - offset);
-					float maxVal              = static_cast<float>(m_currentDisplayedScalarField->displayRange().stop() - offset);
-					float minSat              = static_cast<float>(m_currentDisplayedScalarField->saturationRange().start() - offset);
-					float maxSat              = static_cast<float>(m_currentDisplayedScalarField->saturationRange().stop() - offset);
-					float satRange            = static_cast<float>(m_currentDisplayedScalarField->saturationRange().range());
-					float outOfRangeGreyScale = ccColor::lightGreyRGB.r / 255.0f;
-
-					int locMinVal = prog->uniformLocation("uMinVal");
-					if (locMinVal >= 0)
-					{
-						glFunc->glUniform1f(locMinVal, minVal);
-					}
-					int locMaxVal = prog->uniformLocation("uMaxVal");
-					if (locMaxVal >= 0)
-					{
-						glFunc->glUniform1f(locMaxVal, maxVal);
-					}
-					int locMinSat = prog->uniformLocation("uMinSat");
-					if (locMinSat >= 0)
-					{
-						glFunc->glUniform1f(locMinSat, minSat);
-					}
-					int locMaxSat = prog->uniformLocation("uMaxSat");
-					if (locMaxSat >= 0)
-					{
-						glFunc->glUniform1f(locMaxSat, maxSat);
-					}
-					int locSatRange = prog->uniformLocation("uSatRange");
-					if (locSatRange >= 0)
-					{
-						glFunc->glUniform1f(locSatRange, satRange);
-					}
-					int locOutOfRangeGreyScale = prog->uniformLocation("uOutOfRangeGreyScale");
-					if (locOutOfRangeGreyScale >= 0)
-					{
-						glFunc->glUniform1f(locOutOfRangeGreyScale, outOfRangeGreyScale);
-					}
+					ccGLSL::SetSFTextureUniforms(glFunc, prog.data(), sfTex.data(), m_currentDisplayedScalarField);
 				}
 			}
 			else

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -2864,7 +2864,7 @@ void ccPointCloud::glChunkVertexPointer(const CC_DRAW_CONTEXT& context, size_t c
 		if (s_vboVertex != 0)
 		{
 			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVertex);
-			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(ccChunk::Size(chunkIndex, m_points) * 3 * sizeof(PointCoordinateType)), ccChunk::Start(m_points, chunkIndex), GL_DYNAMIC_DRAW);
+			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(ccChunk::Size(chunkIndex, m_points) * 3 * sizeof(PointCoordinateType)), ccChunk::Start(m_points, chunkIndex), GL_STREAM_DRAW);
 			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_POS);
 			glFunc->glVertexAttribPointer(ccGLSL::ATTR_POS, 3, GL_COORD_TYPE, GL_FALSE, decimStep * 3 * sizeof(PointCoordinateType), nullptr);
 		}
@@ -2906,7 +2906,7 @@ static void glChunkVisibilityPointer(const ccGenericPointCloud::VisibilityTableT
 	}
 
 	glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVisib);
-	glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(count * sizeof(float)), s_visibilityBuffer, GL_DYNAMIC_DRAW);
+	glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(count * sizeof(float)), s_visibilityBuffer, GL_STREAM_DRAW);
 	glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_VIS);
 	glFunc->glVertexAttribPointer(ccGLSL::ATTR_VIS, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
 }
@@ -2962,7 +2962,7 @@ void ccPointCloud::glChunkNormalPointer(const CC_DRAW_CONTEXT& context, size_t c
 				}
 
 				glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboNormals);
-				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(count * sizeof(float)), s_normalBuffer, GL_DYNAMIC_DRAW);
+				glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(count * sizeof(float)), s_normalBuffer, GL_STREAM_DRAW);
 				glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_NOR);
 				glFunc->glVertexAttribPointer(ccGLSL::ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
 			}
@@ -3040,7 +3040,7 @@ void ccPointCloud::glChunkColorPointer(const CC_DRAW_CONTEXT& context, size_t ch
 		if (s_vboColor != 0)
 		{
 			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
-			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(ccChunk::Size(chunkIndex, m_rgbaColors->size()) * 4 * sizeof(unsigned char)), ccChunk::Start(*m_rgbaColors, chunkIndex), GL_DYNAMIC_DRAW);
+			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(ccChunk::Size(chunkIndex, m_rgbaColors->size()) * 4 * sizeof(unsigned char)), ccChunk::Start(*m_rgbaColors, chunkIndex), GL_STREAM_DRAW);
 			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_COL);
 			glFunc->glVertexAttribPointer(ccGLSL::ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, decimStep * 4 * sizeof(ColorCompType), nullptr);
 		}
@@ -3097,7 +3097,7 @@ void ccPointCloud::glChunkSFPointer(const CC_DRAW_CONTEXT& context, size_t chunk
 		if (0 != s_vboSF)
 		{
 			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboSF);
-			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(ccChunk::Size(chunkIndex, m_currentDisplayedScalarField->size()) * sizeof(float)), ccChunk::Start(m_currentDisplayedScalarField->data(), chunkIndex), GL_DYNAMIC_DRAW);
+			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(ccChunk::Size(chunkIndex, m_currentDisplayedScalarField->size()) * sizeof(float)), ccChunk::Start(m_currentDisplayedScalarField->data(), chunkIndex), GL_STREAM_DRAW);
 			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_SF);
 			glFunc->glVertexAttribPointer(ccGLSL::ATTR_SF, 1, GL_FLOAT, GL_FALSE, decimStep * sizeof(float), nullptr);
 		}
@@ -3154,7 +3154,7 @@ static void glLODChunkVertexPointer(ccPointCloud*      cloud,
 		if (0 != s_vboVertex)
 		{
 			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVertex);
-			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * 3 * sizeof(PointCoordinateType)), s_pointBuffer, GL_DYNAMIC_DRAW);
+			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * 3 * sizeof(PointCoordinateType)), s_pointBuffer, GL_STREAM_DRAW);
 			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_POS);
 			glFunc->glVertexAttribPointer(ccGLSL::ATTR_POS, 3, GL_COORD_TYPE, GL_FALSE, 0, nullptr);
 		}
@@ -3195,7 +3195,7 @@ static void glLODChunkVisibilityPointer(const ccGenericPointCloud::VisibilityTab
 	}
 
 	glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboVisib);
-	glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * sizeof(float)), s_visibilityBuffer, GL_DYNAMIC_DRAW);
+	glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * sizeof(float)), s_visibilityBuffer, GL_STREAM_DRAW);
 	glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_VIS);
 	glFunc->glVertexAttribPointer(ccGLSL::ATTR_VIS, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
 }
@@ -3224,7 +3224,7 @@ static void glLODChunkNormalPointer(NormsIndexesTableType* normals,
 			}
 
 			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboNormals);
-			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * sizeof(float)), s_normalBuffer, GL_DYNAMIC_DRAW);
+			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * sizeof(float)), s_normalBuffer, GL_STREAM_DRAW);
 			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_NOR);
 			glFunc->glVertexAttribPointer(ccGLSL::ATTR_NOR, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
 		}
@@ -3284,7 +3284,7 @@ static void glLODChunkColorPointer(RGBAColorsTableType* colors,
 		{
 			// we must re-order colors in a dedicated static array
 			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboColor);
-			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * 4 * sizeof(unsigned char)), s_rgbBuffer4ub, GL_DYNAMIC_DRAW);
+			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * 4 * sizeof(unsigned char)), s_rgbBuffer4ub, GL_STREAM_DRAW);
 			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_COL);
 			glFunc->glVertexAttribPointer(ccGLSL::ATTR_COL, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, nullptr);
 		}
@@ -3324,7 +3324,7 @@ static void glLODChunkSFPointer(ccScalarField*     sf,
 			}
 
 			glFunc->glBindBuffer(GL_ARRAY_BUFFER, s_vboSF);
-			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * sizeof(float)), s_rgbBuffer4ub, GL_DYNAMIC_DRAW);
+			glFunc->glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>((stopIndex - startIndex) * sizeof(float)), s_rgbBuffer4ub, GL_STREAM_DRAW);
 			glFunc->glEnableVertexAttribArray(ccGLSL::ATTR_SF);
 			glFunc->glVertexAttribPointer(ccGLSL::ATTR_SF, 1, GL_FLOAT, GL_FALSE, 0, nullptr);
 		}
@@ -3556,13 +3556,18 @@ void ccPointCloud::drawMeOnly(CC_DRAW_CONTEXT& context)
 				// meanwhile we will display less points
 				if (context.minLODPointCount && toDisplay.count > context.minLODPointCount)
 				{
-					GLint maxStride = 2048;
+					static GLint MaxStride = 0;
+					if (MaxStride == 0)
+					{
 #ifdef GL_MAX_VERTEX_ATTRIB_STRIDE
-					glFunc->glGetIntegerv(GL_MAX_VERTEX_ATTRIB_STRIDE, &maxStride);
+						glFunc->glGetIntegerv(GL_MAX_VERTEX_ATTRIB_STRIDE, &MaxStride);
+#else
+						MaxStride = 2048;
 #endif
+					}
 					// maxStride == decimStep * 3 * sizeof(PointCoordinateType)
 					toDisplay.decimStep = static_cast<int>(ceil(static_cast<float>(toDisplay.count) / context.minLODPointCount));
-					toDisplay.decimStep = std::min<unsigned>(toDisplay.decimStep, maxStride / (3 * sizeof(PointCoordinateType)));
+					toDisplay.decimStep = std::min<unsigned>(toDisplay.decimStep, MaxStride / (3 * sizeof(PointCoordinateType)));
 				}
 			}
 		}

--- a/libs/qCC_glWindow/src/ccGLWindowInterface.cpp
+++ b/libs/qCC_glWindow/src/ccGLWindowInterface.cpp
@@ -6998,7 +6998,7 @@ void ccGLWindowInterface::drawPivot()
 			glEnableSunLight();
 			CC_DRAW_CONTEXT CONTEXT;
 			getContext(CONTEXT);
-			CONTEXT.drawingFlags = CC_DRAW_3D | CC_DRAW_FOREGROUND | CC_LIGHT_ENABLED;
+			CONTEXT.drawingFlags = CC_DRAW_3D | CC_DRAW_FOREGROUND | CC_LIGHT_ENABLED | CC_NO_SHADER;
 			CONTEXT.display      = nullptr;
 			sphere.draw(CONTEXT);
 			glFunc->glPopAttrib(); // GL_LIGHTING_BIT

--- a/plugins/core/Standard/qCompass/src/ccSNECloud.cpp
+++ b/plugins/core/Standard/qCompass/src/ccSNECloud.cpp
@@ -17,7 +17,7 @@
 
 #include "ccSNECloud.h"
 #include <ccScalarField.h>
-#include <ccColorRampShader.h>
+
 //pass ctors straight to ccPointCloud
 ccSNECloud::ccSNECloud()
 	: ccPointCloud()

--- a/qCC/main.cpp
+++ b/qCC/main.cpp
@@ -31,7 +31,6 @@
 #include <ccColorScalesManager.h>
 #include <ccLog.h>
 #include <ccNormalVectors.h>
-#include <ccPointCloud.h>
 
 // qCC_io
 #include <FileIOFilter.h>
@@ -332,7 +331,6 @@ int main(int argc, char** argv)
 	}
 
 	// release global structures
-	ccPointCloud::ReleaseShaders(); // must be done before the OpenGL context is released (i.e. before the windows is destroyed)
 	MainWindow::DestroyInstance();
 	FileIOFilter::UnregisterAll();
 


### PR DESCRIPTION
Draw mesh and clouds in a faster way, by using:
- a composite GLSL 1.2 program
- a texture with uncompressed normals for normal display
- a texture of SF colors for SF display
- hidden points/SF values are processed by the same shader (if available)

Does not work with partial or textured meshes yet.