### PR TITLE
Honor E57 principal point in image viewport projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,7 @@ Improvements:
 		- CC will now properly handle the case when a reflective transformation has been applied to a cloud (see bug fixes)
 		- Empty scans will not trigger an error anymore (just a warning message)
 		- E57 timestamps are now loaded as scalar fields
+		- image viewport projection now accounts for the principal point (principalPointX/Y) specified in pinhole image metadata
 
 	- PLY files:
 		- loading dialog: new 'Add all' button to add all the unused standard properties to be loaded as scalar fields

--- a/libs/qCC_db/include/ccGenericGLDisplay.h
+++ b/libs/qCC_db/include/ccGenericGLDisplay.h
@@ -27,6 +27,7 @@
 
 // Qt
 #include <QFont>
+#include <QPointF>
 
 class QWidget;
 class ccDrawableObject;
@@ -219,11 +220,13 @@ class ccGenericGLDisplay
 	    \param fov_deg vertical field of view (in degrees). Optional (ignored if 0).
 	    \param viewerBasedPerspective whether the perspective view should be object-centered (false) or camera-centered (true)
 	    \param bubbleViewMode set whether bubble-view mode should be enabled or not (in which case viewerBasedPerspective is forced by default)
+	    \param projectionCenterOffset projection center offset in normalized screen coordinates (+X right, +Y up)
 	**/
 	virtual void setupProjectiveViewport(const ccGLMatrixd& cameraMatrix,
 	                                     float              fov_deg                = 0.0f,
 	                                     bool               viewerBasedPerspective = true,
-	                                     bool               bubbleViewMode         = false) = 0;
+	                                     bool               bubbleViewMode         = false,
+	                                     const QPointF&     projectionCenterOffset = QPointF()) = 0;
 
 	//! Warns the display that the enity is about to be removed
 	virtual void aboutToBeRemoved(ccDrawableObject* entity) = 0;

--- a/libs/qCC_db/src/ccCameraSensor.cpp
+++ b/libs/qCC_db/src/ccCameraSensor.cpp
@@ -30,6 +30,8 @@
 
 // Qt
 #include <QDir>
+#include <QPointF>
+#include <QSizeF>
 #include <QTextStream>
 
 ccCameraSensor::IntrinsicParameters::IntrinsicParameters()
@@ -424,6 +426,24 @@ bool ccCameraSensor::applyImageViewport(ccImage* image, ccGenericGLDisplay* win 
 	double fov_deg    = CCCoreLib::RadiansToDegrees(fOV_rad);
 	ccLog::Print(QString("[ccCameraSensor::applyImageViewport] Horizontal FOV = %1 deg").arg(fov_deg));
 
+	QSizeF displayedImageSize = image->computeDisplayedSize(screenSize.width(), screenSize.height());
+	QPointF projectionCenterOffset;
+	if (m_intrinsicParams.arrayWidth > 0
+	    && m_intrinsicParams.arrayHeight > 0
+	    && screenSize.width() > 0
+	    && screenSize.height() > 0)
+	{
+		const double principalPointOffsetX = static_cast<double>(m_intrinsicParams.principal_point[0])
+		                                     - m_intrinsicParams.arrayWidth / 2.0;
+		const double principalPointOffsetY = m_intrinsicParams.arrayHeight / 2.0
+		                                     - static_cast<double>(m_intrinsicParams.principal_point[1]);
+
+		projectionCenterOffset.setX(2.0 * principalPointOffsetX * displayedImageSize.width()
+		                            / (m_intrinsicParams.arrayWidth * screenSize.width()));
+		projectionCenterOffset.setY(2.0 * principalPointOffsetY * displayedImageSize.height()
+		                            / (m_intrinsicParams.arrayHeight * screenSize.height()));
+	}
+
 	// camera position/orientation
 	ccIndexedTransformation trans;
 	if (!getActiveAbsoluteTransformation(trans))
@@ -432,7 +452,7 @@ bool ccCameraSensor::applyImageViewport(ccImage* image, ccGenericGLDisplay* win 
 	}
 
 	ccGLMatrixd transd(trans.data());
-	win->setupProjectiveViewport(transd, static_cast<float>(fov_deg));
+	win->setupProjectiveViewport(transd, static_cast<float>(fov_deg), true, false, projectionCenterOffset);
 
 	return true;
 }

--- a/libs/qCC_db/src/ccCameraSensor.cpp
+++ b/libs/qCC_db/src/ccCameraSensor.cpp
@@ -426,7 +426,7 @@ bool ccCameraSensor::applyImageViewport(ccImage* image, ccGenericGLDisplay* win 
 	double fov_deg    = CCCoreLib::RadiansToDegrees(fOV_rad);
 	ccLog::Print(QString("[ccCameraSensor::applyImageViewport] Horizontal FOV = %1 deg").arg(fov_deg));
 
-	QSizeF displayedImageSize = image->computeDisplayedSize(screenSize.width(), screenSize.height());
+	QSizeF  displayedImageSize = image->computeDisplayedSize(screenSize.width(), screenSize.height());
 	QPointF projectionCenterOffset;
 	if (m_intrinsicParams.arrayWidth > 0
 	    && m_intrinsicParams.arrayHeight > 0

--- a/libs/qCC_glWindow/include/ccGLWindowInterface.h
+++ b/libs/qCC_glWindow/include/ccGLWindowInterface.h
@@ -32,6 +32,7 @@
 #include <QElapsedTimer>
 #include <QOpenGLExtraFunctions>
 #include <QOpenGLTexture>
+#include <QPointF>
 #include <QTimer>
 
 // system
@@ -203,7 +204,11 @@ class CCGLWINDOW_LIB_API ccGLWindowInterface : public ccGenericGLDisplay
 	QPointF toCenteredGLCoordinates(const QPointF& coordinates) const;
 	QPointF toCenteredGLCoordinates(int x, int y) const override;
 	QPointF toCornerGLCoordinates(int x, int y) const override;
-	void    setupProjectiveViewport(const ccGLMatrixd& cameraMatrix, float fov_deg = 0.0f, bool viewerBasedPerspective = true, bool bubbleViewMode = false) override;
+	void    setupProjectiveViewport(const ccGLMatrixd& cameraMatrix,
+	                                float              fov_deg                = 0.0f,
+	                                bool               viewerBasedPerspective = true,
+	                                bool               bubbleViewMode         = false,
+	                                const QPointF&     projectionCenterOffset = QPointF()) override;
 	void    aboutToBeRemoved(ccDrawableObject* entity) override;
 	void    getGLCameraParameters(ccGLCameraParameters& params) override;
 
@@ -1260,6 +1265,8 @@ class CCGLWINDOW_LIB_API ccGLWindowInterface : public ccGenericGLDisplay
 
 	//! Viewport parameters (zoom, etc.)
 	ccViewportParameters m_viewportParams;
+	//! Projection center offset in normalized screen coordinates (+X right, +Y up)
+	QPointF m_projectiveViewportCenterOffset;
 
 	//! Last mouse position
 	QPointF m_lastMousePos;

--- a/libs/qCC_glWindow/src/ccGLWindowInterface.cpp
+++ b/libs/qCC_glWindow/src/ccGLWindowInterface.cpp
@@ -263,6 +263,7 @@ ccGLWindowInterface::ccGLWindowInterface(QObject* parent /*=nullptr*/, bool sile
     , m_initialized(false)
     , m_trihedronGLList(GL_INVALID_LIST_ID)
     , m_pivotGLList(GL_INVALID_LIST_ID)
+    , m_projectiveViewportCenterOffset(0.0, 0.0)
     , m_lastMousePos(-1.0, -1.0)
     , m_validModelviewMatrix(false)
     , m_validProjectionMatrix(false)
@@ -1652,7 +1653,17 @@ ccGLMatrixd ccGLWindowInterface::computeProjectionMatrix(bool withGLfeatures, Pr
 			//	const_cast<ccGLWindow*>(this)->displayNewMessage(QString("eye sep. = %1 - convergence = %3").arg(*eyeOffset).arg(convergence), ccGLWindowInterface::LOWER_LEFT_MESSAGE, false, 2, ccGLWindowInterface::PERSPECTIVE_STATE_MESSAGE);
 		}
 
-		projMatrix = ccGL::Frustum(-xMax - frustumAsymmetry, xMax - frustumAsymmetry, -yMax, yMax, zNear, zFar);
+		// Shift the frustum in the opposite direction so the optical axis lands on
+		// the requested screen position.
+		const double projectionCenterShiftX = m_projectiveViewportCenterOffset.x() * xMax;
+		const double projectionCenterShiftY = m_projectiveViewportCenterOffset.y() * yMax;
+
+		projMatrix = ccGL::Frustum(-xMax - frustumAsymmetry - projectionCenterShiftX,
+		                           xMax - frustumAsymmetry - projectionCenterShiftX,
+		                           -yMax - projectionCenterShiftY,
+		                           yMax - projectionCenterShiftY,
+		                           zNear,
+		                           zFar);
 	}
 	else
 	{
@@ -3047,6 +3058,7 @@ void ccGLWindowInterface::setPerspectiveState(bool state, bool objectCenteredVie
 	// new state
 	m_viewportParams.perspectiveView    = state;
 	m_viewportParams.objectCenteredView = objectCenteredView;
+	m_projectiveViewportCenterOffset    = QPointF();
 
 	if (m_viewportParams.perspectiveView)
 	{
@@ -3277,7 +3289,8 @@ bool ccGLWindowInterface::setFarClippingPlaneDepth(double depth)
 void ccGLWindowInterface::setViewportParameters(const ccViewportParameters& params)
 {
 	ccViewportParameters oldParams = m_viewportParams;
-	m_viewportParams               = params;
+	m_viewportParams                    = params;
+	m_projectiveViewportCenterOffset    = QPointF();
 
 	if (m_stereoModeEnabled && !params.perspectiveView)
 	{
@@ -3315,7 +3328,8 @@ void ccGLWindowInterface::rotateBaseViewMat(const ccGLMatrixd& rotMat)
 void ccGLWindowInterface::setupProjectiveViewport(const ccGLMatrixd& cameraMatrix,
                                                   float              fov_deg /*=0.0f*/,
                                                   bool               viewerBasedPerspective /*=true*/,
-                                                  bool               bubbleViewMode /*=false*/)
+                                                  bool               bubbleViewMode /*=false*/,
+                                                  const QPointF&     projectionCenterOffset /*=QPointF()*/)
 {
 	// perspective (viewer-based by default)
 	if (bubbleViewMode)
@@ -3327,6 +3341,14 @@ void ccGLWindowInterface::setupProjectiveViewport(const ccGLMatrixd& cameraMatri
 	if (fov_deg > 0.0f)
 	{
 		setFov(fov_deg);
+	}
+
+	if (m_projectiveViewportCenterOffset != projectionCenterOffset)
+	{
+		m_projectiveViewportCenterOffset = projectionCenterOffset;
+		invalidateViewport();
+		invalidateVisualization();
+		deprecate3DLayer();
 	}
 
 	// set the camera matrix 'translation' as OpenGL camera center
@@ -3363,6 +3385,7 @@ void ccGLWindowInterface::setCustomView(const CCVector3d& forward, const CCVecto
 
 	ccGLMatrixd viewMat = ccGLMatrixd::FromViewDirAndUpDir(forward, up);
 	setBaseViewMat(viewMat);
+	m_projectiveViewportCenterOffset = QPointF();
 
 	if (wasViewerBased)
 		setPerspectiveState(m_viewportParams.perspectiveView, false);
@@ -3404,6 +3427,7 @@ void ccGLWindowInterface::setView(CC_VIEW_ORIENTATION orientation, bool forceRed
 	                                                      getDefaultVertDir(),
 	                                                      &m_lockedRotationAngle_rad,
 	                                                      &m_lockedRotationOrthoAngle_rad);
+	m_projectiveViewportCenterOffset = QPointF();
 
 	if (wasViewerBased)
 	{

--- a/libs/qCC_glWindow/src/ccGLWindowInterface.cpp
+++ b/libs/qCC_glWindow/src/ccGLWindowInterface.cpp
@@ -3288,9 +3288,9 @@ bool ccGLWindowInterface::setFarClippingPlaneDepth(double depth)
 
 void ccGLWindowInterface::setViewportParameters(const ccViewportParameters& params)
 {
-	ccViewportParameters oldParams = m_viewportParams;
-	m_viewportParams                    = params;
-	m_projectiveViewportCenterOffset    = QPointF();
+	ccViewportParameters oldParams   = m_viewportParams;
+	m_viewportParams                 = params;
+	m_projectiveViewportCenterOffset = QPointF();
 
 	if (m_stereoModeEnabled && !params.perspectiveView)
 	{
@@ -3423,10 +3423,10 @@ void ccGLWindowInterface::setView(CC_VIEW_ORIENTATION orientation, bool forceRed
 		setPerspectiveState(m_viewportParams.perspectiveView, true);
 	}
 
-	m_viewportParams.viewMat = ccGLUtils::GenerateViewMat(orientation,
-	                                                      getDefaultVertDir(),
-	                                                      &m_lockedRotationAngle_rad,
-	                                                      &m_lockedRotationOrthoAngle_rad);
+	m_viewportParams.viewMat         = ccGLUtils::GenerateViewMat(orientation,
+                                                          getDefaultVertDir(),
+                                                          &m_lockedRotationAngle_rad,
+                                                          &m_lockedRotationOrthoAngle_rad);
 	m_projectiveViewportCenterOffset = QPointF();
 
 	if (wasViewerBased)


### PR DESCRIPTION
## Summary

- use `principalPointX/Y` imported from E57 pinhole image metadata when applying an image viewport
- convert the offset from the image center to normalized screen coordinates using the displayed image bounds
- apply the offset through an asymmetric projection frustum

## Validation

- built the `CloudCompare` and `QE57_IO_PLUGIN` targets in Release mode with MSVC/Ninja and Qt 6.11.1
- visually compared the point-cloud overlay before and after applying the principal-point offset

## Before / after

| Before: principal point treated as the image center | After: E57 principal-point offset applied |
|---|---|
| <img alt="Before applying the E57 principal-point offset" src="https://github.com/user-attachments/assets/ed89de4a-9346-48ac-b7b8-51c1c2f2fdec"> | <img alt="After applying the E57 principal-point offset" src="https://github.com/user-attachments/assets/d5e5ac27-8703-4815-9395-661ae8bfacb3"> |

## Test data

Source data: AIST 3DDB, "L02 - Tokyo metropolitan area survey data"  
File: `7701_202402121530_S03_000004.e57`  
License: CC BY AIST

- [Open the dataset in AIST 3DDB Viewer](https://gsvrg.ipri.aist.go.jp/3ddb_demo/tdv/index.html?version=0.5.2&imagery=%E6%A8%99%E6%BA%96%E5%9C%B0%E5%9B%B3%20%28Standard%20map%29&terrain=WGS84%20Ellipsoid&dx=-3949647.5284139547&dy=3353679.9316803915&dz=3707031.4445944247&odx=0.129085846803591&ody=0.6298056235857183&odz=-0.7659515132531591&upx=-0.6049591304774399&upy=0.6620402916704784&upz=0.4424105589346257&sp_title=L02-%E9%83%BD%E5%86%85%E8%A8%88%E6%B8%AC%E3%83%87%E3%83%BC%E3%82%BF&sp_type=POINTCLOUD&sp_sdate=&sp_edate=&sp_bbon=false&sp_bblon=139.66466035004999&sp_bblat=35.7639473585805&sp_bbhgh=0&sp_bbyaw=0&sp_bbslon=50&sp_bbslat=50&sp_bbshgh=50&sp_footp=false&sp_translucency=false&sp_underground=false&sp_psz=1.5&sp_pidx=0&do_search=false&ldm=116716,116718,116720,116722,116538,116540,116544,116546,116548,116550,116552,116566,116568,116576,116578&cart=116716,116718,116720,116722,116538,116540,116544,116546,116548,116550,116552,116566,116568,116576,116578&wms=false&wms_lys=Polygon&wms_opa=1)
