### PR TITLE
Run the geometric feature and SF gradient computations in a worker thread (#2164)

### DIFF
--- a/qCC/ccLibAlgorithms.cpp
+++ b/qCC/ccLibAlgorithms.cpp
@@ -21,6 +21,7 @@
 #include <ScalarFieldTools.h>
 
 // qCC_db
+#include <ccBackgroundTask.h>
 #include <ccOctree.h>
 #include <ccPointCloud.h>
 #include <ccScalarField.h>
@@ -335,13 +336,18 @@ namespace ccLibAlgorithms
 					}
 				}
 
-				CCCoreLib::GeometricalAnalysisTools::ErrorCode result = CCCoreLib::GeometricalAnalysisTools::ComputeCharactersitic(c,
-				                                                                                                                   subOption,
-				                                                                                                                   cloud,
-				                                                                                                                   radius,
-				                                                                                                                   roughnessUpDir,
-				                                                                                                                   pDlg,
-				                                                                                                                   octree.data());
+				// only the computation itself runs in a worker thread
+				CCCoreLib::GeometricalAnalysisTools::ErrorCode result = ccBackgroundTask::Run(
+				    [&]()
+				    {
+					    return CCCoreLib::GeometricalAnalysisTools::ComputeCharactersitic(c,
+					                                                                      subOption,
+					                                                                      cloud,
+					                                                                      radius,
+					                                                                      roughnessUpDir,
+					                                                                      pDlg,
+					                                                                      octree.data());
+				    });
 
 				if (result == CCCoreLib::GeometricalAnalysisTools::NoError)
 				{
@@ -564,12 +570,17 @@ namespace ccLibAlgorithms
 				switch (algo)
 				{
 				case CCLIB_ALGO_SF_GRADIENT:
-					result = CCCoreLib::ScalarFieldTools::computeScalarFieldGradient(cloud,
-					                                                                 0, // auto --> FIXME: should be properly set by the user!
-					                                                                 euclidean,
-					                                                                 false,
-					                                                                 pDlg.get(),
-					                                                                 octree.data());
+					// only the computation itself runs in a worker thread
+					result = ccBackgroundTask::Run(
+					    [&]()
+					    {
+						    return CCCoreLib::ScalarFieldTools::computeScalarFieldGradient(cloud,
+						                                                                   0, // auto --> FIXME: should be properly set by the user!
+						                                                                   euclidean,
+						                                                                   false,
+						                                                                   pDlg.get(),
+						                                                                   octree.data());
+					    });
 					break;
 
 				default:


### PR DESCRIPTION
Addresses #2164.

`ComputeCharactersitic` runs on the GUI thread and ends up in `blockingMap`, same as the SOR and noise filters were. It goes through `ccBackgroundTask::Run` now. I did the SF gradient too, same path.

I put a timer on the GUI thread ticking every 50 ms and ran it on 6 million points. 1 tick out of 34 before, 39 out of 39 after.

That explains the three symptoms in the report. The one `processEvents()` before the blocking map is inside `#ifndef __APPLE__`, so on Linux the dialog appears and then never repaints, and on macOS it never appears.

The octree stays on the GUI thread. `computeOctree` calls `addChild` and `removeChild`, and the DB tree is a Qt model. It already works anyway.

`ccAlignDlg` calls `ComputeLocalDensityApprox` the same way. Different tool and a small cloud, so I left it. Say if you want it.

Built on Ubuntu 24.04 with GCC 15.3 and Qt 6.9.3, no new warnings. Checked both in the GUI. Not built on Windows or macOS.