### PR TITLE
Progress logging thread safety

### DIFF
--- a/libs/qCC_db/include/ccProgressDialog.h
+++ b/libs/qCC_db/include/ccProgressDialog.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // ##########################################################################
 // #                                                                        #
 // #                              CLOUDCOMPARE                              #
@@ -14,9 +16,6 @@
 // #          COPYRIGHT: EDF R&D / TELECOM ParisTech (ENST-TSI)             #
 // #                                                                        #
 // ##########################################################################
-
-#ifndef CC_PROGRESS_DIALOG_HEADER
-#define CC_PROGRESS_DIALOG_HEADER
 
 // Local
 #include "qCC_db.h"
@@ -52,9 +51,7 @@ class QCC_DB_LIB_API ccProgressDialog : public QProgressDialog
 	                 QWidget* parent       = nullptr);
 
 	//! Destructor (virtual)
-	virtual ~ccProgressDialog()
-	{
-	}
+	virtual ~ccProgressDialog() = default;
 
 	// inherited method
 	virtual void        update(float percent) override;
@@ -92,5 +89,3 @@ class QCC_DB_LIB_API ccProgressDialog : public QProgressDialog
 	//! Last displayed progress value (percent)
 	QAtomicInt m_lastRefreshValue;
 };
-
-#endif // CC_PROGRESS_DIALOG_HEADER

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -6528,11 +6528,10 @@ bool ccPointCloud::orientNormalsWithGrids(ccProgressDialog* pDlg /*=nullptr*/)
 	// progress dialog
 	if (pDlg)
 	{
-		pDlg->setWindowTitle(QObject::tr("Orienting normals"));
-		pDlg->setLabelText(QObject::tr("Points: %L1").arg(pointCount));
-		pDlg->setRange(0, static_cast<int>(pointCount));
-		pDlg->show();
-		QCoreApplication::processEvents();
+		pDlg->setMethodTitle(QObject::tr("Orienting normals (Grids)"));
+		pDlg->setInfo(QObject::tr("Points: %L1").arg(pointCount));
+		pDlg->update(0);
+		pDlg->start();
 	}
 
 	// for each grid cell
@@ -6592,7 +6591,7 @@ bool ccPointCloud::orientNormalsWithGrids(ccProgressDialog* pDlg /*=nullptr*/)
 						}
 						else
 						{
-							pDlg->setValue(++progressIndex);
+							pDlg->update(++progressIndex / static_cast<float>(pointCount));
 						}
 					}
 				}
@@ -6605,8 +6604,16 @@ bool ccPointCloud::orientNormalsWithGrids(ccProgressDialog* pDlg /*=nullptr*/)
 
 bool ccPointCloud::orientNormalsTowardViewPoint(CCVector3& VP, ccProgressDialog* pDlg)
 {
-	int progressIndex = 0;
-	for (unsigned pointIndex = 0; pointIndex < m_points.size(); ++pointIndex)
+	const unsigned pointCount = size();
+	if(pDlg)
+	{
+		pDlg->setMethodTitle(QObject::tr("Orienting normals (Viewpoint)"));
+		pDlg->setInfo(QObject::tr("Points: %L1").arg(pointCount));
+		pDlg->update(0);
+		pDlg->start();
+	}
+
+	for (unsigned pointIndex = 0; pointIndex < pointCount; ++pointIndex)
 	{
 		const CCVector3* P  = getPoint(pointIndex);
 		CCVector3        N  = getPointNormal(pointIndex);
@@ -6630,7 +6637,7 @@ bool ccPointCloud::orientNormalsTowardViewPoint(CCVector3& VP, ccProgressDialog*
 			}
 			else
 			{
-				pDlg->setValue(++progressIndex);
+				pDlg->update(pointIndex / static_cast<float>(pointCount));
 			}
 		}
 	}

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -6292,13 +6292,12 @@ bool ccPointCloud::computeNormalsWithGrids(double                       minTrian
 	{
 		pDlg->setMethodTitle(QObject::tr("Normals computation (Grid)"));
 		pDlg->setInfo(QObject::tr("Points: %L1").arg(pointCount));
-		pDlg->setAutoClose(false);
+		pDlg->start();
 	}
-
-	PointCoordinateType minAngleCos = static_cast<PointCoordinateType>(cos(CCCoreLib::DegreesToRadians(minTriangleAngle_deg)));
-	// double minTriangleAngle_rad = CCCoreLib::DegreesToRadians(minTriangleAngle_deg);
-
 	CCCoreLib::NormalizedProgress nProgress(pDlg, pointCount);
+
+	auto minAngleCos = static_cast<PointCoordinateType>(cos(CCCoreLib::DegreesToRadians(minTriangleAngle_deg)));
+
 	// for each grid cell
 	for (size_t gi = 0; gi < gridCount(); ++gi)
 	{
@@ -6316,11 +6315,6 @@ bool ccPointCloud::computeNormalsWithGrids(double                       minTrian
 		}
 
 		// progress dialog
-		if (pDlg)
-		{
-			pDlg->start();
-		}
-
 		// the code below has been kindly provided by Romain Janvier
 		const CCVector3 sensorOrigin = (scanGrid->sensorPosition.getTranslationAsVec3D() /* + m_globalShift*/).toPC();
 
@@ -6452,16 +6446,15 @@ bool ccPointCloud::computeNormalsWithGrids(double                       minTrian
 					theNorms[t.u[1]] += N;
 					theNorms[t.u[2]] += N;
 				}
-			}
-
-			if (pDlg)
-			{
-				// update progress dialog
-				if (!nProgress.oneStep())
+				if (pDlg)
 				{
-					unallocateNorms();
-					ccLog::Warning("[computeNormalsWithGrids] Process cancelled by user");
-					return false;
+					// update progress dialog
+					if (!nProgress.oneStep())
+					{
+						unallocateNorms();
+						ccLog::Warning("[computeNormalsWithGrids] Process cancelled by user");
+						return false;
+					}
 				}
 			}
 		}

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -6290,10 +6290,8 @@ bool ccPointCloud::computeNormalsWithGrids(double                       minTrian
 	// progress dialog
 	if (pDlg)
 	{
-		pDlg->setWindowTitle(QObject::tr("Normals computation"));
+		pDlg->setMethodTitle(QObject::tr("Normals computation (Grid)"));
 		pDlg->setAutoClose(false);
-		pDlg->show();
-		QCoreApplication::processEvents();
 	}
 
 	PointCoordinateType minAngleCos = static_cast<PointCoordinateType>(cos(CCCoreLib::DegreesToRadians(minTriangleAngle_deg)));
@@ -6318,10 +6316,8 @@ bool ccPointCloud::computeNormalsWithGrids(double                       minTrian
 		// progress dialog
 		if (pDlg)
 		{
-			pDlg->setLabelText(QObject::tr("Grid: %1 x %2").arg(scanGrid->w).arg(scanGrid->h));
-			pDlg->setValue(0);
-			pDlg->setRange(0, static_cast<int>(scanGrid->indexes.size()));
-			QCoreApplication::processEvents();
+			pDlg->setInfo(QObject::tr("Grid: %1 x %2").arg(scanGrid->w).arg(scanGrid->h));
+			pDlg->start();
 		}
 
 		// the code below has been kindly provided by Romain Janvier
@@ -6460,7 +6456,7 @@ bool ccPointCloud::computeNormalsWithGrids(double                       minTrian
 			if (pDlg)
 			{
 				// update progress dialog
-				if (pDlg->wasCanceled())
+				if (pDlg->isCancelRequested())
 				{
 					unallocateNorms();
 					ccLog::Warning("[computeNormalsWithGrids] Process cancelled by user");
@@ -6468,7 +6464,7 @@ bool ccPointCloud::computeNormalsWithGrids(double                       minTrian
 				}
 				else
 				{
-					pDlg->setValue(static_cast<unsigned>(j + 1) * scanGrid->w);
+					pDlg->update((j + 1) / static_cast<float>(scanGrid->w));
 				}
 			}
 		}

--- a/libs/qCC_db/src/ccPointCloud.cpp
+++ b/libs/qCC_db/src/ccPointCloud.cpp
@@ -6291,12 +6291,14 @@ bool ccPointCloud::computeNormalsWithGrids(double                       minTrian
 	if (pDlg)
 	{
 		pDlg->setMethodTitle(QObject::tr("Normals computation (Grid)"));
+		pDlg->setInfo(QObject::tr("Points: %L1").arg(pointCount));
 		pDlg->setAutoClose(false);
 	}
 
 	PointCoordinateType minAngleCos = static_cast<PointCoordinateType>(cos(CCCoreLib::DegreesToRadians(minTriangleAngle_deg)));
 	// double minTriangleAngle_rad = CCCoreLib::DegreesToRadians(minTriangleAngle_deg);
 
+	CCCoreLib::NormalizedProgress nProgress(pDlg, pointCount);
 	// for each grid cell
 	for (size_t gi = 0; gi < gridCount(); ++gi)
 	{
@@ -6316,12 +6318,11 @@ bool ccPointCloud::computeNormalsWithGrids(double                       minTrian
 		// progress dialog
 		if (pDlg)
 		{
-			pDlg->setInfo(QObject::tr("Grid: %1 x %2").arg(scanGrid->w).arg(scanGrid->h));
 			pDlg->start();
 		}
 
 		// the code below has been kindly provided by Romain Janvier
-		CCVector3 sensorOrigin = (scanGrid->sensorPosition.getTranslationAsVec3D() /* + m_globalShift*/).toPC();
+		const CCVector3 sensorOrigin = (scanGrid->sensorPosition.getTranslationAsVec3D() /* + m_globalShift*/).toPC();
 
 		for (int j = 0; j < static_cast<int>(scanGrid->h) - 1; ++j)
 		{
@@ -6456,15 +6457,11 @@ bool ccPointCloud::computeNormalsWithGrids(double                       minTrian
 			if (pDlg)
 			{
 				// update progress dialog
-				if (pDlg->isCancelRequested())
+				if (!nProgress.oneStep())
 				{
 					unallocateNorms();
 					ccLog::Warning("[computeNormalsWithGrids] Process cancelled by user");
 					return false;
-				}
-				else
-				{
-					pDlg->update((j + 1) / static_cast<float>(scanGrid->w));
 				}
 			}
 		}
@@ -6530,12 +6527,11 @@ bool ccPointCloud::orientNormalsWithGrids(ccProgressDialog* pDlg /*=nullptr*/)
 	{
 		pDlg->setMethodTitle(QObject::tr("Orienting normals (Grids)"));
 		pDlg->setInfo(QObject::tr("Points: %L1").arg(pointCount));
-		pDlg->update(0);
 		pDlg->start();
 	}
 
 	// for each grid cell
-	int progressIndex = 0;
+	CCCoreLib::NormalizedProgress nProgress(pDlg, pointCount);
 	for (size_t gi = 0; gi < gridCount(); ++gi)
 	{
 		const ccPointCloud::Grid::Shared& scanGrid = grid(gi);
@@ -6552,7 +6548,7 @@ bool ccPointCloud::orientNormalsWithGrids(ccProgressDialog* pDlg /*=nullptr*/)
 		}
 
 		// ccGLMatrixd toSensorCS = scanGrid->sensorPosition.inverse();
-		CCVector3 sensorOrigin = (scanGrid->sensorPosition.getTranslationAsVec3D() /* + m_globalShift*/).toPC();
+		const CCVector3 sensorOrigin = (scanGrid->sensorPosition.getTranslationAsVec3D() /* + m_globalShift*/).toPC();
 
 		const int* _indexGrid = scanGrid->indexes.data();
 		for (int j = 0; j < static_cast<int>(scanGrid->h); ++j)
@@ -6583,15 +6579,11 @@ bool ccPointCloud::orientNormalsWithGrids(ccProgressDialog* pDlg /*=nullptr*/)
 					if (pDlg)
 					{
 						// update progress dialog
-						if (pDlg->wasCanceled())
+						if (!nProgress.oneStep())
 						{
 							unallocateNorms();
 							ccLog::Warning("[orientNormalsWithGrids] Process cancelled by user");
 							return false;
-						}
-						else
-						{
-							pDlg->update(++progressIndex / static_cast<float>(pointCount));
 						}
 					}
 				}
@@ -6605,14 +6597,14 @@ bool ccPointCloud::orientNormalsWithGrids(ccProgressDialog* pDlg /*=nullptr*/)
 bool ccPointCloud::orientNormalsTowardViewPoint(CCVector3& VP, ccProgressDialog* pDlg)
 {
 	const unsigned pointCount = size();
-	if(pDlg)
+	if (pDlg)
 	{
 		pDlg->setMethodTitle(QObject::tr("Orienting normals (Viewpoint)"));
 		pDlg->setInfo(QObject::tr("Points: %L1").arg(pointCount));
-		pDlg->update(0);
 		pDlg->start();
 	}
 
+	CCCoreLib::NormalizedProgress nProgress(pDlg, pointCount);
 	for (unsigned pointIndex = 0; pointIndex < pointCount; ++pointIndex)
 	{
 		const CCVector3* P  = getPoint(pointIndex);
@@ -6629,15 +6621,11 @@ bool ccPointCloud::orientNormalsTowardViewPoint(CCVector3& VP, ccProgressDialog*
 		if (pDlg)
 		{
 			// update progress dialog
-			if (pDlg->wasCanceled())
+			if (!nProgress.oneStep())
 			{
 				unallocateNorms();
 				ccLog::Warning("[orientNormalsWithSensors] Process cancelled by user");
 				return false;
-			}
-			else
-			{
-				pDlg->update(pointIndex / static_cast<float>(pointCount));
 			}
 		}
 	}

--- a/qCC/ccEntityAction.cpp
+++ b/qCC/ccEntityAction.cpp
@@ -2316,7 +2316,7 @@ namespace ccEntityAction
 			ccBackgroundTask::Run(
 			    [&]()
 			    {
-				    for (auto cloud : clouds)
+				    for (auto* cloud : clouds)
 				    {
 					    Q_ASSERT(cloud != nullptr);
 
@@ -2325,37 +2325,6 @@ namespace ccEntityAction
 
 					    if (useGridStructure && cloud->gridCount())
 					    {
-#if 0
-					ccPointCloud* newCloud = new ccPointCloud("temp");
-					newCloud->reserve(cloud->size());
-					for (size_t gi=0; gi<cloud->gridCount(); ++gi)
-					{
-						const ccPointCloud::Grid::Shared& scanGrid = cloud->grid(gi);
-						if (scanGrid && scanGrid->indexes.empty())
-						{
-							//empty grid, we skip it
-							continue;
-						}
-						ccGLMatrixd toSensor = scanGrid->sensorPosition.inverse();
-
-						const int* _indexGrid = scanGrid->indexes.data();
-						for (int j = 0; j < static_cast<int>(scanGrid->h); ++j)
-						{
-							for (int i = 0; i < static_cast<int>(scanGrid->w); ++i, ++_indexGrid)
-							{
-								if (*_indexGrid >= 0)
-								{
-									unsigned pointIndex = static_cast<unsigned>(*_indexGrid);
-									const CCVector3* P = cloud->getPoint(pointIndex);
-									CCVector3 Q = toSensor * (*P);
-									newCloud->addPoint(Q);
-								}
-							}
-						}
-
-						addToDB(newCloud);
-					}
-#endif
 						    if (s_orientNormals)
 						    {
 							    if (orientNormalsWithGrids || orientNormalsWithSensors) // withGrids and withSensors take precedence over other methods


### PR DESCRIPTION
Now that some part of long-run computations are offloaded to a different thread (see https://github.com/CloudCompare/CloudCompare/pull/2375 for example), some methods need to be reworked in order to avoid invoking GUI updates outside the main loop (which could cause crashes or UB)

This pull request adjusts three ccPointCloud methods that previously triggered GUI updates within their code.